### PR TITLE
Add Docker support, npm publish, and README rewrite

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,5 @@
+node_modules
+dist
+.git
+.github
+.env

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,16 @@
+# Stage 1: Build
+FROM node:22-alpine AS builder
+WORKDIR /app
+COPY package*.json tsconfig.json ./
+RUN npm ci
+COPY src/ src/
+RUN npm run build
+
+# Stage 2: Run
+FROM node:22-alpine
+WORKDIR /app
+COPY package*.json ./
+RUN npm ci --omit=dev
+COPY --from=builder /app/dist/ dist/
+ENV NODE_ENV=production
+ENTRYPOINT ["node", "dist/index.js"]

--- a/README.md
+++ b/README.md
@@ -1,53 +1,174 @@
+<div align="center">
+
 # Discord MCP Server
 
-![License](https://img.shields.io/badge/license-ISC-blue)
-![Node](https://img.shields.io/badge/node-%3E%3D18-green)
-![Tools](https://img.shields.io/badge/tools-60-orange)
-![MCP](https://img.shields.io/badge/MCP-compatible-purple)
-![Discord.js](https://img.shields.io/badge/discord.js-v14-5865F2)
+**A lightweight, multi-guild Discord MCP server with 60+ tools**
 
-A [Model Context Protocol](https://modelcontextprotocol.io/) (MCP) server that lets Claude control Discord:
-read/send messages, manage members, roles, channels, permissions, forums, and webhooks.
+[![npm](https://img.shields.io/npm/v/@pasympa/discord-mcp)](https://www.npmjs.com/package/@pasympa/discord-mcp)
+[![License](https://img.shields.io/github/license/PaSympa/discord-mcp)](LICENSE)
+[![Node](https://img.shields.io/badge/node-%3E%3D18-green)](https://nodejs.org)
+[![Discord.js](https://img.shields.io/badge/discord.js-v14-5865F2)](https://discord.js.org)
+[![MCP](https://img.shields.io/badge/MCP-compatible-purple)](https://modelcontextprotocol.io)
 
-## Features
+Manage your entire Discord server from **Claude Desktop**, **Claude Code**, **Cursor**, **VS Code Copilot**, or any MCP-compatible client.
+Messages, channels, roles, permissions, moderation, forums, webhooks — all through natural language.
 
-- **60 tools** covering messages, channels, roles, permissions, moderation, forums, webhooks, and more
-- Full **permission management** — audit, copy, and override channel permissions
-- **Moderation** — kick, ban, timeout, bulk delete, audit log
-- **Rich messages** — embeds, reactions, threads, pins, search
-- **Forum channels** — create/manage forum posts, threads, and tags
-- **Webhooks** — create, send, edit, delete, and list webhooks
-- **Membership screening** — view and update server rules for new members
-- Modular architecture — easy to extend with new tools
+</div>
+
+---
+
+## Why this one?
+
+- **60+ tools** — messages, channels, roles, permissions, moderation, forums, webhooks, embeds, and more
+- **Multi-guild** — works across multiple servers, no `GUILD_ID` lock-in
+- **Lightweight** — TypeScript + Node.js, ~25kB package, ~73MB Docker image (vs 400MB+ for Java alternatives)
+- **Modular** — clean architecture, easy to extend with new tools
+- **Two install methods** — npm or Docker, your choice
 
 ---
 
 ## Quick Start
 
-1. Clone the repo and run `npm install && npm run build`
-2. Set `DISCORD_TOKEN` in your environment or a `.env` file
-3. Add the server to your Claude Desktop config (see [Configuration](#configuration))
-4. Restart Claude Desktop
+Add this to your MCP client config and replace `YOUR_TOKEN_HERE` with your bot token:
+
+```json
+{
+  "mcpServers": {
+    "discord": {
+      "command": "npx",
+      "args": ["-y", "@pasympa/discord-mcp"],
+      "env": {
+        "DISCORD_TOKEN": "YOUR_TOKEN_HERE"
+      }
+    }
+  }
+}
+```
+
+No install needed — `npx` handles everything.
+
+> Don't have a bot yet? See [Creating Your Discord Bot](#creating-your-discord-bot).
 
 ---
 
-## Prerequisites
+## Configuration
 
-- **Node.js** >= 18
-- A **Discord Bot** with its token
-- Claude Desktop (or any MCP-compatible client)
+<details>
+<summary><strong>Claude Desktop</strong></summary>
 
----
+Add the config above to your `claude_desktop_config.json`:
 
-## Installation
+- **macOS**: `~/Library/Application Support/Claude/claude_desktop_config.json`
+- **Windows**: `%APPDATA%\Claude\claude_desktop_config.json`
+
+Restart Claude Desktop after saving.
+
+</details>
+
+<details>
+<summary><strong>Claude Code</strong></summary>
 
 ```bash
-cd discord-mcp
-
-npm install
-
-npm run build
+claude mcp add discord -e DISCORD_TOKEN=YOUR_TOKEN_HERE -- npx -y @pasympa/discord-mcp
 ```
+
+</details>
+
+<details>
+<summary><strong>Cursor</strong></summary>
+
+Add the config above to `~/.cursor/mcp.json`. See [Cursor MCP docs](https://docs.cursor.com/context/model-context-protocol) for details.
+
+</details>
+
+<details>
+<summary><strong>VS Code / GitHub Copilot</strong></summary>
+
+Add to your `.vscode/mcp.json`:
+
+```json
+{
+  "inputs": [
+    {
+      "type": "promptString",
+      "id": "discord-token",
+      "description": "Discord Bot Token",
+      "password": true
+    }
+  ],
+  "servers": {
+    "discord": {
+      "command": "npx",
+      "args": ["-y", "@pasympa/discord-mcp"],
+      "env": {
+        "DISCORD_TOKEN": "${input:discord-token}"
+      }
+    }
+  }
+}
+```
+
+See [VS Code MCP docs](https://code.visualstudio.com/docs/copilot/chat/mcp-servers) for details.
+
+</details>
+
+<details>
+<summary><strong>Docker</strong></summary>
+
+```json
+{
+  "mcpServers": {
+    "discord": {
+      "command": "docker",
+      "args": [
+        "run", "--rm", "-i",
+        "-e", "DISCORD_TOKEN=YOUR_TOKEN_HERE",
+        "pasympa/discord-mcp:latest"
+      ]
+    }
+  }
+}
+```
+
+</details>
+
+<details>
+<summary><strong>From source</strong></summary>
+
+```bash
+git clone https://github.com/PaSympa/discord-mcp
+cd discord-mcp
+npm install && npm run build
+```
+
+```json
+{
+  "mcpServers": {
+    "discord": {
+      "command": "node",
+      "args": ["/absolute/path/to/discord-mcp/dist/index.js"],
+      "env": {
+        "DISCORD_TOKEN": "YOUR_TOKEN_HERE"
+      }
+    }
+  }
+}
+```
+
+</details>
+
+<details>
+<summary><strong>.env file (alternative)</strong></summary>
+
+Instead of passing the token in the MCP config, create a `.env` file at the project root:
+
+```
+DISCORD_TOKEN=YOUR_TOKEN_HERE
+```
+
+The server loads `.env` automatically via `dotenv`.
+
+</details>
 
 ---
 
@@ -66,44 +187,7 @@ npm run build
 
 ---
 
-## Configuration
-
-### Claude Desktop
-
-Add this to your `claude_desktop_config.json`:
-
-**macOS**: `~/Library/Application Support/Claude/claude_desktop_config.json`
-**Windows**: `%APPDATA%\Claude\claude_desktop_config.json`
-
-```json
-{
-  "mcpServers": {
-    "discord": {
-      "command": "node",
-      "args": ["/ABSOLUTE/PATH/TO/discord-mcp/dist/index.js"],
-      "env": {
-        "DISCORD_TOKEN": "YOUR_TOKEN_HERE"
-      }
-    }
-  }
-}
-```
-
-Restart Claude Desktop after saving.
-
-### .env file (alternative)
-
-Instead of passing the token in the MCP config, you can create a `.env` file at the project root:
-
-```
-DISCORD_TOKEN=YOUR_TOKEN_HERE
-```
-
-The server loads `.env` automatically via `dotenv`.
-
----
-
-## Available MCP Tools (60 total)
+## Available Tools (60)
 
 ### Discovery & Navigation
 
@@ -114,7 +198,7 @@ The server loads `.env` automatically via `dotenv`.
 | `discord_list_channels` | List all channels in a guild grouped by category |
 | `discord_find_channel_by_name` | Find a channel by name (partial match) |
 
-### Messages
+### Messages (13 tools)
 
 | Tool | Description |
 |---|---|
@@ -122,49 +206,49 @@ The server loads `.env` automatically via `dotenv`.
 | `discord_send_message` | Send a plain text message |
 | `discord_reply_message` | Reply to a specific message |
 | `discord_edit_message` | Edit a message sent by the bot |
+| `discord_delete_message` | Delete a specific message |
 | `discord_add_reaction` | Add a reaction emoji to a message |
 | `discord_create_thread` | Create a thread from a message or standalone |
 | `discord_bulk_delete_messages` | Delete multiple messages at once (2-100) |
-| `discord_send_embed` | Send a rich embed (title, description, color, fields, footer, image, thumbnail, author, URL, timestamp) |
+| `discord_send_embed` | Send a rich embed with all options |
 | `discord_edit_embed` | Edit an embed previously sent by the bot |
 | `discord_send_multiple_embeds` | Send up to 10 embeds in a single message |
-| `discord_delete_message` | Delete a specific message |
 | `discord_pin_message` | Pin or unpin a message |
-| `discord_search_messages` | Search messages by keyword (last 100 messages) |
+| `discord_search_messages` | Search messages by keyword (last 100) |
 
-### Channels
+### Channels (5 tools)
 
 | Tool | Description |
 |---|---|
 | `discord_create_channel` | Create a text, voice channel or category |
 | `discord_delete_channel` | Delete a channel |
-| `discord_edit_channel` | Edit name, topic (text only), slowmode (text only) |
+| `discord_edit_channel` | Edit name, topic, slowmode |
 | `discord_move_channel` | Move a channel into/out of a category |
 | `discord_clone_channel` | Clone a channel with its permissions |
 
-### Channel Permissions
+### Channel Permissions (6 tools)
 
 | Tool | Description |
 |---|---|
 | `discord_get_channel_permissions` | List all permission overwrites on a channel |
 | `discord_set_role_permission` | Allow/deny permissions for a role on a channel |
 | `discord_set_member_permission` | Allow/deny permissions for a member on a channel |
-| `discord_reset_channel_permissions` | Remove all permission overwrites (reset to inherited) |
-| `discord_copy_permissions` | Copy permission overwrites from one channel to another |
-| `discord_audit_permissions` | Full permission audit report for all channels in a guild |
+| `discord_reset_channel_permissions` | Remove all overwrites (reset to inherited) |
+| `discord_copy_permissions` | Copy overwrites from one channel to another |
+| `discord_audit_permissions` | Full permission audit for all channels |
 
-### Members
+### Members (6 tools)
 
 | Tool | Description |
 |---|---|
 | `discord_list_members` | List guild members with their roles |
-| `discord_get_member_info` | Detailed member info (roles, permissions, join date, timeout) |
+| `discord_get_member_info` | Detailed member info (roles, permissions, join date) |
 | `discord_kick_member` | Kick a member |
-| `discord_ban_member` | Ban a member (optionally delete messages from last 0-7 days) |
+| `discord_ban_member` | Ban a member (optionally delete recent messages) |
 | `discord_unban_member` | Unban a user |
-| `discord_timeout_member` | Put a member in timeout (0 to remove) |
+| `discord_timeout_member` | Timeout a member (0 to remove) |
 
-### Roles
+### Roles (7 tools)
 
 | Tool | Description |
 |---|---|
@@ -176,43 +260,38 @@ The server loads `.env` automatically via `dotenv`.
 | `discord_remove_role` | Remove a role from a member |
 | `discord_get_role_members` | List all members with a specific role |
 
-### Membership Screening
-
-| Tool | Description |
-|---|---|
-| `discord_get_membership_screening` | Get the current membership screening form (rules/questions for new members) |
-| `discord_update_membership_screening` | Update the screening form: welcome message + rules new members must agree to |
-
-### Moderation
-
-| Tool | Description |
-|---|---|
-| `discord_get_audit_log` | Fetch the guild audit log (who did what and when) |
-
-### Forums
+### Forums (10 tools)
 
 | Tool | Description |
 |---|---|
 | `discord_get_forum_channels` | List all forum channels in a guild |
 | `discord_create_forum_channel` | Create a new forum channel |
-| `discord_create_forum_post` | Create a post/thread in a forum channel |
-| `discord_get_forum_post` | Get a forum post details and its messages |
-| `discord_list_forum_threads` | List all threads in a forum channel (active + archived) |
-| `discord_reply_to_forum` | Reply to a forum post/thread |
+| `discord_create_forum_post` | Create a post/thread in a forum |
+| `discord_get_forum_post` | Get a post's details and messages |
+| `discord_list_forum_threads` | List threads (active + archived) |
+| `discord_reply_to_forum` | Reply to a forum post |
 | `discord_delete_forum_post` | Delete a forum thread |
-| `discord_get_forum_tags` | Get available tags for a forum channel |
-| `discord_set_forum_tags` | Set/update available tags on a forum channel |
-| `discord_update_forum_post` | Update a forum post (title, archived, locked, tags) |
+| `discord_get_forum_tags` | Get available tags |
+| `discord_set_forum_tags` | Set/update tags on a forum |
+| `discord_update_forum_post` | Update title, archived, locked, tags |
 
-### Webhooks
+### Webhooks (5 tools)
 
 | Tool | Description |
 |---|---|
 | `discord_create_webhook` | Create a webhook on a channel |
-| `discord_send_webhook_message` | Send a message via webhook (custom username/avatar) |
+| `discord_send_webhook_message` | Send via webhook (custom username/avatar, embeds) |
 | `discord_edit_webhook` | Edit a webhook's name, avatar, or channel |
 | `discord_delete_webhook` | Delete a webhook |
-| `discord_list_webhooks` | List all webhooks for a channel or guild |
+| `discord_list_webhooks` | List webhooks for a channel or guild |
+
+### Moderation & Screening
+
+| Tool | Description |
+|---|---|
+| `discord_get_audit_log` | Fetch the guild audit log |
+| `discord_get_membership_screening` | Get the membership screening form |
+| `discord_update_membership_screening` | Update screening rules for new members |
 
 ### Stats
 
@@ -226,18 +305,12 @@ The server loads `.env` automatically via `dotenv`.
 
 ```
 "List all servers the bot is in"
-"Read the last 10 messages from channel 123456789"
+"Read the last 10 messages in #general"
 "Send 'Hello everyone!' to the announcements channel"
-"Reply to the last message in #general"
-"React with a thumbs up to message 123456789"
-"Create a thread called 'Discussion' from the last message"
-"Delete the last 50 messages in #spam"
-"Create a channel #new-project in server 987654321"
-"List all members and their roles"
-"Assign the Moderator role to user 112233445566"
-"Ban user 112233445566 and delete their messages from the last 3 days"
-"Timeout user 112233445566 for 30 minutes"
+"Create a forum channel called 'feedback' with tags Bug, Feature, Question"
 "Show the full permission audit for the server"
+"Create a webhook on #notifications and send a test message"
+"Ban user 112233445566 and delete their messages from the last 3 days"
 ```
 
 ---
@@ -256,23 +329,24 @@ Then **right-click** on a server, channel, or user > **Copy ID**.
 ```
 discord-mcp/
 ├── src/
-│   ├── index.ts             <- Entry point (MCP server + transport)
-│   ├── client.ts            <- Discord client + shared helpers
+│   ├── index.ts             ← Entry point (MCP server + transport)
+│   ├── client.ts            ← Discord client + shared helpers
 │   └── tools/
-│       ├── index.ts         <- Tool registry (aggregates all modules)
-│       ├── types.ts         <- Shared TypeScript interfaces
-│       ├── discovery.ts     <- Guild/channel discovery tools
-│       ├── messages.ts      <- Message CRUD, reactions, threads
-│       ├── channels.ts      <- Channel management tools
-│       ├── permissions.ts   <- Permission overwrite tools
-│       ├── members.ts       <- Member management tools
-│       ├── roles.ts         <- Role CRUD and assignment tools
-│       ├── moderation.ts    <- Audit log tools
-│       ├── screening.ts     <- Membership screening tools
-│       ├── stats.ts         <- Server statistics tools
-│       ├── forums.ts        <- Forum channel tools
-│       └── webhooks.ts      <- Webhook management tools
-├── dist/                    <- Compiled output (generated by npm run build)
+│       ├── index.ts         ← Tool registry
+│       ├── types.ts         ← Shared TypeScript interfaces
+│       ├── discovery.ts     ← Guild/channel discovery
+│       ├── messages.ts      ← Message CRUD, reactions, threads, embeds
+│       ├── channels.ts      ← Channel management
+│       ├── permissions.ts   ← Permission overwrites
+│       ├── members.ts       ← Member management
+│       ├── roles.ts         ← Role CRUD and assignment
+│       ├── moderation.ts    ← Audit log
+│       ├── screening.ts     ← Membership screening
+│       ├── stats.ts         ← Server statistics
+│       ├── forums.ts        ← Forum channels, posts, tags
+│       └── webhooks.ts      ← Webhook management
+├── Dockerfile
+├── .dockerignore
 ├── package.json
 ├── tsconfig.json
 └── README.md
@@ -280,7 +354,7 @@ discord-mcp/
 
 ### Adding a new tool
 
-1. Create a new file in `src/tools/` (e.g. `onboarding.ts`)
+1. Create a new file in `src/tools/` (e.g. `events.ts`)
 2. Export `definitions` (tool schemas) and `handle()` (tool logic)
 3. Import and add it to the `modules` array in `src/tools/index.ts`
 
@@ -296,7 +370,7 @@ discord-mcp/
 
 ## Contributing
 
-Contributions are welcome! Here's how to get started:
+Contributions are welcome!
 
 1. Fork the repository
 2. Create a feature branch (`git checkout -b feature/my-feature`)
@@ -307,4 +381,4 @@ Contributions are welcome! Here's how to get started:
 
 ## License
 
-ISC — see [LICENSE](LICENSE) for details.
+MIT — see [LICENSE](LICENSE) for details.

--- a/package.json
+++ b/package.json
@@ -1,17 +1,43 @@
 {
-  "name": "discord-mcp",
+  "name": "@pasympa/discord-mcp",
   "version": "1.1.0",
-  "description": "MCP server that lets Claude control Discord",
+  "description": "A lightweight, multi-guild Discord MCP server with 60+ tools",
   "main": "dist/index.js",
   "type": "commonjs",
+  "bin": {
+    "discord-mcp": "dist/index.js"
+  },
+  "files": [
+    "dist"
+  ],
   "scripts": {
     "build": "tsc",
     "start": "node dist/index.js",
-    "dev": "tsc && node dist/index.js"
+    "dev": "tsc && node dist/index.js",
+    "prepublishOnly": "npm run build"
   },
-  "keywords": [],
-  "author": "",
-  "license": "ISC",
+  "keywords": [
+    "discord",
+    "mcp",
+    "model-context-protocol",
+    "claude",
+    "ai",
+    "bot",
+    "discord-bot",
+    "cursor",
+    "windsurf",
+    "claude-desktop"
+  ],
+  "author": "PaSympa",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/PaSympa/discord-mcp"
+  },
+  "homepage": "https://github.com/PaSympa/discord-mcp#readme",
+  "bugs": {
+    "url": "https://github.com/PaSympa/discord-mcp/issues"
+  },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.27.1",
     "discord.js": "^14.25.1",


### PR DESCRIPTION
## Summary
- **Dockerfile** — multi-stage build with node:22-alpine (~73MB image)
- **npm publish** — published as `@pasympa/discord-mcp` with bin, keywords, repository fields
- **README rewrite** — Quick Start with npx one-liner, collapsible config sections for Claude Desktop, Claude Code, Cursor, VS Code/Copilot, Docker, and from source. Added "Why this one?" positioning section.

## Test plan
- [x] `docker build` succeeds
- [x] Container starts and exits cleanly with proper error when no token
- [x] `npm publish --access public` succeeded (v1.1.0 live on npm)
- [x] README renders correctly on GitHub