### PR TITLE
Lazy Discord connection

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -13,10 +13,6 @@ import {
 // ────────────────────────────────────────────────────────────────────────────────
 
 const DISCORD_TOKEN = process.env.DISCORD_TOKEN;
-if (!DISCORD_TOKEN) {
-  console.error("❌  DISCORD_TOKEN env variable is required.");
-  process.exit(1);
-}
 
 export const discord = new Client({
   intents: [
@@ -29,21 +25,38 @@ export const discord = new Client({
 });
 
 let discordReady = false;
-discord.once("clientReady", () => {
-  discordReady = true;
-  console.error(`✅  Discord bot connected as ${discord.user?.tag}`);
-});
-
-discord.login(DISCORD_TOKEN);
+let loginPromise: Promise<void> | null = null;
 
 // ─── Helpers ───────────────────────────────────────────────────────────────────
 
 /**
- * Ensures the Discord client has completed its login handshake.
- * @throws {Error} If the client is not yet connected.
+ * Lazily connects to Discord on first tool call.
+ * Allows the MCP server to start and respond to ListTools without a connection.
  */
-export function assertReady() {
-  if (!discordReady) throw new Error("Discord bot is not connected yet. Retry in a moment.");
+export async function ensureConnected(): Promise<void> {
+  if (discordReady) return;
+
+  if (!DISCORD_TOKEN) {
+    throw new Error(
+      "DISCORD_TOKEN is required. Set it in your MCP client config or a .env file."
+    );
+  }
+
+  if (!loginPromise) {
+    loginPromise = new Promise<void>((resolve, reject) => {
+      discord.once("ready", () => {
+        discordReady = true;
+        console.error(`✅  Discord bot connected as ${discord.user?.tag}`);
+        resolve();
+      });
+      discord.login(DISCORD_TOKEN).catch((err) => {
+        loginPromise = null;
+        reject(new Error(`Discord login failed: ${err.message}`));
+      });
+    });
+  }
+
+  await loginPromise;
 }
 
 /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,7 +13,7 @@ import {
   ListToolsRequestSchema,
 } from "@modelcontextprotocol/sdk/types.js";
 
-import { assertReady, discord } from "./client.js";
+import { ensureConnected, discord } from "./client.js";
 import { getAllDefinitions, handleTool } from "./tools/index.js";
 
 // ─── MCP Server ────────────────────────────────────────────────────────────────
@@ -32,10 +32,10 @@ server.setRequestHandler(ListToolsRequestSchema, async () => ({
 // ─── Tool Handler ───────────────────────────────────────────────────────────────
 
 server.setRequestHandler(CallToolRequestSchema, async (req) => {
-  assertReady();
   const { name, arguments: args = {} } = req.params;
 
   try {
+    await ensureConnected();
     return await handleTool(name, args);
   } catch (err: unknown) {
     const message = err instanceof Error ? err.message : String(err);


### PR DESCRIPTION
Defer discord.login() to first tool call so ListTools works without a valid token. Required for Glama inspection.