### PR TITLE
feat: add scheduled events tools (6 new tools)

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # Discord MCP Server
 
-**A lightweight, multi-guild Discord MCP server with 60+ tools**
+**A lightweight, multi-guild Discord MCP server with 66+ tools**
 
 [![npm](https://img.shields.io/npm/v/@pasympa/discord-mcp)](https://www.npmjs.com/package/@pasympa/discord-mcp)
 [![License](https://img.shields.io/github/license/PaSympa/discord-mcp)](LICENSE)
@@ -21,7 +21,7 @@ Messages, channels, roles, permissions, moderation, forums, webhooks — all thr
 
 ## Why this one?
 
-- **60+ tools** — messages, channels, roles, permissions, moderation, forums, webhooks, embeds, and more
+- **66+ tools** — messages, channels, roles, permissions, moderation, forums, webhooks, scheduled events, embeds, and more
 - **Multi-guild** — works across multiple servers, no `GUILD_ID` lock-in
 - **Lightweight** — TypeScript + Node.js, ~25kB package, ~73MB Docker image (vs 400MB+ for Java alternatives)
 - **Modular** — clean architecture, easy to extend with new tools
@@ -184,12 +184,12 @@ The server loads `.env` automatically via `dotenv`.
    - Message Content Intent
 5. **OAuth2 > URL Generator**:
    - Scopes: `bot`
-   - Permissions: `Send Messages`, `Read Message History`, `Manage Channels`, `Manage Roles`, `Kick Members`, `Ban Members`, `Moderate Members`, `View Audit Log`, `Manage Messages`, `Manage Threads`, `Add Reactions`, `Manage Guild`, `Manage Webhooks`
+   - Permissions: `Send Messages`, `Read Message History`, `Manage Channels`, `Manage Roles`, `Kick Members`, `Ban Members`, `Moderate Members`, `View Audit Log`, `Manage Messages`, `Manage Threads`, `Add Reactions`, `Manage Guild`, `Manage Webhooks`, `Manage Events`
 6. Copy the generated URL and invite the bot to your server
 
 ---
 
-## Available Tools (60)
+## Available Tools (66)
 
 ### Discovery & Navigation
 
@@ -287,6 +287,17 @@ The server loads `.env` automatically via `dotenv`.
 | `discord_delete_webhook` | Delete a webhook |
 | `discord_list_webhooks` | List webhooks for a channel or guild |
 
+### Scheduled Events (6 tools)
+
+| Tool | Description |
+|---|---|
+| `discord_list_scheduled_events` | List all scheduled events in a guild |
+| `discord_get_scheduled_event` | Get detailed info about a scheduled event |
+| `discord_create_scheduled_event` | Create a voice, stage, or external event |
+| `discord_edit_scheduled_event` | Edit an existing scheduled event |
+| `discord_delete_scheduled_event` | Delete a scheduled event |
+| `discord_get_event_subscribers` | Get users who marked "Interested" |
+
 ### Moderation & Screening
 
 | Tool | Description |
@@ -313,6 +324,8 @@ The server loads `.env` automatically via `dotenv`.
 "Show the full permission audit for the server"
 "Create a webhook on #notifications and send a test message"
 "Ban user 112233445566 and delete their messages from the last 3 days"
+"Create an event called 'Game Night' for next Friday at 8pm"
+"List all upcoming events in the server"
 ```
 
 ---
@@ -346,7 +359,8 @@ discord-mcp/
 │       ├── screening.ts     ← Membership screening
 │       ├── stats.ts         ← Server statistics
 │       ├── forums.ts        ← Forum channels, posts, tags
-│       └── webhooks.ts      ← Webhook management
+│       ├── webhooks.ts      ← Webhook management
+│       └── scheduledEvents.ts ← Scheduled events
 ├── Dockerfile
 ├── .dockerignore
 ├── package.json

--- a/src/client.ts
+++ b/src/client.ts
@@ -21,6 +21,7 @@ export const discord = new Client({
     GatewayIntentBits.MessageContent,
     GatewayIntentBits.GuildMembers,
     GatewayIntentBits.GuildModeration,
+    GatewayIntentBits.GuildScheduledEvents,
   ],
 });
 

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -21,6 +21,7 @@ import screening from "./screening.js";
 import stats from "./stats.js";
 import forums from "./forums.js";
 import webhooks from "./webhooks.js";
+import scheduledEvents from "./scheduledEvents.js";
 
 const modules: ToolModule[] = [
   discovery,
@@ -34,6 +35,7 @@ const modules: ToolModule[] = [
   stats,
   forums,
   webhooks,
+  scheduledEvents,
 ];
 
 /**

--- a/src/tools/scheduledEvents.ts
+++ b/src/tools/scheduledEvents.ts
@@ -1,0 +1,277 @@
+import { GuildScheduledEventEntityType, GuildScheduledEventPrivacyLevel, GuildScheduledEventStatus } from "discord.js";
+import { discord, validateId } from "../client.js";
+import type { ToolModule, ToolResult } from "./types.js";
+
+/** Tool definitions for managing guild scheduled events. */
+export const definitions = [
+  {
+    name: "discord_list_scheduled_events",
+    description: "List all scheduled events in a guild.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        guild_id: { type: "string" },
+      },
+      required: ["guild_id"],
+    },
+  },
+  {
+    name: "discord_get_scheduled_event",
+    description: "Get detailed info about a specific scheduled event.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        guild_id: { type: "string" },
+        event_id: { type: "string" },
+      },
+      required: ["guild_id", "event_id"],
+    },
+  },
+  {
+    name: "discord_create_scheduled_event",
+    description:
+      "Create a scheduled event in a guild. Use entity_type 'VOICE' or 'STAGE_INSTANCE' with a channel_id, or 'EXTERNAL' with a location and scheduled_end_time.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        guild_id: { type: "string" },
+        name: { type: "string" },
+        description: { type: "string" },
+        entity_type: {
+          type: "string",
+          description: "'VOICE', 'STAGE_INSTANCE', or 'EXTERNAL'.",
+        },
+        scheduled_start_time: {
+          type: "string",
+          description: "ISO 8601 datetime (e.g. '2025-06-01T20:00:00Z').",
+        },
+        scheduled_end_time: {
+          type: "string",
+          description: "ISO 8601 datetime. Required for EXTERNAL events.",
+        },
+        channel_id: {
+          type: "string",
+          description: "Voice or stage channel ID. Required for VOICE/STAGE_INSTANCE.",
+        },
+        location: {
+          type: "string",
+          description: "Location string. Required for EXTERNAL events.",
+        },
+        image: { type: "string", description: "Cover image URL." },
+      },
+      required: ["guild_id", "name", "entity_type", "scheduled_start_time"],
+    },
+  },
+  {
+    name: "discord_edit_scheduled_event",
+    description: "Edit an existing scheduled event. Only provided fields are updated.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        guild_id: { type: "string" },
+        event_id: { type: "string" },
+        name: { type: "string" },
+        description: { type: "string" },
+        scheduled_start_time: { type: "string", description: "ISO 8601 datetime." },
+        scheduled_end_time: { type: "string", description: "ISO 8601 datetime." },
+        channel_id: { type: "string" },
+        location: { type: "string" },
+        image: { type: "string", description: "Cover image URL." },
+        status: {
+          type: "string",
+          description: "'SCHEDULED', 'ACTIVE', 'COMPLETED', or 'CANCELED'.",
+        },
+      },
+      required: ["guild_id", "event_id"],
+    },
+  },
+  {
+    name: "discord_delete_scheduled_event",
+    description: "Delete a scheduled event.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        guild_id: { type: "string" },
+        event_id: { type: "string" },
+      },
+      required: ["guild_id", "event_id"],
+    },
+  },
+  {
+    name: "discord_get_event_subscribers",
+    description: "Get users who marked 'Interested' in a scheduled event.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        guild_id: { type: "string" },
+        event_id: { type: "string" },
+        limit: { type: "number", description: "1–100, default 25." },
+      },
+      required: ["guild_id", "event_id"],
+    },
+  },
+];
+
+// ─── Helpers ────────────────────────────────────────────────────────────────────
+
+const ENTITY_TYPE_MAP: Record<string, GuildScheduledEventEntityType> = {
+  STAGE_INSTANCE: GuildScheduledEventEntityType.StageInstance,
+  VOICE: GuildScheduledEventEntityType.Voice,
+  EXTERNAL: GuildScheduledEventEntityType.External,
+};
+
+const STATUS_MAP: Record<string, GuildScheduledEventStatus> = {
+  SCHEDULED: GuildScheduledEventStatus.Scheduled,
+  ACTIVE: GuildScheduledEventStatus.Active,
+  COMPLETED: GuildScheduledEventStatus.Completed,
+  CANCELED: GuildScheduledEventStatus.Canceled,
+};
+
+const ENTITY_TYPE_NAMES: Record<number, string> = {
+  [GuildScheduledEventEntityType.StageInstance]: "STAGE_INSTANCE",
+  [GuildScheduledEventEntityType.Voice]: "VOICE",
+  [GuildScheduledEventEntityType.External]: "EXTERNAL",
+};
+
+const STATUS_NAMES: Record<number, string> = {
+  [GuildScheduledEventStatus.Scheduled]: "SCHEDULED",
+  [GuildScheduledEventStatus.Active]: "ACTIVE",
+  [GuildScheduledEventStatus.Completed]: "COMPLETED",
+  [GuildScheduledEventStatus.Canceled]: "CANCELED",
+};
+
+function serializeEvent(event: import("discord.js").GuildScheduledEvent) {
+  return {
+    id: event.id,
+    name: event.name,
+    description: event.description ?? null,
+    status: STATUS_NAMES[event.status] ?? event.status,
+    entity_type: ENTITY_TYPE_NAMES[event.entityType] ?? event.entityType,
+    channel_id: event.channelId ?? null,
+    location: event.entityMetadata?.location ?? null,
+    scheduled_start_time: event.scheduledStartAt?.toISOString() ?? null,
+    scheduled_end_time: event.scheduledEndAt?.toISOString() ?? null,
+    creator_id: event.creatorId ?? null,
+    user_count: event.userCount ?? null,
+    image: event.coverImageURL() ?? null,
+  };
+}
+
+// ─── Handler ────────────────────────────────────────────────────────────────────
+
+export async function handle(
+  name: string,
+  args: Record<string, unknown>,
+): Promise<ToolResult | null> {
+  switch (name) {
+    case "discord_list_scheduled_events": {
+      const guildId = validateId(args.guild_id, "guild_id");
+      const guild = await discord.guilds.fetch(guildId);
+      const events = await guild.scheduledEvents.fetch();
+      const list = [...events.values()].map(serializeEvent);
+      return { content: [{ type: "text", text: JSON.stringify(list, null, 2) }] };
+    }
+
+    case "discord_get_scheduled_event": {
+      const guildId = validateId(args.guild_id, "guild_id");
+      const eventId = validateId(args.event_id, "event_id");
+      const guild = await discord.guilds.fetch(guildId);
+      const event = await guild.scheduledEvents.fetch(eventId);
+      return { content: [{ type: "text", text: JSON.stringify(serializeEvent(event), null, 2) }] };
+    }
+
+    case "discord_create_scheduled_event": {
+      const guildId = validateId(args.guild_id, "guild_id");
+      const guild = await discord.guilds.fetch(guildId);
+
+      const entityTypeStr = String(args.entity_type).toUpperCase();
+      const entityType = ENTITY_TYPE_MAP[entityTypeStr];
+      if (!entityType) throw new Error(`Invalid entity_type: "${args.entity_type}". Must be VOICE, STAGE_INSTANCE, or EXTERNAL.`);
+
+      if ((entityType === GuildScheduledEventEntityType.Voice || entityType === GuildScheduledEventEntityType.StageInstance) && !args.channel_id) {
+        throw new Error("channel_id is required for VOICE or STAGE_INSTANCE events.");
+      }
+      if (entityType === GuildScheduledEventEntityType.External && !args.location) {
+        throw new Error("location is required for EXTERNAL events.");
+      }
+      if (entityType === GuildScheduledEventEntityType.External && !args.scheduled_end_time) {
+        throw new Error("scheduled_end_time is required for EXTERNAL events.");
+      }
+
+      const options: Record<string, unknown> = {
+        name: String(args.name),
+        scheduledStartTime: String(args.scheduled_start_time),
+        entityType,
+        privacyLevel: GuildScheduledEventPrivacyLevel.GuildOnly,
+      };
+      if (args.description) options.description = String(args.description);
+      if (args.scheduled_end_time) options.scheduledEndTime = String(args.scheduled_end_time);
+      if (args.channel_id) options.channel = validateId(args.channel_id, "channel_id");
+      if (args.location) options.entityMetadata = { location: String(args.location) };
+      if (args.image) options.image = String(args.image);
+
+      const event = await guild.scheduledEvents.create(options as any);
+      return {
+        content: [{ type: "text", text: `✅ Scheduled event "${event.name}" created (id: ${event.id}).` }],
+      };
+    }
+
+    case "discord_edit_scheduled_event": {
+      const guildId = validateId(args.guild_id, "guild_id");
+      const eventId = validateId(args.event_id, "event_id");
+      const guild = await discord.guilds.fetch(guildId);
+      const event = await guild.scheduledEvents.fetch(eventId);
+
+      const options: Record<string, unknown> = {};
+      if (args.name) options.name = String(args.name);
+      if (args.description !== undefined) options.description = String(args.description);
+      if (args.scheduled_start_time) options.scheduledStartTime = String(args.scheduled_start_time);
+      if (args.scheduled_end_time) options.scheduledEndTime = String(args.scheduled_end_time);
+      if (args.channel_id) options.channel = validateId(args.channel_id, "channel_id");
+      if (args.location) options.entityMetadata = { location: String(args.location) };
+      if (args.image) options.image = String(args.image);
+      if (args.status) {
+        const statusStr = String(args.status).toUpperCase();
+        const status = STATUS_MAP[statusStr];
+        if (!status) throw new Error(`Invalid status: "${args.status}". Must be SCHEDULED, ACTIVE, COMPLETED, or CANCELED.`);
+        options.status = status;
+      }
+
+      const updated = await event.edit(options as any);
+      return {
+        content: [{ type: "text", text: `✅ Scheduled event "${updated.name}" updated (id: ${updated.id}).` }],
+      };
+    }
+
+    case "discord_delete_scheduled_event": {
+      const guildId = validateId(args.guild_id, "guild_id");
+      const eventId = validateId(args.event_id, "event_id");
+      const guild = await discord.guilds.fetch(guildId);
+      const event = await guild.scheduledEvents.fetch(eventId);
+      await event.delete();
+      return {
+        content: [{ type: "text", text: `✅ Scheduled event "${event.name}" deleted (id: ${eventId}).` }],
+      };
+    }
+
+    case "discord_get_event_subscribers": {
+      const guildId = validateId(args.guild_id, "guild_id");
+      const eventId = validateId(args.event_id, "event_id");
+      const guild = await discord.guilds.fetch(guildId);
+      const event = await guild.scheduledEvents.fetch(eventId);
+      const limit = Math.min(Number(args.limit ?? 25), 100);
+      const subscribers = await event.fetchSubscribers({ limit });
+      const list = [...subscribers.values()].map((sub) => ({
+        user_id: sub.user.id,
+        username: sub.user.username,
+        avatar: sub.user.displayAvatarURL(),
+      }));
+      return { content: [{ type: "text", text: JSON.stringify(list, null, 2) }] };
+    }
+
+    default:
+      return null;
+  }
+}
+
+export default { definitions, handle } satisfies ToolModule;


### PR DESCRIPTION
## Summary
- Add 6 new scheduled events tools: list, get, create, edit, delete, get subscribers
- Supports VOICE, STAGE_INSTANCE, and EXTERNAL event types
- Adds GuildScheduledEvents intent
- Updates README (66 tools, new section, permissions, examples)

## Test plan
- [x] Tested all 6 tools on live Discord server
- [x] Created, listed, got details, edited, and deleted an external event
- [x] Fetched subscribers
- [x] Build passes with no errors