### PR TITLE
feat: add invite management tools (4 new tools)

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # Discord MCP Server
 
-**A lightweight, multi-guild Discord MCP server with 66+ tools**
+**A lightweight, multi-guild Discord MCP server with 70+ tools**
 
 [![npm](https://img.shields.io/npm/v/@pasympa/discord-mcp)](https://www.npmjs.com/package/@pasympa/discord-mcp)
 [![License](https://img.shields.io/github/license/PaSympa/discord-mcp)](LICENSE)
@@ -21,7 +21,7 @@ Messages, channels, roles, permissions, moderation, forums, webhooks — all thr
 
 ## Why this one?
 
-- **66+ tools** — messages, channels, roles, permissions, moderation, forums, webhooks, scheduled events, embeds, and more
+- **70+ tools** — messages, channels, roles, permissions, moderation, forums, webhooks, scheduled events, invites, embeds, and more
 - **Multi-guild** — works across multiple servers, no `GUILD_ID` lock-in
 - **Lightweight** — TypeScript + Node.js, ~25kB package, ~73MB Docker image (vs 400MB+ for Java alternatives)
 - **Modular** — clean architecture, easy to extend with new tools
@@ -184,12 +184,12 @@ The server loads `.env` automatically via `dotenv`.
    - Message Content Intent
 5. **OAuth2 > URL Generator**:
    - Scopes: `bot`
-   - Permissions: `Send Messages`, `Read Message History`, `Manage Channels`, `Manage Roles`, `Kick Members`, `Ban Members`, `Moderate Members`, `View Audit Log`, `Manage Messages`, `Manage Threads`, `Add Reactions`, `Manage Guild`, `Manage Webhooks`, `Manage Events`
+   - Permissions: `Send Messages`, `Read Message History`, `Manage Channels`, `Manage Roles`, `Kick Members`, `Ban Members`, `Moderate Members`, `View Audit Log`, `Manage Messages`, `Manage Threads`, `Add Reactions`, `Manage Guild`, `Manage Webhooks`, `Manage Events`, `Create Instant Invite`
 6. Copy the generated URL and invite the bot to your server
 
 ---
 
-## Available Tools (66)
+## Available Tools (70)
 
 ### Discovery & Navigation
 
@@ -298,6 +298,15 @@ The server loads `.env` automatically via `dotenv`.
 | `discord_delete_scheduled_event` | Delete a scheduled event |
 | `discord_get_event_subscribers` | Get users who marked "Interested" |
 
+### Invites (4 tools)
+
+| Tool | Description |
+|---|---|
+| `discord_list_invites` | List all active invites in a guild |
+| `discord_get_invite` | Get details about an invite by its code |
+| `discord_create_invite` | Create an invite link for a channel |
+| `discord_delete_invite` | Revoke an invite |
+
 ### Moderation & Screening
 
 | Tool | Description |
@@ -326,6 +335,8 @@ The server loads `.env` automatically via `dotenv`.
 "Ban user 112233445566 and delete their messages from the last 3 days"
 "Create an event called 'Game Night' for next Friday at 8pm"
 "List all upcoming events in the server"
+"Create a permanent invite for #general"
+"List all active invites and delete expired ones"
 ```
 
 ---
@@ -360,7 +371,8 @@ discord-mcp/
 │       ├── stats.ts         ← Server statistics
 │       ├── forums.ts        ← Forum channels, posts, tags
 │       ├── webhooks.ts      ← Webhook management
-│       └── scheduledEvents.ts ← Scheduled events
+│       ├── scheduledEvents.ts ← Scheduled events
+│       └── invites.ts        ← Invite management
 ├── Dockerfile
 ├── .dockerignore
 ├── package.json

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@pasympa/discord-mcp",
-  "version": "1.2.0",
-  "description": "A lightweight, multi-guild Discord MCP server with 60+ tools",
+  "version": "1.3.0",
+  "description": "A lightweight, multi-guild Discord MCP server with 70+ tools",
   "main": "dist/index.js",
   "type": "commonjs",
   "bin": {

--- a/src/client.ts
+++ b/src/client.ts
@@ -22,6 +22,7 @@ export const discord = new Client({
     GatewayIntentBits.GuildMembers,
     GatewayIntentBits.GuildModeration,
     GatewayIntentBits.GuildScheduledEvents,
+    GatewayIntentBits.GuildInvites,
   ],
 });
 

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -22,6 +22,7 @@ import stats from "./stats.js";
 import forums from "./forums.js";
 import webhooks from "./webhooks.js";
 import scheduledEvents from "./scheduledEvents.js";
+import invites from "./invites.js";
 
 const modules: ToolModule[] = [
   discovery,
@@ -36,6 +37,7 @@ const modules: ToolModule[] = [
   forums,
   webhooks,
   scheduledEvents,
+  invites,
 ];
 
 /**

--- a/src/tools/invites.ts
+++ b/src/tools/invites.ts
@@ -1,0 +1,150 @@
+import { discord, validateId } from "../client.js";
+import type { ToolModule, ToolResult } from "./types.js";
+
+/** Tool definitions for managing guild invites. */
+export const definitions = [
+  {
+    name: "discord_list_invites",
+    description: "List all active invites in a guild.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        guild_id: { type: "string" },
+      },
+      required: ["guild_id"],
+    },
+  },
+  {
+    name: "discord_get_invite",
+    description: "Get details about a specific invite by its code.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        invite_code: {
+          type: "string",
+          description: "The invite code (e.g. 'abc123' from discord.gg/abc123).",
+        },
+      },
+      required: ["invite_code"],
+    },
+  },
+  {
+    name: "discord_create_invite",
+    description: "Create an invite link for a channel.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        channel_id: { type: "string" },
+        max_age: {
+          type: "number",
+          description: "Invite duration in seconds (0 = never expires). Default 86400 (24h).",
+        },
+        max_uses: {
+          type: "number",
+          description: "Max number of uses (0 = unlimited). Default 0.",
+        },
+        unique: {
+          type: "boolean",
+          description: "If true, create a new unique invite even if one exists. Default false.",
+        },
+        temporary: {
+          type: "boolean",
+          description: "If true, members joined via this invite are kicked when they disconnect. Default false.",
+        },
+      },
+      required: ["channel_id"],
+    },
+  },
+  {
+    name: "discord_delete_invite",
+    description: "Delete (revoke) an invite by its code.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        invite_code: {
+          type: "string",
+          description: "The invite code to revoke.",
+        },
+        reason: { type: "string" },
+      },
+      required: ["invite_code"],
+    },
+  },
+];
+
+// ─── Helpers ────────────────────────────────────────────────────────────────────
+
+function serializeInvite(invite: import("discord.js").Invite) {
+  return {
+    code: invite.code,
+    url: invite.url,
+    channel_id: invite.channelId ?? null,
+    channel_name: invite.channel?.name ?? null,
+    inviter: invite.inviter
+      ? { id: invite.inviter.id, username: invite.inviter.username }
+      : null,
+    uses: invite.uses ?? 0,
+    max_uses: invite.maxUses ?? 0,
+    max_age: invite.maxAge ?? 0,
+    temporary: invite.temporary ?? false,
+    created_at: invite.createdAt?.toISOString() ?? null,
+    expires_at: invite.expiresAt?.toISOString() ?? null,
+  };
+}
+
+// ─── Handler ────────────────────────────────────────────────────────────────────
+
+export async function handle(
+  name: string,
+  args: Record<string, unknown>,
+): Promise<ToolResult | null> {
+  switch (name) {
+    case "discord_list_invites": {
+      const guildId = validateId(args.guild_id, "guild_id");
+      const guild = await discord.guilds.fetch(guildId);
+      const invites = await guild.invites.fetch();
+      const list = [...invites.values()].map(serializeInvite);
+      return { content: [{ type: "text", text: JSON.stringify(list, null, 2) }] };
+    }
+
+    case "discord_get_invite": {
+      const code = String(args.invite_code ?? "").replace(/^(https?:\/\/)?(discord\.gg\/)?/, "");
+      if (!code) throw new Error("invite_code is required.");
+      const invite = await discord.fetchInvite(code);
+      return { content: [{ type: "text", text: JSON.stringify(serializeInvite(invite), null, 2) }] };
+    }
+
+    case "discord_create_invite": {
+      const channelId = validateId(args.channel_id, "channel_id");
+      const channel = await discord.channels.fetch(channelId);
+      if (!channel || !("createInvite" in channel)) {
+        throw new Error(`Channel ${channelId} does not support invites.`);
+      }
+
+      const invite = await (channel as any).createInvite({
+        maxAge: Number(args.max_age ?? 86400),
+        maxUses: Number(args.max_uses ?? 0),
+        unique: Boolean(args.unique ?? false),
+        temporary: Boolean(args.temporary ?? false),
+      });
+      return {
+        content: [{ type: "text", text: `✅ Invite created: ${invite.url} (code: ${invite.code}, max_age: ${invite.maxAge}s, max_uses: ${invite.maxUses}).` }],
+      };
+    }
+
+    case "discord_delete_invite": {
+      const code = String(args.invite_code ?? "").replace(/^(https?:\/\/)?(discord\.gg\/)?/, "");
+      if (!code) throw new Error("invite_code is required.");
+      const invite = await discord.fetchInvite(code);
+      await invite.delete(args.reason ? String(args.reason) : undefined);
+      return {
+        content: [{ type: "text", text: `✅ Invite "${code}" deleted.` }],
+      };
+    }
+
+    default:
+      return null;
+  }
+}
+
+export default { definitions, handle } satisfies ToolModule;


### PR DESCRIPTION
## Summary
- Add 4 invite tools: list, get, create, delete
- Supports max_age, max_uses, unique, temporary options
- Strips discord.gg URLs from invite codes automatically
- Adds GuildInvites intent
- Bumps version to 1.3.0
- Updates README (70 tools)

## Test plan
- [x] Listed all active invites on live server
- [x] Created invite with custom max_age and max_uses
- [x] Got invite details by code
- [x] Deleted test invite
- [x] Build passes with no errors

## Release
After merge:
- `npm publish --access public`
- `docker build -t pasympa/discord-mcp:1.3.0 -t pasympa/discord-mcp:latest .`
- `docker push pasympa/discord-mcp --all-tags`