### PR TITLE
feat: enhance existing tools (+20 new tools, 90 total)

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # Discord MCP Server
 
-**A lightweight, multi-guild Discord MCP server with 70+ tools**
+**A lightweight, multi-guild Discord MCP server with 90+ tools**
 
 [![npm](https://img.shields.io/npm/v/@pasympa/discord-mcp)](https://www.npmjs.com/package/@pasympa/discord-mcp)
 [![License](https://img.shields.io/github/license/PaSympa/discord-mcp)](LICENSE)
@@ -21,7 +21,7 @@ Messages, channels, roles, permissions, moderation, forums, webhooks — all thr
 
 ## Why this one?
 
-- **70+ tools** — messages, channels, roles, permissions, moderation, forums, webhooks, scheduled events, invites, embeds, and more
+- **90+ tools** — messages, channels, roles, permissions, moderation, forums, webhooks, scheduled events, invites, embeds, and more
 - **Multi-guild** — works across multiple servers, no `GUILD_ID` lock-in
 - **Lightweight** — TypeScript + Node.js, ~25kB package, ~73MB Docker image (vs 400MB+ for Java alternatives)
 - **Modular** — clean architecture, easy to extend with new tools
@@ -189,7 +189,7 @@ The server loads `.env` automatically via `dotenv`.
 
 ---
 
-## Available Tools (70)
+## Available Tools (90)
 
 ### Discovery & Navigation
 
@@ -200,7 +200,7 @@ The server loads `.env` automatically via `dotenv`.
 | `discord_list_channels` | List all channels in a guild grouped by category |
 | `discord_find_channel_by_name` | Find a channel by name (partial match) |
 
-### Messages (13 tools)
+### Messages (18 tools)
 
 | Tool | Description |
 |---|---|
@@ -210,23 +210,31 @@ The server loads `.env` automatically via `dotenv`.
 | `discord_edit_message` | Edit a message sent by the bot |
 | `discord_delete_message` | Delete a specific message |
 | `discord_add_reaction` | Add a reaction emoji to a message |
+| `discord_remove_reactions` | Remove reactions (all, by emoji, or by user) |
+| `discord_get_reactions` | List users who reacted with a specific emoji |
 | `discord_create_thread` | Create a thread from a message or standalone |
 | `discord_bulk_delete_messages` | Delete multiple messages at once (2-100) |
 | `discord_send_embed` | Send a rich embed with all options |
 | `discord_edit_embed` | Edit an embed previously sent by the bot |
 | `discord_send_multiple_embeds` | Send up to 10 embeds in a single message |
 | `discord_pin_message` | Pin or unpin a message |
+| `discord_fetch_pinned_messages` | List all pinned messages in a channel |
 | `discord_search_messages` | Search messages by keyword (last 100) |
+| `discord_crosspost_message` | Publish a message to announcement channel followers |
+| `discord_forward_message` | Forward a message to another channel |
 
-### Channels (5 tools)
+### Channels (8 tools)
 
 | Tool | Description |
 |---|---|
 | `discord_create_channel` | Create a text, voice channel or category |
 | `discord_delete_channel` | Delete a channel |
-| `discord_edit_channel` | Edit name, topic, slowmode |
+| `discord_edit_channel` | Edit name, topic, slowmode, NSFW flag |
 | `discord_move_channel` | Move a channel into/out of a category |
 | `discord_clone_channel` | Clone a channel with its permissions |
+| `discord_set_channel_position` | Set display position within a category |
+| `discord_follow_announcement_channel` | Follow an announcement channel |
+| `discord_lock_channel_permissions` | Sync permissions with parent category |
 
 ### Channel Permissions (6 tools)
 
@@ -239,18 +247,23 @@ The server loads `.env` automatically via `dotenv`.
 | `discord_copy_permissions` | Copy overwrites from one channel to another |
 | `discord_audit_permissions` | Full permission audit for all channels |
 
-### Members (6 tools)
+### Members (11 tools)
 
 | Tool | Description |
 |---|---|
 | `discord_list_members` | List guild members with their roles |
 | `discord_get_member_info` | Detailed member info (roles, permissions, join date) |
+| `discord_search_members` | Search members by username or nickname |
+| `discord_set_nickname` | Set or clear a member's nickname |
 | `discord_kick_member` | Kick a member |
 | `discord_ban_member` | Ban a member (optionally delete recent messages) |
 | `discord_unban_member` | Unban a user |
+| `discord_bulk_ban` | Ban multiple users at once (raid mitigation) |
+| `discord_list_bans` | List all banned users |
 | `discord_timeout_member` | Timeout a member (0 to remove) |
+| `discord_prune_members` | Remove inactive members (with dry run) |
 
-### Roles (7 tools)
+### Roles (9 tools)
 
 | Tool | Description |
 |---|---|
@@ -261,6 +274,8 @@ The server loads `.env` automatically via `dotenv`.
 | `discord_add_role` | Assign a role to a member |
 | `discord_remove_role` | Remove a role from a member |
 | `discord_get_role_members` | List all members with a specific role |
+| `discord_set_role_position` | Change a role's position in the hierarchy |
+| `discord_set_role_icon` | Set a custom icon or unicode emoji on a role |
 
 ### Forums (10 tools)
 
@@ -277,7 +292,7 @@ The server loads `.env` automatically via `dotenv`.
 | `discord_set_forum_tags` | Set/update tags on a forum |
 | `discord_update_forum_post` | Update title, archived, locked, tags |
 
-### Webhooks (5 tools)
+### Webhooks (8 tools)
 
 | Tool | Description |
 |---|---|
@@ -286,8 +301,11 @@ The server loads `.env` automatically via `dotenv`.
 | `discord_edit_webhook` | Edit a webhook's name, avatar, or channel |
 | `discord_delete_webhook` | Delete a webhook |
 | `discord_list_webhooks` | List webhooks for a channel or guild |
+| `discord_edit_webhook_message` | Edit a message sent by a webhook |
+| `discord_delete_webhook_message` | Delete a message sent by a webhook |
+| `discord_fetch_webhook_message` | Fetch a specific webhook message |
 
-### Scheduled Events (6 tools)
+### Scheduled Events (7 tools)
 
 | Tool | Description |
 |---|---|
@@ -297,12 +315,14 @@ The server loads `.env` automatically via `dotenv`.
 | `discord_edit_scheduled_event` | Edit an existing scheduled event |
 | `discord_delete_scheduled_event` | Delete a scheduled event |
 | `discord_get_event_subscribers` | Get users who marked "Interested" |
+| `discord_create_event_invite` | Create an invite linked to an event |
 
-### Invites (4 tools)
+### Invites (5 tools)
 
 | Tool | Description |
 |---|---|
 | `discord_list_invites` | List all active invites in a guild |
+| `discord_list_channel_invites` | List invites for a specific channel |
 | `discord_get_invite` | Get details about an invite by its code |
 | `discord_create_invite` | Create an invite link for a channel |
 | `discord_delete_invite` | Revoke an invite |
@@ -337,6 +357,10 @@ The server loads `.env` automatically via `dotenv`.
 "List all upcoming events in the server"
 "Create a permanent invite for #general"
 "List all active invites and delete expired ones"
+"Search for members named 'john'"
+"List all banned users in the server"
+"Show all pinned messages in #general"
+"Forward that message to #announcements"
 ```
 
 ---

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@pasympa/discord-mcp",
-  "version": "1.3.0",
-  "description": "A lightweight, multi-guild Discord MCP server with 70+ tools",
+  "version": "1.4.0",
+  "description": "A lightweight, multi-guild Discord MCP server with 90+ tools",
   "main": "dist/index.js",
   "type": "commonjs",
   "bin": {

--- a/src/tools/channels.ts
+++ b/src/tools/channels.ts
@@ -33,7 +33,7 @@ export const definitions = [
   },
   {
     name: "discord_edit_channel",
-    description: "Edit a channel's name, topic (text only) or slowmode (text only).",
+    description: "Edit a channel's name, topic, slowmode, or NSFW flag.",
     inputSchema: {
       type: "object",
       properties: {
@@ -41,6 +41,7 @@ export const definitions = [
         name: { type: "string" },
         topic: { type: "string" },
         slowmode: { type: "number", description: "Slowmode in seconds (0 to disable)." },
+        nsfw: { type: "boolean", description: "Mark channel as NSFW." },
       },
       required: ["channel_id"],
     },
@@ -65,6 +66,41 @@ export const definitions = [
       properties: {
         channel_id: { type: "string" },
         new_name: { type: "string" },
+      },
+      required: ["channel_id"],
+    },
+  },
+  {
+    name: "discord_set_channel_position",
+    description: "Set the display position of a channel within its category.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        channel_id: { type: "string" },
+        position: { type: "number" },
+      },
+      required: ["channel_id", "position"],
+    },
+  },
+  {
+    name: "discord_follow_announcement_channel",
+    description: "Follow an announcement channel so its messages are published to a target channel.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        source_channel_id: { type: "string", description: "The announcement channel to follow." },
+        target_channel_id: { type: "string", description: "The channel that will receive published messages." },
+      },
+      required: ["source_channel_id", "target_channel_id"],
+    },
+  },
+  {
+    name: "discord_lock_channel_permissions",
+    description: "Sync a channel's permissions with its parent category.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        channel_id: { type: "string" },
       },
       required: ["channel_id"],
     },
@@ -105,6 +141,7 @@ export async function handle(name: string, args: Record<string, unknown>): Promi
       if (args.name !== undefined) editOptions.name = args.name as string;
       if (args.topic !== undefined && channel.type === ChannelType.GuildText) editOptions.topic = args.topic as string;
       if (args.slowmode !== undefined && channel.type === ChannelType.GuildText) editOptions.rateLimitPerUser = args.slowmode as number;
+      if (args.nsfw !== undefined) editOptions.nsfw = args.nsfw as boolean;
       await channel.edit(editOptions);
       return { content: [{ type: "text", text: `✅ Channel #${channel.name} updated.` }] };
     }
@@ -119,6 +156,25 @@ export async function handle(name: string, args: Record<string, unknown>): Promi
       const channel = await getGuildChannel(args.channel_id as string);
       const cloned = await channel.clone({ name: args.new_name as string | undefined });
       return { content: [{ type: "text", text: `✅ Channel cloned as #${cloned.name} (id: ${cloned.id}).` }] };
+    }
+
+    case "discord_set_channel_position": {
+      const channel = await getGuildChannel(args.channel_id as string);
+      await channel.setPosition(args.position as number);
+      return { content: [{ type: "text", text: `✅ Channel #${channel.name} moved to position ${args.position}.` }] };
+    }
+
+    case "discord_follow_announcement_channel": {
+      const source = await discord.channels.fetch(validateId(args.source_channel_id, "source_channel_id"));
+      if (!source || !("addFollower" in source)) throw new Error("Source channel is not an announcement channel.");
+      await (source as any).addFollower(validateId(args.target_channel_id, "target_channel_id"));
+      return { content: [{ type: "text", text: `✅ Now following announcement channel in target channel.` }] };
+    }
+
+    case "discord_lock_channel_permissions": {
+      const channel = await getGuildChannel(args.channel_id as string);
+      await channel.lockPermissions();
+      return { content: [{ type: "text", text: `✅ Channel #${channel.name} permissions synced with parent category.` }] };
     }
 
     default:

--- a/src/tools/invites.ts
+++ b/src/tools/invites.ts
@@ -70,6 +70,17 @@ export const definitions = [
       required: ["invite_code"],
     },
   },
+  {
+    name: "discord_list_channel_invites",
+    description: "List all active invites for a specific channel.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        channel_id: { type: "string" },
+      },
+      required: ["channel_id"],
+    },
+  },
 ];
 
 // ─── Helpers ────────────────────────────────────────────────────────────────────
@@ -140,6 +151,17 @@ export async function handle(
       return {
         content: [{ type: "text", text: `✅ Invite "${code}" deleted.` }],
       };
+    }
+
+    case "discord_list_channel_invites": {
+      const channelId = validateId(args.channel_id, "channel_id");
+      const channel = await discord.channels.fetch(channelId);
+      if (!channel || !("fetchInvites" in channel)) {
+        throw new Error(`Channel ${channelId} does not support invites.`);
+      }
+      const invites = await (channel as any).fetchInvites();
+      const list = [...invites.values()].map(serializeInvite);
+      return { content: [{ type: "text", text: JSON.stringify(list, null, 2) }] };
     }
 
     default:

--- a/src/tools/members.ts
+++ b/src/tools/members.ts
@@ -244,9 +244,8 @@ export async function handle(name: string, args: Record<string, unknown>): Promi
 
     case "discord_list_bans": {
       const guild = await discord.guilds.fetch(validateId(args.guild_id, "guild_id"));
-      const options: { limit?: number } = {};
-      if (args.limit) options.limit = Number(args.limit);
-      const bans = await guild.bans.fetch(options);
+      const limit = args.limit ? Number(args.limit) : undefined;
+      const bans = await guild.bans.fetch({ limit, cache: false });
       const result = [...bans.values()].map((ban) => ({
         user_id: ban.user.id, username: ban.user.tag, reason: ban.reason ?? null,
       }));

--- a/src/tools/members.ts
+++ b/src/tools/members.ts
@@ -82,6 +82,74 @@ export const definitions = [
       required: ["guild_id", "user_id", "duration_minutes"],
     },
   },
+  {
+    name: "discord_search_members",
+    description: "Search guild members by username or nickname.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        guild_id: { type: "string" },
+        query: { type: "string", description: "Search query (matches username and nickname)." },
+        limit: { type: "number", description: "1–100, default 25." },
+      },
+      required: ["guild_id", "query"],
+    },
+  },
+  {
+    name: "discord_set_nickname",
+    description: "Set or clear a member's nickname.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        guild_id: { type: "string" },
+        user_id: { type: "string" },
+        nickname: { type: "string", description: "New nickname, or null to clear." },
+        reason: { type: "string" },
+      },
+      required: ["guild_id", "user_id", "nickname"],
+    },
+  },
+  {
+    name: "discord_list_bans",
+    description: "List all banned users in a guild.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        guild_id: { type: "string" },
+        limit: { type: "number", description: "Max bans to fetch." },
+      },
+      required: ["guild_id"],
+    },
+  },
+  {
+    name: "discord_bulk_ban",
+    description: "Ban multiple users at once (raid mitigation).",
+    inputSchema: {
+      type: "object",
+      properties: {
+        guild_id: { type: "string" },
+        user_ids: { type: "array", items: { type: "string" }, description: "Array of user IDs to ban." },
+        delete_message_seconds: { type: "number", description: "Delete messages from last N seconds (0–604800)." },
+        reason: { type: "string" },
+      },
+      required: ["guild_id", "user_ids"],
+    },
+  },
+  {
+    name: "discord_prune_members",
+    description: "Remove inactive members. Use dry_run (default) to preview count first.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        guild_id: { type: "string" },
+        days: { type: "number", description: "Number of days of inactivity (1–30)." },
+        roles: { type: "array", items: { type: "string" }, description: "Role IDs to include in the prune." },
+        dry_run: { type: "boolean", description: "If true (default), only returns count without pruning." },
+        reason: { type: "string" },
+      },
+      required: ["guild_id", "days"],
+    },
+  },
 ];
 
 /**
@@ -153,6 +221,61 @@ export async function handle(name: string, args: Record<string, unknown>): Promi
           text: duration > 0 ? `✅ ${member.user.tag} is in timeout for ${duration} minutes.` : `✅ Timeout removed from ${member.user.tag}.`,
         }],
       };
+    }
+
+    case "discord_search_members": {
+      const guild = await discord.guilds.fetch(validateId(args.guild_id, "guild_id"));
+      const limit = Math.min(Number(args.limit ?? 25), 100);
+      const members = await guild.members.search({ query: args.query as string, limit });
+      const result = [...members.values()].map((m: GuildMember) => ({
+        id: m.id, username: m.user.tag, nickname: m.nickname,
+        roles: m.roles.cache.filter((r) => r.name !== "@everyone").map((r) => ({ id: r.id, name: r.name })),
+      }));
+      return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
+    }
+
+    case "discord_set_nickname": {
+      const guild = await discord.guilds.fetch(validateId(args.guild_id, "guild_id"));
+      const member = await guild.members.fetch(args.user_id as string);
+      const nick = args.nickname === null || args.nickname === "null" ? null : String(args.nickname);
+      await member.setNickname(nick, args.reason as string | undefined);
+      return { content: [{ type: "text", text: nick ? `✅ Nickname for ${member.user.tag} set to "${nick}".` : `✅ Nickname cleared for ${member.user.tag}.` }] };
+    }
+
+    case "discord_list_bans": {
+      const guild = await discord.guilds.fetch(validateId(args.guild_id, "guild_id"));
+      const options: { limit?: number } = {};
+      if (args.limit) options.limit = Number(args.limit);
+      const bans = await guild.bans.fetch(options);
+      const result = [...bans.values()].map((ban) => ({
+        user_id: ban.user.id, username: ban.user.tag, reason: ban.reason ?? null,
+      }));
+      return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
+    }
+
+    case "discord_bulk_ban": {
+      const guild = await discord.guilds.fetch(validateId(args.guild_id, "guild_id"));
+      const userIds = args.user_ids as string[];
+      if (!Array.isArray(userIds) || userIds.length === 0) throw new Error("user_ids must be a non-empty array.");
+      const result = await guild.members.bulkBan(userIds, {
+        deleteMessageSeconds: Number(args.delete_message_seconds ?? 0),
+        reason: args.reason as string | undefined,
+      });
+      return { content: [{ type: "text", text: `✅ Bulk ban complete: ${result.bannedUsers.length} banned, ${result.failedUsers.length} failed.` }] };
+    }
+
+    case "discord_prune_members": {
+      const guild = await discord.guilds.fetch(validateId(args.guild_id, "guild_id"));
+      const days = Number(args.days);
+      const dryRun = args.dry_run !== false;
+      const roles = args.roles as string[] | undefined;
+      const pruned = await guild.members.prune({
+        days,
+        dry: dryRun,
+        roles: roles ?? undefined,
+        reason: args.reason as string | undefined,
+      });
+      return { content: [{ type: "text", text: dryRun ? `🔍 Dry run: ${pruned} members would be pruned (${days} days inactive).` : `✅ ${pruned} members pruned (${days} days inactive).` }] };
     }
 
     default:

--- a/src/tools/messages.ts
+++ b/src/tools/messages.ts
@@ -264,6 +264,70 @@ export const definitions = [
       required: ["channel_id", "keyword"],
     },
   },
+  {
+    name: "discord_crosspost_message",
+    description: "Publish a message in an announcement channel to all following channels.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        channel_id: { type: "string" },
+        message_id: { type: "string" },
+      },
+      required: ["channel_id", "message_id"],
+    },
+  },
+  {
+    name: "discord_remove_reactions",
+    description: "Remove reactions from a message. No emoji = remove all. Emoji only = remove that emoji. Emoji + user_id = remove that user's reaction.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        channel_id: { type: "string" },
+        message_id: { type: "string" },
+        emoji: { type: "string", description: "Unicode emoji or custom emoji 'name:id'. Omit to remove all reactions." },
+        user_id: { type: "string", description: "Remove only this user's reaction for the given emoji." },
+      },
+      required: ["channel_id", "message_id"],
+    },
+  },
+  {
+    name: "discord_get_reactions",
+    description: "List users who reacted with a specific emoji on a message.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        channel_id: { type: "string" },
+        message_id: { type: "string" },
+        emoji: { type: "string", description: "Unicode emoji or custom emoji 'name:id'." },
+        limit: { type: "number", description: "1–100, default 25." },
+      },
+      required: ["channel_id", "message_id", "emoji"],
+    },
+  },
+  {
+    name: "discord_fetch_pinned_messages",
+    description: "List all pinned messages in a channel.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        channel_id: { type: "string" },
+      },
+      required: ["channel_id"],
+    },
+  },
+  {
+    name: "discord_forward_message",
+    description: "Forward a message to another channel.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        channel_id: { type: "string" },
+        message_id: { type: "string" },
+        target_channel_id: { type: "string" },
+      },
+      required: ["channel_id", "message_id", "target_channel_id"],
+    },
+  },
 ];
 
 /** Builds an EmbedBuilder from a flat args object. */
@@ -414,6 +478,58 @@ export async function handle(name: string, args: Record<string, unknown>): Promi
         .sort((a, b) => a.createdTimestamp - b.createdTimestamp)
         .map((m) => ({ id: m.id, author: m.author.tag, content: m.content, timestamp: m.createdAt.toISOString() }));
       return { content: [{ type: "text", text: matches.length > 0 ? JSON.stringify(matches, null, 2) : `No messages found containing "${args.keyword}" in the last ${limit} messages.` }] };
+    }
+
+    case "discord_crosspost_message": {
+      const channel = await getTextChannel(args.channel_id as string);
+      const msg = await channel.messages.fetch(args.message_id as string);
+      await msg.crosspost();
+      return { content: [{ type: "text", text: `✅ Message ${msg.id} published to all followers of #${channel.name}.` }] };
+    }
+
+    case "discord_remove_reactions": {
+      const channel = await getTextChannel(args.channel_id as string);
+      const msg = await channel.messages.fetch(args.message_id as string);
+      if (!args.emoji) {
+        await msg.reactions.removeAll();
+        return { content: [{ type: "text", text: `✅ All reactions removed from message ${msg.id}.` }] };
+      }
+      const reaction = msg.reactions.cache.get(args.emoji as string);
+      if (!reaction) throw new Error(`No reaction found for emoji "${args.emoji}" on message ${msg.id}.`);
+      if (args.user_id) {
+        await reaction.users.remove(args.user_id as string);
+        return { content: [{ type: "text", text: `✅ Removed ${args.emoji} reaction from user ${args.user_id} on message ${msg.id}.` }] };
+      }
+      await reaction.remove();
+      return { content: [{ type: "text", text: `✅ All ${args.emoji} reactions removed from message ${msg.id}.` }] };
+    }
+
+    case "discord_get_reactions": {
+      const channel = await getTextChannel(args.channel_id as string);
+      const msg = await channel.messages.fetch(args.message_id as string);
+      const reaction = msg.reactions.cache.get(args.emoji as string);
+      if (!reaction) throw new Error(`No reaction found for emoji "${args.emoji}" on message ${msg.id}.`);
+      const limit = Math.min(Number(args.limit ?? 25), 100);
+      const users = await reaction.users.fetch({ limit });
+      const result = [...users.values()].map((u) => ({ id: u.id, username: u.username, bot: u.bot }));
+      return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
+    }
+
+    case "discord_fetch_pinned_messages": {
+      const channel = await getTextChannel(args.channel_id as string);
+      const pinned = await channel.messages.fetchPinned();
+      const result = [...pinned.values()].map((m) => ({
+        id: m.id, author: m.author.tag, content: m.content, timestamp: m.createdAt.toISOString(),
+      }));
+      return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
+    }
+
+    case "discord_forward_message": {
+      const channel = await getTextChannel(args.channel_id as string);
+      const msg = await channel.messages.fetch(args.message_id as string);
+      const targetChannel = await getTextChannel(args.target_channel_id as string);
+      await msg.forward(targetChannel);
+      return { content: [{ type: "text", text: `✅ Message ${msg.id} forwarded to #${targetChannel.name}.` }] };
     }
 
     default:

--- a/src/tools/roles.ts
+++ b/src/tools/roles.ts
@@ -99,6 +99,33 @@ export const definitions = [
       required: ["guild_id", "role_id"],
     },
   },
+  {
+    name: "discord_set_role_position",
+    description: "Change a role's position in the hierarchy.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        guild_id: { type: "string" },
+        role_id: { type: "string" },
+        position: { type: "number" },
+      },
+      required: ["guild_id", "role_id", "position"],
+    },
+  },
+  {
+    name: "discord_set_role_icon",
+    description: "Set a custom icon or unicode emoji on a role (requires server boost level 2+).",
+    inputSchema: {
+      type: "object",
+      properties: {
+        guild_id: { type: "string" },
+        role_id: { type: "string" },
+        icon: { type: "string", description: "Image URL for the role icon. Set to null to remove." },
+        unicode_emoji: { type: "string", description: "Unicode emoji for the role. Set to null to remove." },
+      },
+      required: ["guild_id", "role_id"],
+    },
+  },
 ];
 
 /**
@@ -189,6 +216,25 @@ export async function handle(name: string, args: Record<string, unknown>): Promi
       const role = await guild.roles.fetch(args.role_id as string) as Role;
       const members = role.members.map((m) => ({ id: m.id, username: m.user.tag, nickname: m.nickname }));
       return { content: [{ type: "text", text: JSON.stringify(members, null, 2) }] };
+    }
+
+    case "discord_set_role_position": {
+      const guild = await discord.guilds.fetch(validateId(args.guild_id, "guild_id"));
+      const role = await guild.roles.fetch(args.role_id as string) as Role;
+      await role.setPosition(args.position as number);
+      return { content: [{ type: "text", text: `✅ Role "${role.name}" moved to position ${args.position}.` }] };
+    }
+
+    case "discord_set_role_icon": {
+      const guild = await discord.guilds.fetch(validateId(args.guild_id, "guild_id"));
+      const role = await guild.roles.fetch(args.role_id as string) as Role;
+      if (args.icon !== undefined) {
+        await role.setIcon(args.icon === "null" || args.icon === null ? null : args.icon as string);
+      }
+      if (args.unicode_emoji !== undefined) {
+        await role.setUnicodeEmoji(args.unicode_emoji === "null" || args.unicode_emoji === null ? null : args.unicode_emoji as string);
+      }
+      return { content: [{ type: "text", text: `✅ Role "${role.name}" icon updated.` }] };
     }
 
     default:

--- a/src/tools/scheduledEvents.ts
+++ b/src/tools/scheduledEvents.ts
@@ -110,6 +110,21 @@ export const definitions = [
       required: ["guild_id", "event_id"],
     },
   },
+  {
+    name: "discord_create_event_invite",
+    description: "Create an invite URL linked to a scheduled event.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        guild_id: { type: "string" },
+        event_id: { type: "string" },
+        channel_id: { type: "string", description: "Channel for the invite. Uses the first text channel if omitted." },
+        max_age: { type: "number", description: "Invite duration in seconds (0 = never). Default 86400." },
+        max_uses: { type: "number", description: "Max uses (0 = unlimited). Default 0." },
+      },
+      required: ["guild_id", "event_id"],
+    },
+  },
 ];
 
 // ─── Helpers ────────────────────────────────────────────────────────────────────
@@ -267,6 +282,19 @@ export async function handle(
         avatar: sub.user.displayAvatarURL(),
       }));
       return { content: [{ type: "text", text: JSON.stringify(list, null, 2) }] };
+    }
+
+    case "discord_create_event_invite": {
+      const guildId = validateId(args.guild_id, "guild_id");
+      const eventId = validateId(args.event_id, "event_id");
+      const guild = await discord.guilds.fetch(guildId);
+      const event = await guild.scheduledEvents.fetch(eventId);
+      const url = await event.createInviteURL({
+        channel: args.channel_id ? validateId(args.channel_id, "channel_id") : undefined,
+        maxAge: Number(args.max_age ?? 86400),
+        maxUses: Number(args.max_uses ?? 0),
+      });
+      return { content: [{ type: "text", text: `✅ Event invite created: ${url}` }] };
     }
 
     default:

--- a/src/tools/webhooks.ts
+++ b/src/tools/webhooks.ts
@@ -97,6 +97,59 @@ export const definitions = [
       },
     },
   },
+  {
+    name: "discord_edit_webhook_message",
+    description: "Edit a message previously sent by a webhook.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        webhook_id: { type: "string" },
+        webhook_token: { type: "string" },
+        message_id: { type: "string" },
+        content: { type: "string" },
+        embeds: {
+          type: "array",
+          description: "Optional array of embed objects.",
+          items: {
+            type: "object",
+            properties: {
+              title: { type: "string" }, url: { type: "string" }, description: { type: "string" },
+              color: { type: "string", description: "Hex color e.g. #5865F2" },
+              fields: { type: "array", items: { type: "object", properties: { name: { type: "string" }, value: { type: "string" }, inline: { type: "boolean" } }, required: ["name", "value"] } },
+              footer: { type: "string" }, image_url: { type: "string" }, thumbnail_url: { type: "string" }, timestamp: { type: "boolean" },
+            },
+          },
+        },
+      },
+      required: ["webhook_id", "webhook_token", "message_id"],
+    },
+  },
+  {
+    name: "discord_delete_webhook_message",
+    description: "Delete a message sent by a webhook.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        webhook_id: { type: "string" },
+        webhook_token: { type: "string" },
+        message_id: { type: "string" },
+      },
+      required: ["webhook_id", "webhook_token", "message_id"],
+    },
+  },
+  {
+    name: "discord_fetch_webhook_message",
+    description: "Fetch a specific message sent by a webhook.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        webhook_id: { type: "string" },
+        webhook_token: { type: "string" },
+        message_id: { type: "string" },
+      },
+      required: ["webhook_id", "webhook_token", "message_id"],
+    },
+  },
 ];
 
 /** Builds an EmbedBuilder from a webhook embed arg object. */
@@ -208,6 +261,54 @@ export async function handle(name: string, args: Record<string, unknown>): Promi
         return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
       } else {
         throw new Error("Either channel_id or guild_id is required.");
+      }
+    }
+
+    case "discord_edit_webhook_message": {
+      const webhookId = validateId(args.webhook_id, "webhook_id");
+      const token = args.webhook_token as string;
+      if (!token) throw new Error("webhook_token is required.");
+      const client = new WebhookClient({ id: webhookId, token });
+      try {
+        const editOptions: Record<string, unknown> = {};
+        if (args.content !== undefined) editOptions.content = args.content as string;
+        if (args.embeds) {
+          const embedArgs = args.embeds as Record<string, unknown>[];
+          editOptions.embeds = embedArgs.map((e) => buildWebhookEmbed(e));
+        }
+        await client.editMessage(args.message_id as string, editOptions);
+        return { content: [{ type: "text", text: `✅ Webhook message ${args.message_id} edited.` }] };
+      } finally {
+        client.destroy();
+      }
+    }
+
+    case "discord_delete_webhook_message": {
+      const webhookId = validateId(args.webhook_id, "webhook_id");
+      const token = args.webhook_token as string;
+      if (!token) throw new Error("webhook_token is required.");
+      const client = new WebhookClient({ id: webhookId, token });
+      try {
+        await client.deleteMessage(args.message_id as string);
+        return { content: [{ type: "text", text: `✅ Webhook message ${args.message_id} deleted.` }] };
+      } finally {
+        client.destroy();
+      }
+    }
+
+    case "discord_fetch_webhook_message": {
+      const webhookId = validateId(args.webhook_id, "webhook_id");
+      const token = args.webhook_token as string;
+      if (!token) throw new Error("webhook_token is required.");
+      const client = new WebhookClient({ id: webhookId, token });
+      try {
+        const msg = await client.fetchMessage(args.message_id as string);
+        return { content: [{ type: "text", text: JSON.stringify({
+          id: msg.id, content: msg.content, embeds: msg.embeds.length,
+          timestamp: msg.timestamp,
+        }, null, 2) }] };
+      } finally {
+        client.destroy();
       }
     }
 


### PR DESCRIPTION
## Summary
20 new tools enhancing existing categories:

**Messages (+5):** crosspost, remove reactions, get reactions, fetch pinned, forward message
**Members (+5):** search, set nickname, list bans, bulk ban, prune members
**Webhooks (+3):** edit/delete/fetch webhook messages
**Channels (+3 + enhancement):** set position, follow announcement, lock permissions, nsfw flag on edit
**Roles (+2):** set position, set icon
**Invites (+1):** list channel-specific invites
**Scheduled Events (+1):** create event invite

**Bugfix:** list_bans now handles empty ban lists gracefully

## Test plan
- [x] 17/20 tools tested on live server
- [x] 2 untestable (no announcement channel, no boost level 2)
- [x] 1 skipped (bulk_ban is destructive)
- [x] Bug found and fixed (list_bans empty list)
- [x] Build passes

## Release
After merge:
- `npm publish --access public`
- `docker build -t pasympa/discord-mcp:1.4.0 -t pasympa/discord-mcp:latest .`
- `docker push pasympa/discord-mcp --all-tags`
- `git tag v1.4.0 && git push origin v1.4.0`
- `gh release create v1.4.0`