### PR TITLE
chore: bump version to 1.5.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@pasympa/discord-mcp",
-  "version": "1.4.1",
+  "version": "1.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@pasympa/discord-mcp",
-      "version": "1.4.1",
+      "version": "1.5.0",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.27.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pasympa/discord-mcp",
-  "version": "1.4.1",
+  "version": "1.5.0",
   "description": "A lightweight, multi-guild Discord MCP server with 90+ tools",
   "main": "dist/index.js",
   "type": "commonjs",


### PR DESCRIPTION
## Summary
- Bump `package.json` and `package-lock.json` from 1.4.1 → 1.5.0
- Includes the new DM toolset merged since 1.4.1 (PRs #11, #12, #13): `discord_send_dm`, embed/edit/read/reply/delete

## Test plan
- [x] Merge this PR
- [x] Tag `v1.5.0` on `main` after merge to trigger the release workflow (npm + Docker + GitHub release)