### PR TITLE
docs: enrich descriptions for Glama-rated B/C tools

### DIFF
--- a/src/tools/dm.ts
+++ b/src/tools/dm.ts
@@ -32,6 +32,7 @@ const embedProperties = {
   color: { type: "string", description: "Hex color e.g. #5865F2" },
   fields: {
     type: "array",
+    description: "Name/value blocks shown inside the embed (max 25). Set inline:true to render up to 3 side-by-side.",
     items: {
       type: "object",
       properties: {
@@ -84,7 +85,7 @@ export const definitions = [
   {
     name: "discord_send_dm_embed",
     description:
-      "Send a rich embed as a direct message to a user.",
+      "Send a rich embed as a direct message to a user. The bot must share at least one server with the user, and the user must allow DMs from server members.",
     inputSchema: {
       type: "object",
       properties: {
@@ -127,7 +128,7 @@ export const definitions = [
   {
     name: "discord_delete_dm",
     description:
-      "Delete a message sent by the bot in a DM.",
+      "Delete a message previously sent by the bot in a DM. The bot can only delete its own messages.",
     inputSchema: {
       type: "object",
       properties: {
@@ -153,7 +154,7 @@ export const definitions = [
   {
     name: "discord_reply_dm",
     description:
-      "Reply to a specific message in a DM conversation.",
+      "Reply to a specific message in a DM, creating a quoted reply. Works on any message in the DM (bot or user).",
     inputSchema: {
       type: "object",
       properties: {

--- a/src/tools/invites.ts
+++ b/src/tools/invites.ts
@@ -72,7 +72,8 @@ export const definitions = [
   },
   {
     name: "discord_list_channel_invites",
-    description: "List all active invites for a specific channel.",
+    description:
+      "List all active invites for a specific channel. Unlike discord_list_invites which returns guild-wide invites, this scopes the result to a single channel.",
     inputSchema: {
       type: "object",
       properties: {


### PR DESCRIPTION
## Summary
Glama assigned grades A/B/C to individual tools based on description quality (TDQS). This PR brings the B/C-rated tools up to the same style as the A-rated ones — 1-2 sentences with the key constraint or use case noted.

| Tool | Glama grade | Fix |
|---|---|---|
| \`discord_send_dm_embed\` | C | Add bot-must-share-server + DM permission constraint |
| \`discord_delete_dm\` | B | Clarify bot can only delete its own messages |
| \`discord_reply_dm\` | B | Note quoted reply works on any DM message |
| \`discord_list_channel_invites\` | B | Distinguish from guild-wide \`discord_list_invites\` |

Also added a description on the embed \`fields\` array (the only array prop in the pattern that was missing one).

## Style
Matches the existing A-rated tools: short, factual, mention the one non-obvious constraint. No over-engineering — most properties keep their existing minimal style for consistency with the rest of the codebase.

## Test plan
- [x] \`npm run build\` passes
- [x] After merge, request Glama rescan to confirm grade improvements