### PR TITLE
fix: allow getTextChannel to accept ThreadChannel (fixes #17)

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -3,6 +3,7 @@ import {
   Client,
   GatewayIntentBits,
   TextChannel,
+  ThreadChannel,
   GuildChannel,
   PermissionsBitField,
 } from "discord.js";
@@ -62,15 +63,18 @@ export async function ensureConnected(): Promise<void> {
 }
 
 /**
- * Fetches a channel by ID and guarantees it is a text channel.
+ * Fetches a channel by ID and guarantees it is a text-capable guild channel
+ * (a TextChannel or any thread inside one — announcement / public / private / forum).
+ * Both class hierarchies expose the message-send / edit / fetch surface used by
+ * the message tools, so the wrapper accepts either.
  * @param channelId - Discord snowflake ID of the channel.
- * @returns The resolved TextChannel instance.
- * @throws {Error} If the channel does not exist or is not a text channel.
+ * @returns The resolved TextChannel or ThreadChannel instance.
+ * @throws {Error} If the channel does not exist or is neither a text channel nor a thread.
  */
-export async function getTextChannel(channelId: string): Promise<TextChannel> {
+export async function getTextChannel(channelId: string): Promise<TextChannel | ThreadChannel> {
   const channel = await discord.channels.fetch(channelId);
-  if (!channel || !(channel instanceof TextChannel))
-    throw new Error(`Channel ${channelId} is not a text channel or doesn't exist.`);
+  if (!channel || (!(channel instanceof TextChannel) && !(channel instanceof ThreadChannel)))
+    throw new Error(`Channel ${channelId} is not a text or thread channel or doesn't exist.`);
   return channel;
 }
 

--- a/src/tools/messages.ts
+++ b/src/tools/messages.ts
@@ -1,4 +1,11 @@
-import { EmbedBuilder, ColorResolvable, ChannelType } from "discord.js";
+import {
+  EmbedBuilder,
+  ColorResolvable,
+  ChannelType,
+  TextChannel,
+  PublicThreadChannel,
+  PrivateThreadChannel,
+} from "discord.js";
 import { discord, getTextChannel } from "../client.js";
 import { MAX_FETCH_LIMIT, DEFAULTS } from "../constants.js";
 import type { ToolModule, ToolResult } from "./types.js";
@@ -411,6 +418,9 @@ export async function handle(name: string, args: Record<string, unknown>): Promi
         });
         return { content: [{ type: "text", text: `✅ Thread "${thread.name}" created from message (id: ${thread.id}).` }] };
       } else {
+        if (!(channel instanceof TextChannel)) {
+          throw new Error(`Standalone thread creation requires a parent TextChannel; ${args.channel_id} is itself a thread. Pass a message_id to start a thread from a message instead.`);
+        }
         const thread = await channel.threads.create({
           name: args.name as string,
           autoArchiveDuration: duration as 60 | 1440 | 4320 | 10080,
@@ -529,7 +539,9 @@ export async function handle(name: string, args: Record<string, unknown>): Promi
       const channel = await getTextChannel(args.channel_id as string);
       const msg = await channel.messages.fetch(args.message_id as string);
       const targetChannel = await getTextChannel(args.target_channel_id as string);
-      await msg.forward(targetChannel);
+      // ThreadChannel<boolean> is the abstract base for PublicThreadChannel / PrivateThreadChannel;
+      // any runtime instance is one of them, but the type narrowing can't be expressed without a cast.
+      await msg.forward(targetChannel as TextChannel | PublicThreadChannel<boolean> | PrivateThreadChannel);
       return { content: [{ type: "text", text: `✅ Message ${msg.id} forwarded to #${targetChannel.name}.` }] };
     }
 


### PR DESCRIPTION
## Summary

Fixes #17 — `discord_edit_message` (and other message tools) rejected forum thread channel IDs with `Channel <id> is not a text channel or doesn't exist`, even though the Discord REST API supports these operations on threads and `discord_send_message` already accepts them.

The cause was a too-strict guard in `getTextChannel` (`src/client.ts`) that checked `channel instanceof TextChannel` — rejecting any `ThreadChannel` (forum thread / public thread / private thread / announcement thread).

## Changes

- **`src/client.ts`**: `getTextChannel` now returns `TextChannel | ThreadChannel` and accepts either at runtime. Both classes expose the message-send / edit / fetch surface used by the tool handlers.
- **`src/tools/messages.ts`** — two narrow points where the union needed disambiguating:
  - **`discord_create_thread`** standalone branch (`channel.threads.create`) only exists on `TextChannel`. The `else` branch now narrows with `instanceof TextChannel` and throws a descriptive error pointing users to the `message_id` branch if a thread is passed.
  - **`discord_forward_message`**: `msg.forward(...)` accepts the concrete `PublicThreadChannel | PrivateThreadChannel` union (not the abstract `ThreadChannel<boolean>` base). Runtime instances are always one of the concrete subclasses, so the call site narrows with a typed cast.

## Tools unblocked

After this fix, the following all work on forum threads / thread channels:

- `discord_edit_message` ✅
- `discord_delete_message` ✅
- `discord_add_reaction` ✅
- `discord_read_messages` (when called on a thread that resolved to ThreadChannel — previously also rejected) ✅
- `discord_pin_message` / `discord_fetch_pinned_messages` ✅
- `discord_bulk_delete_messages` ✅
- `discord_search_messages` ✅
- `discord_send_embed` / `discord_send_multiple_embeds` ✅
- `discord_edit_embed` ✅

(All 9 callers of `getTextChannel` in `messages.ts`.)

## Verification

- `npm run build` (tsc) clean — no type errors.
- Discord REST API confirmed pre-fix to accept the operation via direct `PATCH /channels/{thread_id}/messages/{id}` (HTTP 200) — so the runtime side was always fine, only the wrapper's type guard was blocking.

## Notes

No changeset file added — happy to include one if the maintainers prefer.

Filed via @lzrong0203 — discovered while migrating an agent runtime from `@iqai/mcp-discord@0.0.6` (which lacks edit-message entirely) to `@pasympa/discord-mcp@1.5.0`. Forum threads are a primary use case for agentic bots that group related replies under a single topic, so this limitation was high-impact in practice.