### PR TITLE
chore: release 1.5.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [1.5.1] - 2026-05-27
+
+### Fixed
+- `getTextChannel` now accepts `ThreadChannel` (forum / public / private / announcement threads) in addition to `TextChannel`, unblocking all message tools on threads: `discord_edit_message`, `discord_delete_message`, `discord_add_reaction`, `discord_read_messages`, `discord_pin_message`, `discord_fetch_pinned_messages`, `discord_bulk_delete_messages`, `discord_search_messages`, `discord_send_embed`, `discord_edit_embed`, `discord_send_multiple_embeds`, `discord_forward_message` (#17, #18)
+- `discord_create_thread` now throws a clear error if the parent `channel_id` is itself a thread (standalone thread creation requires a `TextChannel`; use `message_id` to start a thread from a message instead)
+
 ## [1.5.0] - 2026-05-04
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@pasympa/discord-mcp",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@pasympa/discord-mcp",
-      "version": "1.5.0",
+      "version": "1.5.1",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.27.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pasympa/discord-mcp",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "description": "A lightweight, multi-guild Discord MCP server with 90+ tools",
   "main": "dist/index.js",
   "type": "commonjs",


### PR DESCRIPTION
## Summary
- Bump version `1.5.0` → `1.5.1`
- Add `CHANGELOG.md` entry for 1.5.1 documenting the thread/forum message-tool fix merged in #18 (fixes #17)

Follow-up to #18 — keeps the version bump + changelog in a separate `chore` PR per the existing release pattern (cf. 1.4.1 / 1.5.0).

## Notes
- npm/Docker publish only triggers on a `v*` tag (see `release.yml`), so merging this does **not** publish. Tag `v1.5.1` separately to release.