### PR TITLE
feat: enrich tool definitions for Glama quality

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## [1.6.0] - 2026-05-28
+
+### Added
+- MCP tool `annotations` on all 97 tools (`readOnlyHint`, `destructiveHint`, `idempotentHint`, `openWorldHint`, `title`) so clients can apply safety policies and parallelize read-only calls
+- `ToolAnnotations` type and optional `annotations` field on `ToolDefinition`
+
+### Changed
+- Enriched every tool description with usage guidance, required Discord permissions, side effects / destructive behavior, and return value — improving agent reliability and directory tool-definition-quality scores
+- Documented every input-schema parameter (100% coverage), including nested embed/field properties, with formats and constraints
+- Extracted shared embed schema fragments (`EMBED_FIELD_PROPS`, `WEBHOOK_EMBED_PROPS`) to keep repeated definitions in sync
+- CONTRIBUTING: documented the tool-definition quality bar (description, annotations, parameter docs)
+
 ## [1.5.1] - 2026-05-27
 
 ### Fixed

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,11 +20,13 @@ import type { ToolModule, ToolResult } from "./types.js";
 export const definitions = [
   {
     name: "discord_my_tool",
-    description: "What this tool does.",
+    description:
+      "One clear action sentence. Then: when to use it vs. similar tools, required Discord permissions, any side effects or destructive/irreversible behavior, and what it returns.",
+    annotations: { title: "My tool", readOnlyHint: false, destructiveHint: false, idempotentHint: false, openWorldHint: true },
     inputSchema: {
       type: "object",
       properties: {
-        guild_id: { type: "string" },
+        guild_id: { type: "string", description: "Discord server (guild) ID (snowflake)." },
       },
       required: ["guild_id"],
     },
@@ -56,6 +58,21 @@ export default { definitions, handle } satisfies ToolModule;
 - Success messages start with `✅`
 - Use `JSON.stringify(data, null, 2)` for list responses
 - Tool names are prefixed with `discord_`
+
+### Tool definition quality
+
+Every tool definition must carry its weight — directory scanners (e.g. Glama) score the
+*lowest*-quality tool heavily, so one thin definition drags the whole server's grade down.
+
+- **Description**: action statement + when to use it vs. similar tools + required Discord
+  permissions + side effects / destructive behavior + what it returns.
+- **`annotations`**: set the MCP hints — `readOnlyHint` (true for pure reads), `destructiveHint`
+  (true for delete/ban/prune/irreversible writes), `idempotentHint` (true if repeating the call
+  changes nothing further), and `openWorldHint: true` (every tool calls the Discord API). Add a
+  short `title`.
+- **Parameters**: give every `inputSchema` property a `description` with its format and constraints
+  (e.g. snowflake, value range, defaults). When the same schema block repeats across tools, extract
+  it into a shared `const` and spread it (see `EMBED_FIELD_PROPS` in `messages.ts`).
 
 ## Development
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@pasympa/discord-mcp",
-  "version": "1.5.1",
+  "version": "1.6.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@pasympa/discord-mcp",
-      "version": "1.5.1",
+      "version": "1.6.0",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.27.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@pasympa/discord-mcp",
-  "version": "1.5.1",
-  "description": "A lightweight, multi-guild Discord MCP server with 90+ tools",
+  "version": "1.6.0",
+  "description": "A lightweight, multi-guild Discord MCP server with 95+ tools",
   "main": "dist/index.js",
   "type": "commonjs",
   "bin": {

--- a/src/tools/channels.ts
+++ b/src/tools/channels.ts
@@ -6,101 +6,117 @@ import type { ToolModule, ToolResult } from "./types.js";
 export const definitions = [
   {
     name: "discord_create_channel",
-    description: "Create a text, voice channel or category in a guild.",
+    description:
+      "Create a text channel, voice channel, or category in a server. Requires the Manage Channels permission. For forum channels use discord_create_forum_channel instead. Returns the new channel's name and ID.",
+    annotations: { title: "Create channel", readOnlyHint: false, destructiveHint: false, idempotentHint: false, openWorldHint: true },
     inputSchema: {
       type: "object",
       properties: {
-        guild_id: { type: "string" },
-        name: { type: "string" },
-        type: { type: "string", enum: ["text", "voice", "category"], description: "Defaults to 'text'." },
-        topic: { type: "string" },
-        category_id: { type: "string" },
+        guild_id: { type: "string", description: "Discord server (guild) ID (snowflake) to create the channel in." },
+        name: { type: "string", description: "Name of the new channel (max 100 characters)." },
+        type: { type: "string", enum: ["text", "voice", "category"], description: "Channel type to create. Defaults to 'text'." },
+        topic: { type: "string", description: "Optional channel topic/description. Applies to text channels only." },
+        category_id: { type: "string", description: "Optional category (snowflake) to nest the new channel under." },
       },
       required: ["guild_id", "name"],
     },
   },
   {
     name: "discord_delete_channel",
-    description: "Delete a channel.",
+    description:
+      "Permanently delete a channel and all of its messages. IRREVERSIBLE. Requires the Manage Channels permission. An optional reason is recorded in the audit log. Returns a confirmation.",
+    annotations: { title: "Delete channel", readOnlyHint: false, destructiveHint: true, idempotentHint: false, openWorldHint: true },
     inputSchema: {
       type: "object",
       properties: {
-        channel_id: { type: "string" },
-        reason: { type: "string" },
+        channel_id: { type: "string", description: "ID (snowflake) of the channel to delete." },
+        reason: { type: "string", description: "Optional reason recorded in the server audit log." },
       },
       required: ["channel_id"],
     },
   },
   {
     name: "discord_edit_channel",
-    description: "Edit a channel's name, topic, slowmode, or NSFW flag.",
+    description:
+      "Update a channel's name, topic, slowmode, or NSFW flag. Only provided fields change; topic and slowmode apply to text channels only. Requires the Manage Channels permission. Returns a confirmation.",
+    annotations: { title: "Edit channel", readOnlyHint: false, destructiveHint: false, idempotentHint: true, openWorldHint: true },
     inputSchema: {
       type: "object",
       properties: {
-        channel_id: { type: "string" },
-        name: { type: "string" },
-        topic: { type: "string" },
-        slowmode: { type: "number", description: "Slowmode in seconds (0 to disable)." },
-        nsfw: { type: "boolean", description: "Mark channel as NSFW." },
+        channel_id: { type: "string", description: "ID (snowflake) of the channel to edit." },
+        name: { type: "string", description: "New channel name (max 100 characters)." },
+        topic: { type: "string", description: "New topic/description (text channels only)." },
+        slowmode: { type: "number", description: "Per-user message cooldown in seconds, 0–21600. 0 disables slowmode." },
+        nsfw: { type: "boolean", description: "Mark (true) or unmark (false) the channel as age-restricted (NSFW)." },
       },
       required: ["channel_id"],
     },
   },
   {
     name: "discord_move_channel",
-    description: "Move a channel into a category (or remove from category if category_id is omitted).",
+    description:
+      "Move a channel into a category, or remove it from its category when category_id is omitted. Requires the Manage Channels permission. Use discord_set_channel_position to reorder within a category. Returns a confirmation.",
+    annotations: { title: "Move channel", readOnlyHint: false, destructiveHint: false, idempotentHint: true, openWorldHint: true },
     inputSchema: {
       type: "object",
       properties: {
-        channel_id: { type: "string" },
-        category_id: { type: "string" },
+        channel_id: { type: "string", description: "ID (snowflake) of the channel to move." },
+        category_id: { type: "string", description: "Target category (snowflake). Omit to move the channel out of any category." },
       },
       required: ["channel_id"],
     },
   },
   {
     name: "discord_clone_channel",
-    description: "Clone a channel with its name, topic and permission overwrites.",
+    description:
+      "Create a copy of a channel, including its name, topic, and permission overwrites (but not its messages). Requires the Manage Channels permission. Returns the cloned channel's name and ID.",
+    annotations: { title: "Clone channel", readOnlyHint: false, destructiveHint: false, idempotentHint: false, openWorldHint: true },
     inputSchema: {
       type: "object",
       properties: {
-        channel_id: { type: "string" },
-        new_name: { type: "string" },
+        channel_id: { type: "string", description: "ID (snowflake) of the channel to clone." },
+        new_name: { type: "string", description: "Optional name for the clone. Defaults to the source channel's name." },
       },
       required: ["channel_id"],
     },
   },
   {
     name: "discord_set_channel_position",
-    description: "Set the display position of a channel within its category.",
+    description:
+      "Set a channel's display order within its category. Use discord_move_channel to change which category it belongs to. Requires the Manage Channels permission. Returns a confirmation.",
+    annotations: { title: "Set channel position", readOnlyHint: false, destructiveHint: false, idempotentHint: true, openWorldHint: true },
     inputSchema: {
       type: "object",
       properties: {
-        channel_id: { type: "string" },
-        position: { type: "number" },
+        channel_id: { type: "string", description: "ID (snowflake) of the channel to reposition." },
+        position: { type: "number", description: "Zero-based position within the category (0 = top)." },
       },
       required: ["channel_id", "position"],
     },
   },
   {
     name: "discord_follow_announcement_channel",
-    description: "Follow an announcement channel so its messages are published to a target channel.",
+    description:
+      "Subscribe a target channel to an announcement (news) channel, so the source's published messages are reposted into the target. The source must be an announcement channel. Requires the Manage Webhooks permission in the target. Returns a confirmation.",
+    annotations: { title: "Follow announcement channel", readOnlyHint: false, destructiveHint: false, idempotentHint: false, openWorldHint: true },
     inputSchema: {
       type: "object",
       properties: {
-        source_channel_id: { type: "string", description: "The announcement channel to follow." },
-        target_channel_id: { type: "string", description: "The channel that will receive published messages." },
+        source_channel_id: { type: "string", description: "ID (snowflake) of the announcement channel to follow." },
+        target_channel_id: { type: "string", description: "ID (snowflake) of the channel that will receive published messages." },
       },
       required: ["source_channel_id", "target_channel_id"],
     },
   },
   {
     name: "discord_lock_channel_permissions",
-    description: "Sync a channel's permissions with its parent category.",
+    description:
+      "Reset a channel's permission overwrites to exactly match its parent category (Discord's 'sync permissions'). The channel must be inside a category. Requires the Manage Roles permission. Returns a confirmation.",
+    annotations: { title: "Sync channel permissions", readOnlyHint: false, destructiveHint: false, idempotentHint: true, openWorldHint: true },
     inputSchema: {
       type: "object",
       properties: {
-        channel_id: { type: "string" },
+        channel_id: { type: "string", description: "ID (snowflake) of the channel to sync with its parent category." },
       },
       required: ["channel_id"],
     },

--- a/src/tools/discovery.ts
+++ b/src/tools/discovery.ts
@@ -6,35 +6,43 @@ import type { ToolModule, ToolResult } from "./types.js";
 export const definitions = [
   {
     name: "discord_list_guilds",
-    description: "List all Discord servers the bot is connected to.",
+    description:
+      "List every Discord server (guild) the bot is a member of (id, name, member count, icon). Takes no arguments. Read-only. Start here to discover the guild_id needed by most other tools.",
+    annotations: { title: "List servers", readOnlyHint: true, openWorldHint: true },
     inputSchema: { type: "object", properties: {} },
   },
   {
     name: "discord_get_guild_info",
-    description: "Get detailed info about a guild: name, member count, channels, roles, boosts.",
+    description:
+      "Get details about one server: name, description, member/channel/role counts, boost tier, owner, and creation date. Read-only. Use discord_get_server_stats for a finer breakdown (humans vs bots, channel types).",
+    annotations: { title: "Get server info", readOnlyHint: true, openWorldHint: true },
     inputSchema: {
       type: "object",
-      properties: { guild_id: { type: "string" } },
+      properties: { guild_id: { type: "string", description: "Discord server (guild) ID (snowflake)." } },
       required: ["guild_id"],
     },
   },
   {
     name: "discord_list_channels",
-    description: "List all channels in a guild grouped by category.",
+    description:
+      "List all channels in a server, grouped by their parent category and ordered by position. Returns a JSON object keyed by category name. Read-only. Use discord_find_channel_by_name to locate a specific channel.",
+    annotations: { title: "List channels", readOnlyHint: true, openWorldHint: true },
     inputSchema: {
       type: "object",
-      properties: { guild_id: { type: "string" } },
+      properties: { guild_id: { type: "string", description: "Discord server (guild) ID (snowflake)." } },
       required: ["guild_id"],
     },
   },
   {
     name: "discord_find_channel_by_name",
-    description: "Find a channel by name in a guild (partial match supported).",
+    description:
+      "Find channels whose name contains a substring (case-insensitive). Returns matching channels (id, name, type) as a JSON array. Read-only. Useful for resolving a channel_id when you only know the channel's name.",
+    annotations: { title: "Find channel by name", readOnlyHint: true, openWorldHint: true },
     inputSchema: {
       type: "object",
       properties: {
-        guild_id: { type: "string" },
-        name: { type: "string" },
+        guild_id: { type: "string", description: "Discord server (guild) ID (snowflake)." },
+        name: { type: "string", description: "Case-insensitive substring to match against channel names." },
       },
       required: ["guild_id", "name"],
     },

--- a/src/tools/dm.ts
+++ b/src/tools/dm.ts
@@ -26,19 +26,19 @@ function buildEmbed(args: Record<string, unknown>): EmbedBuilder {
 
 /** Embed input schema properties (shared across embed tools). */
 const embedProperties = {
-  title: { type: "string" },
+  title: { type: "string", description: "Embed title shown in bold at the top." },
   url: { type: "string", description: "URL that makes the title clickable." },
-  description: { type: "string" },
-  color: { type: "string", description: "Hex color e.g. #5865F2" },
+  description: { type: "string", description: "Main body text of the embed (supports Markdown)." },
+  color: { type: "string", description: "Side-bar color as a hex string, e.g. '#5865F2'." },
   fields: {
     type: "array",
-    description: "Name/value blocks shown inside the embed (max 25). Set inline:true to render up to 3 side-by-side.",
+    description: "Up to 25 name/value field blocks. Set inline:true to render up to 3 side-by-side.",
     items: {
       type: "object",
       properties: {
-        name: { type: "string" },
-        value: { type: "string" },
-        inline: { type: "boolean" },
+        name: { type: "string", description: "Field heading." },
+        value: { type: "string", description: "Field body text." },
+        inline: { type: "boolean", description: "If true, render this field side-by-side with adjacent inline fields." },
       },
       required: ["name", "value"],
     },
@@ -47,24 +47,24 @@ const embedProperties = {
     type: "object",
     description: "Author block shown at the top of the embed.",
     properties: {
-      name: { type: "string" },
-      icon_url: { type: "string" },
-      url: { type: "string" },
+      name: { type: "string", description: "Author display name." },
+      icon_url: { type: "string", description: "Small icon shown next to the author name." },
+      url: { type: "string", description: "URL the author name links to." },
     },
     required: ["name"],
   },
   thumbnail_url: { type: "string", description: "Small image shown in the top-right corner." },
-  footer: { type: "string" },
-  image_url: { type: "string" },
-  timestamp: { type: "boolean", description: "If true, adds the current timestamp to the embed." },
+  footer: { type: "string", description: "Footer text shown at the bottom of the embed." },
+  image_url: { type: "string", description: "Large image shown below the embed body." },
+  timestamp: { type: "boolean", description: "If true, stamp the embed with the current time." },
 } as const;
 
 const userIdProp = {
-  user_id: { type: "string", description: "The Discord user ID." },
+  user_id: { type: "string", description: "Discord user ID (snowflake) of the DM recipient." },
 } as const;
 
 const messageIdProp = {
-  message_id: { type: "string", description: "The message ID (must be a bot message)." },
+  message_id: { type: "string", description: "ID of the target message within the DM conversation." },
 } as const;
 
 /** Tool definitions for direct messages. */
@@ -72,12 +72,13 @@ export const definitions = [
   {
     name: "discord_send_dm",
     description:
-      "Send a direct message to a user by their user ID. The bot must share at least one server with the user.",
+      "Send a private direct message to a user by their user ID. Use discord_send_message to post in a server channel instead. Requires the bot to share at least one server with the user, and the user must allow DMs from server members (otherwise Discord rejects the send). Returns the new message ID.",
+    annotations: { title: "Send DM", readOnlyHint: false, destructiveHint: false, idempotentHint: false, openWorldHint: true },
     inputSchema: {
       type: "object",
       properties: {
         ...userIdProp,
-        content: { type: "string", description: "The message content to send." },
+        content: { type: "string", description: "Plain-text body of the DM (max 2000 characters)." },
       },
       required: ["user_id", "content"],
     },
@@ -85,12 +86,13 @@ export const definitions = [
   {
     name: "discord_send_dm_embed",
     description:
-      "Send a rich embed as a direct message to a user. The bot must share at least one server with the user, and the user must allow DMs from server members.",
+      "Send a rich embed as a private direct message to a user. Use discord_send_dm for plain text, or discord_send_embed to post an embed in a channel. Requires the bot to share a server with the user, and the user must allow DMs from server members. Returns the new message ID.",
+    annotations: { title: "Send DM embed", readOnlyHint: false, destructiveHint: false, idempotentHint: false, openWorldHint: true },
     inputSchema: {
       type: "object",
       properties: {
         ...userIdProp,
-        content: { type: "string", description: "Optional text content above the embed." },
+        content: { type: "string", description: "Optional plain text shown above the embed." },
         ...embedProperties,
       },
       required: ["user_id"],
@@ -99,13 +101,14 @@ export const definitions = [
   {
     name: "discord_edit_dm",
     description:
-      "Edit a text message previously sent by the bot in a DM.",
+      "Edit the text content of a DM message previously sent by this bot. Only the bot's own DM messages can be edited. Use discord_edit_dm_embed for embed messages. Returns a confirmation.",
+    annotations: { title: "Edit DM", readOnlyHint: false, destructiveHint: false, idempotentHint: true, openWorldHint: true },
     inputSchema: {
       type: "object",
       properties: {
         ...userIdProp,
         ...messageIdProp,
-        content: { type: "string", description: "New text content for the message." },
+        content: { type: "string", description: "New plain-text content that fully replaces the existing message (max 2000 characters)." },
       },
       required: ["user_id", "message_id", "content"],
     },
@@ -113,13 +116,14 @@ export const definitions = [
   {
     name: "discord_edit_dm_embed",
     description:
-      "Edit an embed previously sent by the bot in a DM. Only provided fields are updated; omitted fields are removed.",
+      "Replace the embed on a DM message previously sent by this bot. Only the bot's own messages can be edited. Full replace, not merge: provided fields are applied and omitted fields are dropped. Returns a confirmation.",
+    annotations: { title: "Edit DM embed", readOnlyHint: false, destructiveHint: false, idempotentHint: true, openWorldHint: true },
     inputSchema: {
       type: "object",
       properties: {
         ...userIdProp,
         ...messageIdProp,
-        content: { type: "string", description: "Optional new text content above the embed." },
+        content: { type: "string", description: "Optional new plain text shown above the embed." },
         ...embedProperties,
       },
       required: ["user_id", "message_id"],
@@ -128,7 +132,8 @@ export const definitions = [
   {
     name: "discord_delete_dm",
     description:
-      "Delete a message previously sent by the bot in a DM. The bot can only delete its own messages.",
+      "Permanently delete a DM message previously sent by this bot. IRREVERSIBLE. The bot can only delete its own DM messages, not the recipient's. Returns a confirmation.",
+    annotations: { title: "Delete DM", readOnlyHint: false, destructiveHint: true, idempotentHint: false, openWorldHint: true },
     inputSchema: {
       type: "object",
       properties: {
@@ -141,12 +146,13 @@ export const definitions = [
   {
     name: "discord_read_dms",
     description:
-      "Read the last N messages from a DM conversation with a user.",
+      "Read the most recent messages from the bot's DM conversation with a user, oldest-to-newest. Returns a JSON array (id, author, content, embed count, timestamp). Read-only.",
+    annotations: { title: "Read DMs", readOnlyHint: true, openWorldHint: true },
     inputSchema: {
       type: "object",
       properties: {
         ...userIdProp,
-        limit: { type: "number", description: "1–100, default 20." },
+        limit: { type: "number", description: "How many recent messages to fetch (1–100). Default 20." },
       },
       required: ["user_id"],
     },
@@ -154,13 +160,14 @@ export const definitions = [
   {
     name: "discord_reply_dm",
     description:
-      "Reply to a specific message in a DM, creating a quoted reply. Works on any message in the DM (bot or user).",
+      "Reply to a specific message in a DM, attaching a quoted reply reference. Unlike the edit/delete DM tools, this works on any message in the conversation (the bot's or the user's). Use discord_send_dm for a standalone DM with no reference. Returns the new reply's message ID.",
+    annotations: { title: "Reply to DM", readOnlyHint: false, destructiveHint: false, idempotentHint: false, openWorldHint: true },
     inputSchema: {
       type: "object",
       properties: {
         ...userIdProp,
         ...messageIdProp,
-        content: { type: "string", description: "The reply content." },
+        content: { type: "string", description: "Plain-text body of the reply (max 2000 characters)." },
       },
       required: ["user_id", "message_id", "content"],
     },

--- a/src/tools/forums.ts
+++ b/src/tools/forums.ts
@@ -6,42 +6,48 @@ import type { ToolModule, ToolResult } from "./types.js";
 export const definitions = [
   {
     name: "discord_get_forum_channels",
-    description: "List all forum channels in a guild.",
+    description:
+      "List the forum channels in a server (id, name, topic, parent category). Read-only. Use discord_get_forum_tags to see a forum's available tags, or discord_list_forum_threads for its posts.",
+    annotations: { title: "List forum channels", readOnlyHint: true, openWorldHint: true },
     inputSchema: {
       type: "object",
       properties: {
-        guild_id: { type: "string" },
+        guild_id: { type: "string", description: "Discord server (guild) ID (snowflake)." },
       },
       required: ["guild_id"],
     },
   },
   {
     name: "discord_create_forum_channel",
-    description: "Create a new forum channel in a guild.",
+    description:
+      "Create a new forum channel in a server. A forum holds posts (threads) rather than a linear message feed. Requires the Manage Channels permission. Use discord_create_channel for text/voice channels instead. Returns the new channel's name and ID.",
+    annotations: { title: "Create forum channel", readOnlyHint: false, destructiveHint: false, idempotentHint: false, openWorldHint: true },
     inputSchema: {
       type: "object",
       properties: {
-        guild_id: { type: "string" },
-        name: { type: "string" },
-        topic: { type: "string", description: "The forum channel guidelines/topic." },
-        category_id: { type: "string", description: "Parent category ID (optional)." },
+        guild_id: { type: "string", description: "Discord server (guild) ID (snowflake)." },
+        name: { type: "string", description: "Name of the new forum channel (max 100 characters)." },
+        topic: { type: "string", description: "Guidelines/topic text shown at the top of the forum." },
+        category_id: { type: "string", description: "Optional category (snowflake) to nest the forum under." },
       },
       required: ["guild_id", "name"],
     },
   },
   {
     name: "discord_create_forum_post",
-    description: "Create a new post (thread) in a forum channel.",
+    description:
+      "Create a new post (a thread with a starter message) in a forum channel. Requires the Send Messages and Create Public Threads permissions. Use discord_reply_to_forum to add follow-up messages. Returns the new post's name and thread ID.",
+    annotations: { title: "Create forum post", readOnlyHint: false, destructiveHint: false, idempotentHint: false, openWorldHint: true },
     inputSchema: {
       type: "object",
       properties: {
-        forum_channel_id: { type: "string" },
-        title: { type: "string", description: "The post title (thread name)." },
-        content: { type: "string", description: "The initial message content of the post." },
+        forum_channel_id: { type: "string", description: "ID (snowflake) of the forum channel to post in." },
+        title: { type: "string", description: "Title of the post, used as the thread name (max 100 characters)." },
+        content: { type: "string", description: "Body of the post's starter message (max 2000 characters)." },
         applied_tags: {
           type: "array",
           items: { type: "string" },
-          description: "Array of tag IDs to apply to the post.",
+          description: "Optional tag IDs to apply. Get valid IDs from discord_get_forum_tags.",
         },
       },
       required: ["forum_channel_id", "title", "content"],
@@ -49,77 +55,89 @@ export const definitions = [
   },
   {
     name: "discord_get_forum_post",
-    description: "Get a forum post's details and its messages.",
+    description:
+      "Get a forum post's details (title, archived/locked state, applied tags, message count) plus its recent messages, oldest-to-newest. Read-only. Pass the post's thread_id. Returns a JSON object.",
+    annotations: { title: "Get forum post", readOnlyHint: true, openWorldHint: true },
     inputSchema: {
       type: "object",
       properties: {
-        thread_id: { type: "string" },
-        limit: { type: "number", description: "Number of messages to fetch (1–100, default 20)." },
+        thread_id: { type: "string", description: "ID (snowflake) of the forum post (thread)." },
+        limit: { type: "number", description: "How many recent messages to include (1–100). Default 20." },
       },
       required: ["thread_id"],
     },
   },
   {
     name: "discord_list_forum_threads",
-    description: "List all threads (active and archived) in a forum channel.",
+    description:
+      "List every post in a forum channel, both active and archived (id, name, state, tags, message count). Read-only. Use discord_get_forum_post to read one post's messages.",
+    annotations: { title: "List forum threads", readOnlyHint: true, openWorldHint: true },
     inputSchema: {
       type: "object",
       properties: {
-        forum_channel_id: { type: "string" },
+        forum_channel_id: { type: "string", description: "ID (snowflake) of the forum channel to list posts from." },
       },
       required: ["forum_channel_id"],
     },
   },
   {
     name: "discord_reply_to_forum",
-    description: "Reply to a forum post (send a message in a forum thread).",
+    description:
+      "Post a follow-up message inside an existing forum post (thread). Requires the Send Messages permission. Use discord_create_forum_post to start a new post instead. Returns the new message ID.",
+    annotations: { title: "Reply to forum post", readOnlyHint: false, destructiveHint: false, idempotentHint: false, openWorldHint: true },
     inputSchema: {
       type: "object",
       properties: {
-        thread_id: { type: "string" },
-        content: { type: "string" },
+        thread_id: { type: "string", description: "ID (snowflake) of the forum post (thread) to reply in." },
+        content: { type: "string", description: "Plain-text body of the reply (max 2000 characters)." },
       },
       required: ["thread_id", "content"],
     },
   },
   {
     name: "discord_delete_forum_post",
-    description: "Delete (close) a forum post/thread.",
+    description:
+      "Permanently delete a forum post (thread) and all its messages. IRREVERSIBLE. To merely close it without deleting, use discord_update_forum_post with archived:true. Requires the Manage Threads permission (or thread ownership).",
+    annotations: { title: "Delete forum post", readOnlyHint: false, destructiveHint: true, idempotentHint: false, openWorldHint: true },
     inputSchema: {
       type: "object",
       properties: {
-        thread_id: { type: "string" },
+        thread_id: { type: "string", description: "ID (snowflake) of the forum post (thread) to delete." },
       },
       required: ["thread_id"],
     },
   },
   {
     name: "discord_get_forum_tags",
-    description: "Get the available tags for a forum channel.",
+    description:
+      "List the tags available on a forum channel (id, name, emoji, moderated flag). Read-only. Use these IDs with discord_create_forum_post or discord_update_forum_post; manage the tag set with discord_set_forum_tags.",
+    annotations: { title: "Get forum tags", readOnlyHint: true, openWorldHint: true },
     inputSchema: {
       type: "object",
       properties: {
-        forum_channel_id: { type: "string" },
+        forum_channel_id: { type: "string", description: "ID (snowflake) of the forum channel to read tags from." },
       },
       required: ["forum_channel_id"],
     },
   },
   {
     name: "discord_set_forum_tags",
-    description: "Set or update the available tags on a forum channel.",
+    description:
+      "Replace the full set of available tags on a forum channel with the provided list. This overwrites existing tags, so include every tag you want to keep. Requires the Manage Channels permission. Returns a confirmation.",
+    annotations: { title: "Set forum tags", readOnlyHint: false, destructiveHint: false, idempotentHint: true, openWorldHint: true },
     inputSchema: {
       type: "object",
       properties: {
-        forum_channel_id: { type: "string" },
+        forum_channel_id: { type: "string", description: "ID (snowflake) of the forum channel to set tags on." },
         tags: {
           type: "array",
-          description: "Array of tag objects to set on the forum channel.",
+          description: "Complete list of tags to set (replaces all existing tags).",
           items: {
             type: "object",
             properties: {
-              name: { type: "string" },
-              emoji_name: { type: "string", description: "Unicode emoji for the tag (optional)." },
-              moderated: { type: "boolean", description: "If true, only moderators can apply this tag (optional)." },
+              name: { type: "string", description: "Tag label (max 20 characters)." },
+              emoji_name: { type: "string", description: "Optional unicode emoji shown on the tag." },
+              moderated: { type: "boolean", description: "If true, only members with Manage Threads can apply this tag. Default false." },
             },
             required: ["name"],
           },
@@ -130,18 +148,20 @@ export const definitions = [
   },
   {
     name: "discord_update_forum_post",
-    description: "Update a forum post's title, archived/locked status, or applied tags.",
+    description:
+      "Update a forum post's title, archived/locked state, or applied tags. Only provided fields change; passing applied_tags replaces the post's tags. Set archived:true to close a post without deleting it. Requires the Manage Threads permission (or thread ownership).",
+    annotations: { title: "Update forum post", readOnlyHint: false, destructiveHint: false, idempotentHint: true, openWorldHint: true },
     inputSchema: {
       type: "object",
       properties: {
-        thread_id: { type: "string" },
-        title: { type: "string", description: "New title for the forum post." },
-        archived: { type: "boolean", description: "Whether to archive the thread." },
-        locked: { type: "boolean", description: "Whether to lock the thread." },
+        thread_id: { type: "string", description: "ID (snowflake) of the forum post (thread) to update." },
+        title: { type: "string", description: "New title/thread name (max 100 characters)." },
+        archived: { type: "boolean", description: "true to archive (close) the post, false to reopen it." },
+        locked: { type: "boolean", description: "true to lock the post so only moderators can reply." },
         applied_tags: {
           type: "array",
           items: { type: "string" },
-          description: "Array of tag IDs to apply to the post.",
+          description: "Tag IDs to apply; replaces the post's current tags. Get valid IDs from discord_get_forum_tags.",
         },
       },
       required: ["thread_id"],

--- a/src/tools/invites.ts
+++ b/src/tools/invites.ts
@@ -5,24 +5,28 @@ import type { ToolModule, ToolResult } from "./types.js";
 export const definitions = [
   {
     name: "discord_list_invites",
-    description: "List all active invites in a guild.",
+    description:
+      "List all active invites across a server (code, url, channel, inviter, uses, expiry). Requires the Manage Server permission. Read-only. Use discord_list_channel_invites to scope to one channel.",
+    annotations: { title: "List invites", readOnlyHint: true, openWorldHint: true },
     inputSchema: {
       type: "object",
       properties: {
-        guild_id: { type: "string" },
+        guild_id: { type: "string", description: "Discord server (guild) ID (snowflake)." },
       },
       required: ["guild_id"],
     },
   },
   {
     name: "discord_get_invite",
-    description: "Get details about a specific invite by its code.",
+    description:
+      "Look up details for a single invite by its code, including the target server/channel and usage stats. Works for any public invite, not just this server's. Read-only. Returns a JSON object.",
+    annotations: { title: "Get invite", readOnlyHint: true, openWorldHint: true },
     inputSchema: {
       type: "object",
       properties: {
         invite_code: {
           type: "string",
-          description: "The invite code (e.g. 'abc123' from discord.gg/abc123).",
+          description: "The invite code, e.g. 'abc123'. A full discord.gg/abc123 URL is also accepted and stripped.",
         },
       },
       required: ["invite_code"],
@@ -30,26 +34,28 @@ export const definitions = [
   },
   {
     name: "discord_create_invite",
-    description: "Create an invite link for a channel.",
+    description:
+      "Create an invite link for a channel, optionally limiting its lifetime, uses, and membership type. SECURITY: anyone with the returned link can join the server. Requires the Create Instant Invite permission. Returns the invite URL and code.",
+    annotations: { title: "Create invite", readOnlyHint: false, destructiveHint: false, idempotentHint: false, openWorldHint: true },
     inputSchema: {
       type: "object",
       properties: {
-        channel_id: { type: "string" },
+        channel_id: { type: "string", description: "ID (snowflake) of the channel the invite leads to." },
         max_age: {
           type: "number",
-          description: "Invite duration in seconds (0 = never expires). Default 86400 (24h).",
+          description: "Invite lifetime in seconds; 0 means it never expires. Default 86400 (24h).",
         },
         max_uses: {
           type: "number",
-          description: "Max number of uses (0 = unlimited). Default 0.",
+          description: "Maximum number of uses; 0 means unlimited. Default 0.",
         },
         unique: {
           type: "boolean",
-          description: "If true, create a new unique invite even if one exists. Default false.",
+          description: "If true, always mint a fresh invite instead of reusing an equivalent existing one. Default false.",
         },
         temporary: {
           type: "boolean",
-          description: "If true, members joined via this invite are kicked when they disconnect. Default false.",
+          description: "If true, members who join via this invite are removed when they disconnect (unless they get a role). Default false.",
         },
       },
       required: ["channel_id"],
@@ -57,15 +63,17 @@ export const definitions = [
   },
   {
     name: "discord_delete_invite",
-    description: "Delete (revoke) an invite by its code.",
+    description:
+      "Revoke an invite by its code so it can no longer be used. IRREVERSIBLE (the code is freed). Requires the Manage Channels permission (or Manage Server). The reason is recorded in the audit log.",
+    annotations: { title: "Delete invite", readOnlyHint: false, destructiveHint: true, idempotentHint: false, openWorldHint: true },
     inputSchema: {
       type: "object",
       properties: {
         invite_code: {
           type: "string",
-          description: "The invite code to revoke.",
+          description: "The invite code to revoke. A full discord.gg/<code> URL is also accepted.",
         },
-        reason: { type: "string" },
+        reason: { type: "string", description: "Optional reason recorded in the server audit log." },
       },
       required: ["invite_code"],
     },
@@ -73,11 +81,12 @@ export const definitions = [
   {
     name: "discord_list_channel_invites",
     description:
-      "List all active invites for a specific channel. Unlike discord_list_invites which returns guild-wide invites, this scopes the result to a single channel.",
+      "List the active invites that point to one specific channel. Unlike discord_list_invites (server-wide), this scopes results to a single channel. Requires the Manage Channels permission. Read-only.",
+    annotations: { title: "List channel invites", readOnlyHint: true, openWorldHint: true },
     inputSchema: {
       type: "object",
       properties: {
-        channel_id: { type: "string" },
+        channel_id: { type: "string", description: "ID (snowflake) of the channel to list invites for." },
       },
       required: ["channel_id"],
     },

--- a/src/tools/members.ts
+++ b/src/tools/members.ts
@@ -7,146 +7,168 @@ import type { ToolModule, ToolResult } from "./types.js";
 export const definitions = [
   {
     name: "discord_list_members",
-    description: "List guild members with their roles.",
+    description:
+      "List members of a server with their roles, in join order. Returns a JSON array (id, username, nickname, roles, join date). Use discord_search_members to find specific members by name, or discord_get_member_info for one member's full details. Read-only.",
+    annotations: { title: "List members", readOnlyHint: true, openWorldHint: true },
     inputSchema: {
       type: "object",
       properties: {
-        guild_id: { type: "string" },
-        limit: { type: "number", description: "1–1000, default 50." },
+        guild_id: { type: "string", description: "Discord server (guild) ID (snowflake)." },
+        limit: { type: "number", description: "How many members to return (1–1000). Default 50." },
       },
       required: ["guild_id"],
     },
   },
   {
     name: "discord_get_member_info",
-    description: "Get detailed info about a member: roles, permissions, join date, timeout status.",
+    description:
+      "Get full details for one server member: roles, effective permissions, account/join dates, bot flag, and current timeout status. Read-only. Returns a JSON object.",
+    annotations: { title: "Get member info", readOnlyHint: true, openWorldHint: true },
     inputSchema: {
       type: "object",
       properties: {
-        guild_id: { type: "string" },
-        user_id: { type: "string" },
+        guild_id: { type: "string", description: "Discord server (guild) ID (snowflake)." },
+        user_id: { type: "string", description: "Discord user ID (snowflake) of the member." },
       },
       required: ["guild_id", "user_id"],
     },
   },
   {
     name: "discord_kick_member",
-    description: "Kick a member from a guild.",
+    description:
+      "Remove a member from the server. They can rejoin with a new invite (unlike a ban). Requires the Kick Members permission, and the bot's top role must be higher than the target's. Use discord_ban_member to block re-entry. The reason is recorded in the audit log.",
+    annotations: { title: "Kick member", readOnlyHint: false, destructiveHint: true, idempotentHint: false, openWorldHint: true },
     inputSchema: {
       type: "object",
       properties: {
-        guild_id: { type: "string" },
-        user_id: { type: "string" },
-        reason: { type: "string" },
+        guild_id: { type: "string", description: "Discord server (guild) ID (snowflake)." },
+        user_id: { type: "string", description: "Discord user ID (snowflake) of the member to kick." },
+        reason: { type: "string", description: "Optional reason recorded in the server audit log." },
       },
       required: ["guild_id", "user_id"],
     },
   },
   {
     name: "discord_ban_member",
-    description: "Ban a member from a guild.",
+    description:
+      "Ban a user from the server, blocking re-entry until unbanned. Optionally bulk-deletes their recent messages. Requires the Ban Members permission, and the bot's top role must outrank the target's. Use discord_unban_member to reverse, or discord_kick_member for a non-permanent removal. The reason is recorded in the audit log.",
+    annotations: { title: "Ban member", readOnlyHint: false, destructiveHint: true, idempotentHint: true, openWorldHint: true },
     inputSchema: {
       type: "object",
       properties: {
-        guild_id: { type: "string" },
-        user_id: { type: "string" },
-        reason: { type: "string" },
-        delete_message_days: { type: "number", description: "Delete messages from last N days (0–7)." },
+        guild_id: { type: "string", description: "Discord server (guild) ID (snowflake)." },
+        user_id: { type: "string", description: "Discord user ID (snowflake) of the user to ban." },
+        reason: { type: "string", description: "Optional reason recorded in the server audit log." },
+        delete_message_days: { type: "number", description: "Also delete the user's messages from the last N days (0–7). Default 0 (delete nothing)." },
       },
       required: ["guild_id", "user_id"],
     },
   },
   {
     name: "discord_unban_member",
-    description: "Unban a user from a guild.",
+    description:
+      "Lift a ban so the user may rejoin via a new invite. Requires the Ban Members permission. Reverses discord_ban_member. The reason is recorded in the audit log.",
+    annotations: { title: "Unban member", readOnlyHint: false, destructiveHint: false, idempotentHint: true, openWorldHint: true },
     inputSchema: {
       type: "object",
       properties: {
-        guild_id: { type: "string" },
-        user_id: { type: "string" },
-        reason: { type: "string" },
+        guild_id: { type: "string", description: "Discord server (guild) ID (snowflake)." },
+        user_id: { type: "string", description: "Discord user ID (snowflake) of the banned user to unban." },
+        reason: { type: "string", description: "Optional reason recorded in the server audit log." },
       },
       required: ["guild_id", "user_id"],
     },
   },
   {
     name: "discord_timeout_member",
-    description: "Put a member in timeout (0 minutes to remove the timeout).",
+    description:
+      "Mute a member for a set duration (Discord 'timeout'): they cannot send messages, react, or speak until it expires. Pass duration_minutes = 0 to remove an active timeout early. Max 28 days (40320 minutes). Requires the Moderate Members permission.",
+    annotations: { title: "Timeout member", readOnlyHint: false, destructiveHint: false, idempotentHint: true, openWorldHint: true },
     inputSchema: {
       type: "object",
       properties: {
-        guild_id: { type: "string" },
-        user_id: { type: "string" },
-        duration_minutes: { type: "number" },
-        reason: { type: "string" },
+        guild_id: { type: "string", description: "Discord server (guild) ID (snowflake)." },
+        user_id: { type: "string", description: "Discord user ID (snowflake) of the member to time out." },
+        duration_minutes: { type: "number", description: "Timeout length in minutes (1–40320, i.e. up to 28 days). Use 0 to clear an existing timeout." },
+        reason: { type: "string", description: "Optional reason recorded in the server audit log." },
       },
       required: ["guild_id", "user_id", "duration_minutes"],
     },
   },
   {
     name: "discord_search_members",
-    description: "Search guild members by username or nickname.",
+    description:
+      "Find server members whose username or nickname starts with a query string (prefix match). Returns a JSON array (id, username, nickname, roles). Use discord_list_members to page through everyone. Read-only.",
+    annotations: { title: "Search members", readOnlyHint: true, openWorldHint: true },
     inputSchema: {
       type: "object",
       properties: {
-        guild_id: { type: "string" },
-        query: { type: "string", description: "Search query (matches username and nickname)." },
-        limit: { type: "number", description: "1–100, default 25." },
+        guild_id: { type: "string", description: "Discord server (guild) ID (snowflake)." },
+        query: { type: "string", description: "Prefix to match against usernames and nicknames." },
+        limit: { type: "number", description: "Max members to return (1–100). Default 25." },
       },
       required: ["guild_id", "query"],
     },
   },
   {
     name: "discord_set_nickname",
-    description: "Set or clear a member's nickname.",
+    description:
+      "Set or clear a member's server nickname. Pass null (or the string 'null') to clear it. Requires the Manage Nicknames permission (or Change Nickname for the bot itself). The reason is recorded in the audit log.",
+    annotations: { title: "Set nickname", readOnlyHint: false, destructiveHint: false, idempotentHint: true, openWorldHint: true },
     inputSchema: {
       type: "object",
       properties: {
-        guild_id: { type: "string" },
-        user_id: { type: "string" },
-        nickname: { type: "string", description: "New nickname, or null to clear." },
-        reason: { type: "string" },
+        guild_id: { type: "string", description: "Discord server (guild) ID (snowflake)." },
+        user_id: { type: "string", description: "Discord user ID (snowflake) of the member." },
+        nickname: { type: "string", description: "New nickname (max 32 characters), or null to clear it." },
+        reason: { type: "string", description: "Optional reason recorded in the server audit log." },
       },
       required: ["guild_id", "user_id", "nickname"],
     },
   },
   {
     name: "discord_list_bans",
-    description: "List all banned users in a guild.",
+    description:
+      "List the users currently banned from the server, with their ban reasons. Returns a JSON array (user_id, username, reason). Requires the Ban Members permission. Read-only.",
+    annotations: { title: "List bans", readOnlyHint: true, openWorldHint: true },
     inputSchema: {
       type: "object",
       properties: {
-        guild_id: { type: "string" },
-        limit: { type: "number", description: "Max bans to fetch." },
+        guild_id: { type: "string", description: "Discord server (guild) ID (snowflake)." },
+        limit: { type: "number", description: "Optional max number of bans to fetch. Omit to fetch all." },
       },
       required: ["guild_id"],
     },
   },
   {
     name: "discord_bulk_ban",
-    description: "Ban multiple users at once (raid mitigation).",
+    description:
+      "Ban many users in a single call, intended for raid mitigation. Requires the Ban Members permission. Returns counts of banned vs failed users. Use discord_ban_member for a single ban with finer control.",
+    annotations: { title: "Bulk ban", readOnlyHint: false, destructiveHint: true, idempotentHint: false, openWorldHint: true },
     inputSchema: {
       type: "object",
       properties: {
-        guild_id: { type: "string" },
-        user_ids: { type: "array", items: { type: "string" }, description: "Array of user IDs to ban." },
-        delete_message_seconds: { type: "number", description: "Delete messages from last N seconds (0–604800)." },
-        reason: { type: "string" },
+        guild_id: { type: "string", description: "Discord server (guild) ID (snowflake)." },
+        user_ids: { type: "array", items: { type: "string" }, description: "Array of user IDs (snowflakes) to ban." },
+        delete_message_seconds: { type: "number", description: "Also delete each user's messages from the last N seconds (0–604800, i.e. up to 7 days). Default 0." },
+        reason: { type: "string", description: "Optional reason recorded in the server audit log." },
       },
       required: ["guild_id", "user_ids"],
     },
   },
   {
     name: "discord_prune_members",
-    description: "Remove inactive members. Use dry_run (default) to preview count first.",
+    description:
+      "Remove members who have been inactive (no roles, not seen) for a number of days. SAFE BY DEFAULT: dry_run is true unless explicitly set to false, so call it first to preview the count, then re-call with dry_run:false to actually remove them. Removal is irreversible (members must rejoin). Requires the Kick Members permission.",
+    annotations: { title: "Prune inactive members", readOnlyHint: false, destructiveHint: true, idempotentHint: false, openWorldHint: true },
     inputSchema: {
       type: "object",
       properties: {
-        guild_id: { type: "string" },
-        days: { type: "number", description: "Number of days of inactivity (1–30)." },
-        roles: { type: "array", items: { type: "string" }, description: "Role IDs to include in the prune." },
-        dry_run: { type: "boolean", description: "If true (default), only returns count without pruning." },
-        reason: { type: "string" },
+        guild_id: { type: "string", description: "Discord server (guild) ID (snowflake)." },
+        days: { type: "number", description: "Inactivity threshold in days (1–30)." },
+        roles: { type: "array", items: { type: "string" }, description: "Optional role IDs (snowflakes) to include; by default only members with no roles are counted." },
+        dry_run: { type: "boolean", description: "If true (default), only returns the count that would be pruned without removing anyone. Set false to actually prune." },
+        reason: { type: "string", description: "Optional reason recorded in the server audit log." },
       },
       required: ["guild_id", "days"],
     },

--- a/src/tools/messages.ts
+++ b/src/tools/messages.ts
@@ -10,92 +10,141 @@ import { discord, getTextChannel } from "../client.js";
 import { MAX_FETCH_LIMIT, DEFAULTS } from "../constants.js";
 import type { ToolModule, ToolResult } from "./types.js";
 
+/** Reusable input-schema fragment for a rich embed's fields (shared by send/edit/multiple embed tools). */
+const EMBED_FIELD_PROPS = {
+  title: { type: "string", description: "Embed title shown in bold at the top." },
+  url: { type: "string", description: "URL that makes the title clickable." },
+  description: { type: "string", description: "Main body text of the embed (supports Markdown)." },
+  color: { type: "string", description: "Side-bar color as a hex string, e.g. '#5865F2'." },
+  fields: {
+    type: "array",
+    description: "Up to 25 name/value field blocks rendered as a grid.",
+    items: {
+      type: "object",
+      properties: {
+        name: { type: "string", description: "Field heading." },
+        value: { type: "string", description: "Field body text." },
+        inline: { type: "boolean", description: "If true, render this field side-by-side with adjacent inline fields." },
+      },
+      required: ["name", "value"],
+    },
+  },
+  author: {
+    type: "object",
+    description: "Author block shown at the top of the embed.",
+    properties: {
+      name: { type: "string", description: "Author display name." },
+      icon_url: { type: "string", description: "Small icon shown next to the author name." },
+      url: { type: "string", description: "URL the author name links to." },
+    },
+    required: ["name"],
+  },
+  thumbnail_url: { type: "string", description: "Small image shown in the top-right corner." },
+  footer: { type: "string", description: "Footer text shown at the bottom of the embed." },
+  image_url: { type: "string", description: "Large image shown below the embed body." },
+  timestamp: { type: "boolean", description: "If true, stamp the embed with the current time." },
+} as const;
+
 /** Tool definitions for reading, sending, replying, editing, reacting, threading, embedding, deleting, pinning, and searching messages. */
 export const definitions = [
   {
     name: "discord_read_messages",
-    description: "Read the last N messages from a text channel.",
+    description:
+      "Read the most recent messages from a text channel or thread, oldest-to-newest. Returns a JSON array of messages (id, author, content, timestamp, attachment count, pinned flag). Use discord_search_messages to filter by keyword, or discord_fetch_pinned_messages for pinned messages only.",
+    annotations: { title: "Read messages", readOnlyHint: true, openWorldHint: true },
     inputSchema: {
       type: "object",
       properties: {
-        channel_id: { type: "string" },
-        limit: { type: "number", description: "1–100, default 20." },
+        channel_id: { type: "string", description: "ID (snowflake) of the channel or thread to read from." },
+        limit: { type: "number", description: "How many recent messages to fetch (1–100). Default 20." },
       },
       required: ["channel_id"],
     },
   },
   {
     name: "discord_send_message",
-    description: "Send a plain text message to a channel.",
+    description:
+      "Send a plain-text message to a channel or thread. For rich content (title, color, fields, images) use discord_send_embed; to attach a reply reference to an existing message use discord_reply_message. Requires the bot to have the Send Messages permission. Returns the new message ID.",
+    annotations: { title: "Send message", readOnlyHint: false, destructiveHint: false, idempotentHint: false, openWorldHint: true },
     inputSchema: {
       type: "object",
       properties: {
-        channel_id: { type: "string" },
-        content: { type: "string" },
+        channel_id: { type: "string", description: "ID (snowflake) of the target channel or thread." },
+        content: { type: "string", description: "Plain-text body of the message (max 2000 characters)." },
       },
       required: ["channel_id", "content"],
     },
   },
   {
     name: "discord_reply_message",
-    description: "Reply to a specific message in a channel.",
+    description:
+      "Reply to a specific message, attaching a reply reference so clients show it as a threaded reply. Use discord_send_message for a standalone message with no reference. Requires the Send Messages permission. Returns the new reply's message ID.",
+    annotations: { title: "Reply to message", readOnlyHint: false, destructiveHint: false, idempotentHint: false, openWorldHint: true },
     inputSchema: {
       type: "object",
       properties: {
-        channel_id: { type: "string" },
-        message_id: { type: "string", description: "The message ID to reply to." },
-        content: { type: "string" },
+        channel_id: { type: "string", description: "ID (snowflake) of the channel or thread containing the message." },
+        message_id: { type: "string", description: "ID of the message to reply to." },
+        content: { type: "string", description: "Plain-text body of the reply (max 2000 characters)." },
       },
       required: ["channel_id", "message_id", "content"],
     },
   },
   {
     name: "discord_edit_message",
-    description: "Edit a message sent by the bot.",
+    description:
+      "Edit the text content of a message previously sent by this bot. Discord forbids editing other users' messages, so this fails for non-bot messages. Use discord_edit_embed for embed messages. Works in text channels and threads. Returns the edited message ID.",
+    annotations: { title: "Edit message", readOnlyHint: false, destructiveHint: false, idempotentHint: true, openWorldHint: true },
     inputSchema: {
       type: "object",
       properties: {
-        channel_id: { type: "string" },
-        message_id: { type: "string", description: "The message ID to edit (must be a bot message)." },
-        content: { type: "string", description: "New text content for the message." },
+        channel_id: { type: "string", description: "ID (snowflake) of the channel or thread containing the message." },
+        message_id: { type: "string", description: "ID of the message to edit. Must be a message authored by this bot." },
+        content: { type: "string", description: "New plain-text content that fully replaces the existing content (max 2000 characters)." },
       },
       required: ["channel_id", "message_id", "content"],
     },
   },
   {
     name: "discord_add_reaction",
-    description: "Add a reaction emoji to a message.",
+    description:
+      "Add a single emoji reaction to a message as the bot. Requires the Add Reactions and Read Message History permissions. Use discord_remove_reactions to undo. Idempotent: re-adding the bot's existing reaction has no effect.",
+    annotations: { title: "Add reaction", readOnlyHint: false, destructiveHint: false, idempotentHint: true, openWorldHint: true },
     inputSchema: {
       type: "object",
       properties: {
-        channel_id: { type: "string" },
-        message_id: { type: "string" },
-        emoji: { type: "string", description: "Unicode emoji (e.g. '👍') or custom emoji in format 'name:id'." },
+        channel_id: { type: "string", description: "ID (snowflake) of the channel or thread containing the message." },
+        message_id: { type: "string", description: "ID of the message to react to." },
+        emoji: { type: "string", description: "Unicode emoji (e.g. '👍') or a custom emoji in 'name:id' format." },
       },
       required: ["channel_id", "message_id", "emoji"],
     },
   },
   {
     name: "discord_create_thread",
-    description: "Create a thread from an existing message or as a standalone thread in a channel.",
+    description:
+      "Create a thread, either branching from an existing message (pass message_id) or as a standalone thread in a text channel (omit message_id). Standalone creation requires a parent text channel and fails if channel_id is itself a thread. Requires the Create Public Threads permission. Returns the new thread's ID.",
+    annotations: { title: "Create thread", readOnlyHint: false, destructiveHint: false, idempotentHint: false, openWorldHint: true },
     inputSchema: {
       type: "object",
       properties: {
-        channel_id: { type: "string" },
-        name: { type: "string", description: "Thread name." },
-        message_id: { type: "string", description: "Optional: message to start the thread from. If omitted, creates a standalone thread." },
-        auto_archive_duration: { type: "number", description: "Auto-archive after N minutes of inactivity (60, 1440, 4320, 10080). Default 1440 (24h)." },
+        channel_id: { type: "string", description: "ID (snowflake) of the parent text channel. For a message-based thread, the channel containing message_id." },
+        name: { type: "string", description: "Name of the thread to create (max 100 characters)." },
+        message_id: { type: "string", description: "Optional. Message to branch the thread from. If omitted, a standalone thread is created in the channel." },
+        auto_archive_duration: { type: "number", description: "Minutes of inactivity before auto-archiving: 60, 1440, 4320, or 10080. Default 1440 (24h)." },
       },
       required: ["channel_id", "name"],
     },
   },
   {
     name: "discord_bulk_delete_messages",
-    description: "Delete multiple messages at once (2–100, messages must be less than 14 days old).",
+    description:
+      "Permanently delete multiple recent messages in one call. IRREVERSIBLE. Discord only allows bulk-deleting messages younger than 14 days; older ones are skipped. Requires the Manage Messages permission. Use discord_delete_message to remove a single specific message. Returns the number actually deleted.",
+    annotations: { title: "Bulk delete messages", readOnlyHint: false, destructiveHint: true, idempotentHint: false, openWorldHint: true },
     inputSchema: {
       type: "object",
       properties: {
-        channel_id: { type: "string" },
+        channel_id: { type: "string", description: "ID (snowflake) of the channel or thread to delete messages from." },
         count: { type: "number", description: "Number of recent messages to delete (2–100)." },
       },
       required: ["channel_id", "count"],
@@ -103,130 +152,49 @@ export const definitions = [
   },
   {
     name: "discord_send_embed",
-    description: "Send a rich embed message with title, description, color, fields, footer, image, thumbnail, author, URL, and timestamp.",
+    description:
+      "Send a single rich embed (title, description, color, fields, author, footer, images, timestamp). Use discord_send_message for plain text, or discord_send_multiple_embeds to send several embeds at once. Requires the Send Messages and Embed Links permissions. Returns the new message ID.",
+    annotations: { title: "Send embed", readOnlyHint: false, destructiveHint: false, idempotentHint: false, openWorldHint: true },
     inputSchema: {
       type: "object",
       properties: {
-        channel_id: { type: "string" },
-        title: { type: "string" },
-        url: { type: "string", description: "URL that makes the title clickable." },
-        description: { type: "string" },
-        color: { type: "string", description: "Hex color e.g. #5865F2" },
-        fields: {
-          type: "array",
-          items: {
-            type: "object",
-            properties: {
-              name: { type: "string" },
-              value: { type: "string" },
-              inline: { type: "boolean" },
-            },
-            required: ["name", "value"],
-          },
-        },
-        author: {
-          type: "object",
-          description: "Author block shown at the top of the embed.",
-          properties: {
-            name: { type: "string" },
-            icon_url: { type: "string" },
-            url: { type: "string" },
-          },
-          required: ["name"],
-        },
-        thumbnail_url: { type: "string", description: "Small image shown in the top-right corner." },
-        footer: { type: "string" },
-        image_url: { type: "string" },
-        timestamp: { type: "boolean", description: "If true, adds the current timestamp to the embed." },
+        channel_id: { type: "string", description: "ID (snowflake) of the target channel or thread." },
+        ...EMBED_FIELD_PROPS,
       },
       required: ["channel_id"],
     },
   },
   {
     name: "discord_edit_embed",
-    description: "Edit an embed message previously sent by the bot. Only provided fields are updated; omitted fields are removed.",
+    description:
+      "Replace the embed on a message previously sent by this bot. Only this bot's messages can be edited. This is a full replace, not a merge: provided fields are applied and omitted fields are dropped from the embed. Returns a confirmation.",
+    annotations: { title: "Edit embed", readOnlyHint: false, destructiveHint: false, idempotentHint: true, openWorldHint: true },
     inputSchema: {
       type: "object",
       properties: {
-        channel_id: { type: "string" },
-        message_id: { type: "string", description: "The message ID to edit (must be a bot message with an embed)." },
-        title: { type: "string" },
-        url: { type: "string", description: "URL that makes the title clickable." },
-        description: { type: "string" },
-        color: { type: "string", description: "Hex color e.g. #5865F2" },
-        fields: {
-          type: "array",
-          items: {
-            type: "object",
-            properties: {
-              name: { type: "string" },
-              value: { type: "string" },
-              inline: { type: "boolean" },
-            },
-            required: ["name", "value"],
-          },
-        },
-        author: {
-          type: "object",
-          properties: {
-            name: { type: "string" },
-            icon_url: { type: "string" },
-            url: { type: "string" },
-          },
-          required: ["name"],
-        },
-        thumbnail_url: { type: "string" },
-        footer: { type: "string" },
-        image_url: { type: "string" },
-        timestamp: { type: "boolean", description: "If true, adds the current timestamp to the embed." },
+        channel_id: { type: "string", description: "ID (snowflake) of the channel or thread containing the message." },
+        message_id: { type: "string", description: "ID of the message to edit. Must be a bot message that already contains an embed." },
+        ...EMBED_FIELD_PROPS,
       },
       required: ["channel_id", "message_id"],
     },
   },
   {
     name: "discord_send_multiple_embeds",
-    description: "Send up to 10 embeds in a single message.",
+    description:
+      "Send up to 10 embeds in a single message, with optional text above them. Use discord_send_embed for a single embed. Requires the Send Messages and Embed Links permissions. Returns the new message ID.",
+    annotations: { title: "Send multiple embeds", readOnlyHint: false, destructiveHint: false, idempotentHint: false, openWorldHint: true },
     inputSchema: {
       type: "object",
       properties: {
-        channel_id: { type: "string" },
-        content: { type: "string", description: "Optional text content above the embeds." },
+        channel_id: { type: "string", description: "ID (snowflake) of the target channel or thread." },
+        content: { type: "string", description: "Optional plain text shown above the embeds." },
         embeds: {
           type: "array",
-          description: "Array of embed objects (max 10).",
+          description: "Array of embed objects to send (max 10).",
           items: {
             type: "object",
-            properties: {
-              title: { type: "string" },
-              url: { type: "string" },
-              description: { type: "string" },
-              color: { type: "string", description: "Hex color e.g. #5865F2" },
-              fields: {
-                type: "array",
-                items: {
-                  type: "object",
-                  properties: {
-                    name: { type: "string" },
-                    value: { type: "string" },
-                    inline: { type: "boolean" },
-                  },
-                  required: ["name", "value"],
-                },
-              },
-              author: {
-                type: "object",
-                properties: {
-                  name: { type: "string" },
-                  icon_url: { type: "string" },
-                  url: { type: "string" },
-                },
-                required: ["name"],
-              },
-              thumbnail_url: { type: "string" },
-              footer: { type: "string" },
-              image_url: { type: "string" },
-              timestamp: { type: "boolean" },
-            },
+            properties: { ...EMBED_FIELD_PROPS },
           },
         },
       },
@@ -235,103 +203,119 @@ export const definitions = [
   },
   {
     name: "discord_delete_message",
-    description: "Delete a specific message from a channel.",
+    description:
+      "Permanently delete one specific message. IRREVERSIBLE. The bot can always delete its own messages; deleting another user's message requires the Manage Messages permission. Use discord_bulk_delete_messages to remove many at once. An optional reason is recorded in the audit log.",
+    annotations: { title: "Delete message", readOnlyHint: false, destructiveHint: true, idempotentHint: false, openWorldHint: true },
     inputSchema: {
       type: "object",
       properties: {
-        channel_id: { type: "string" },
-        message_id: { type: "string" },
-        reason: { type: "string" },
+        channel_id: { type: "string", description: "ID (snowflake) of the channel or thread containing the message." },
+        message_id: { type: "string", description: "ID of the message to delete." },
+        reason: { type: "string", description: "Optional reason recorded in the server audit log." },
       },
       required: ["channel_id", "message_id"],
     },
   },
   {
     name: "discord_pin_message",
-    description: "Pin or unpin a message in a channel.",
+    description:
+      "Pin or unpin a message in a channel, controlled by the pin flag. Requires the Manage Messages permission. A channel holds at most 50 pins. Idempotent: pinning an already-pinned message (or unpinning an unpinned one) has no additional effect.",
+    annotations: { title: "Pin or unpin message", readOnlyHint: false, destructiveHint: false, idempotentHint: true, openWorldHint: true },
     inputSchema: {
       type: "object",
       properties: {
-        channel_id: { type: "string" },
-        message_id: { type: "string" },
-        pin: { type: "boolean", description: "true to pin, false to unpin." },
+        channel_id: { type: "string", description: "ID (snowflake) of the channel or thread containing the message." },
+        message_id: { type: "string", description: "ID of the message to pin or unpin." },
+        pin: { type: "boolean", description: "true to pin the message, false to unpin it." },
       },
       required: ["channel_id", "message_id", "pin"],
     },
   },
   {
     name: "discord_search_messages",
-    description: "Search messages in a channel by keyword (scans up to last 100 messages).",
+    description:
+      "Keyword search over a channel's recent messages using case-insensitive substring matching. Scans only up to the last 100 messages — it does not search full history. Returns matching messages as a JSON array. Use discord_read_messages to fetch recent messages without filtering.",
+    annotations: { title: "Search messages", readOnlyHint: true, openWorldHint: true },
     inputSchema: {
       type: "object",
       properties: {
-        channel_id: { type: "string" },
-        keyword: { type: "string" },
-        limit: { type: "number", description: "Max messages to scan (default 100)." },
+        channel_id: { type: "string", description: "ID (snowflake) of the channel or thread to search." },
+        keyword: { type: "string", description: "Case-insensitive substring to match within message content." },
+        limit: { type: "number", description: "Max number of recent messages to scan (1–100). Default 100." },
       },
       required: ["channel_id", "keyword"],
     },
   },
   {
     name: "discord_crosspost_message",
-    description: "Publish a message in an announcement channel to all following channels.",
+    description:
+      "Publish (crosspost) a message from an Announcement channel to every server that follows it. Only works in announcement channels on a message that has not already been published. Requires the Send Messages permission (and Manage Messages for messages authored by others). Returns a confirmation.",
+    annotations: { title: "Crosspost message", readOnlyHint: false, destructiveHint: false, idempotentHint: true, openWorldHint: true },
     inputSchema: {
       type: "object",
       properties: {
-        channel_id: { type: "string" },
-        message_id: { type: "string" },
+        channel_id: { type: "string", description: "ID (snowflake) of the announcement channel containing the message." },
+        message_id: { type: "string", description: "ID of the message to publish to followers." },
       },
       required: ["channel_id", "message_id"],
     },
   },
   {
     name: "discord_remove_reactions",
-    description: "Remove reactions from a message. No emoji = remove all. Emoji only = remove that emoji. Emoji + user_id = remove that user's reaction.",
+    description:
+      "Remove reactions from a message. With no emoji: removes ALL reactions. With emoji only: removes every reaction of that emoji. With emoji and user_id: removes that one user's reaction. Removing all reactions or another user's reaction requires the Manage Messages permission. Use discord_add_reaction to add.",
+    annotations: { title: "Remove reactions", readOnlyHint: false, destructiveHint: false, idempotentHint: true, openWorldHint: true },
     inputSchema: {
       type: "object",
       properties: {
-        channel_id: { type: "string" },
-        message_id: { type: "string" },
-        emoji: { type: "string", description: "Unicode emoji or custom emoji 'name:id'. Omit to remove all reactions." },
-        user_id: { type: "string", description: "Remove only this user's reaction for the given emoji." },
+        channel_id: { type: "string", description: "ID (snowflake) of the channel or thread containing the message." },
+        message_id: { type: "string", description: "ID of the message to remove reactions from." },
+        emoji: { type: "string", description: "Unicode emoji or custom emoji 'name:id'. Omit to remove ALL reactions on the message." },
+        user_id: { type: "string", description: "Remove only this user's reaction for the given emoji. Requires emoji to be set." },
       },
       required: ["channel_id", "message_id"],
     },
   },
   {
     name: "discord_get_reactions",
-    description: "List users who reacted with a specific emoji on a message.",
+    description:
+      "List the users who reacted to a message with a specific emoji. Returns a JSON array of users (id, username, bot flag). Read-only.",
+    annotations: { title: "Get reactions", readOnlyHint: true, openWorldHint: true },
     inputSchema: {
       type: "object",
       properties: {
-        channel_id: { type: "string" },
-        message_id: { type: "string" },
-        emoji: { type: "string", description: "Unicode emoji or custom emoji 'name:id'." },
-        limit: { type: "number", description: "1–100, default 25." },
+        channel_id: { type: "string", description: "ID (snowflake) of the channel or thread containing the message." },
+        message_id: { type: "string", description: "ID of the message to inspect." },
+        emoji: { type: "string", description: "Unicode emoji or custom emoji 'name:id' to list reactors for." },
+        limit: { type: "number", description: "Max users to return (1–100). Default 25." },
       },
       required: ["channel_id", "message_id", "emoji"],
     },
   },
   {
     name: "discord_fetch_pinned_messages",
-    description: "List all pinned messages in a channel.",
+    description:
+      "List all pinned messages in a channel as a JSON array (id, author, content, timestamp). Read-only. Use discord_pin_message to change which messages are pinned.",
+    annotations: { title: "Fetch pinned messages", readOnlyHint: true, openWorldHint: true },
     inputSchema: {
       type: "object",
       properties: {
-        channel_id: { type: "string" },
+        channel_id: { type: "string", description: "ID (snowflake) of the channel or thread to list pins from." },
       },
       required: ["channel_id"],
     },
   },
   {
     name: "discord_forward_message",
-    description: "Forward a message to another channel.",
+    description:
+      "Forward an existing message to another channel using Discord's native forward, which preserves the original attribution. Works across text channels and threads. Use discord_send_message to compose new content instead. Requires the Send Messages permission in the target channel. Returns a confirmation.",
+    annotations: { title: "Forward message", readOnlyHint: false, destructiveHint: false, idempotentHint: false, openWorldHint: true },
     inputSchema: {
       type: "object",
       properties: {
-        channel_id: { type: "string" },
-        message_id: { type: "string" },
-        target_channel_id: { type: "string" },
+        channel_id: { type: "string", description: "ID (snowflake) of the channel or thread containing the source message." },
+        message_id: { type: "string", description: "ID of the message to forward." },
+        target_channel_id: { type: "string", description: "ID (snowflake) of the destination channel or thread." },
       },
       required: ["channel_id", "message_id", "target_channel_id"],
     },

--- a/src/tools/moderation.ts
+++ b/src/tools/moderation.ts
@@ -5,13 +5,15 @@ import type { ToolModule, ToolResult } from "./types.js";
 export const definitions = [
   {
     name: "discord_get_audit_log",
-    description: "Fetch the guild audit log (who did what and when).",
+    description:
+      "Fetch the server's audit log — a record of administrative actions (bans, kicks, role/channel changes, etc.) with who performed them and when. Requires the View Audit Log permission. Returns a JSON array (id, action, executor, target, reason, timestamp). Read-only.",
+    annotations: { title: "Get audit log", readOnlyHint: true, openWorldHint: true },
     inputSchema: {
       type: "object",
       properties: {
-        guild_id: { type: "string" },
-        limit: { type: "number", description: "1–100, default 25." },
-        action_type: { type: "number", description: "Optional: filter by Discord action type ID." },
+        guild_id: { type: "string", description: "Discord server (guild) ID (snowflake)." },
+        limit: { type: "number", description: "How many recent entries to fetch (1–100). Default 25." },
+        action_type: { type: "number", description: "Optional Discord AuditLogEvent numeric ID to filter by (e.g. 22 = MemberBanAdd). Omit for all action types." },
       },
       required: ["guild_id"],
     },

--- a/src/tools/permissions.ts
+++ b/src/tools/permissions.ts
@@ -6,74 +6,86 @@ import type { ToolModule, ToolResult } from "./types.js";
 export const definitions = [
   {
     name: "discord_get_channel_permissions",
-    description: "List all permission overwrites on a channel (per role and per member).",
+    description:
+      "List every permission overwrite on a channel, per role and per member, with the allowed and denied permission flags for each. Read-only. Use discord_audit_permissions for a server-wide report across all channels.",
+    annotations: { title: "Get channel permissions", readOnlyHint: true, openWorldHint: true },
     inputSchema: {
       type: "object",
-      properties: { channel_id: { type: "string" } },
+      properties: { channel_id: { type: "string", description: "ID (snowflake) of the channel to inspect." } },
       required: ["channel_id"],
     },
   },
   {
     name: "discord_set_role_permission",
-    description: "Allow or deny specific permissions for a role on a channel.",
+    description:
+      "Add or update a per-channel permission overwrite for a role, allowing and/or denying specific permissions. Merges with the role's existing overwrite (does not reset it). Requires the Manage Roles permission. Use discord_set_member_permission to target a single member instead.",
+    annotations: { title: "Set role channel permission", readOnlyHint: false, destructiveHint: false, idempotentHint: true, openWorldHint: true },
     inputSchema: {
       type: "object",
       properties: {
-        channel_id: { type: "string" },
-        role_id: { type: "string" },
-        allow: { type: "array", items: { type: "string" }, description: "e.g. ['SendMessages','ViewChannel']" },
-        deny: { type: "array", items: { type: "string" } },
-        reason: { type: "string" },
+        channel_id: { type: "string", description: "ID (snowflake) of the channel to set the overwrite on." },
+        role_id: { type: "string", description: "ID (snowflake) of the role to grant/deny permissions for." },
+        allow: { type: "array", items: { type: "string" }, description: "Permission flag names to allow, e.g. ['SendMessages','ViewChannel']. Uses Discord PermissionsBitField flag names." },
+        deny: { type: "array", items: { type: "string" }, description: "Permission flag names to deny, e.g. ['SendMessages']." },
+        reason: { type: "string", description: "Optional reason recorded in the server audit log." },
       },
       required: ["channel_id", "role_id"],
     },
   },
   {
     name: "discord_set_member_permission",
-    description: "Allow or deny specific permissions for a single member on a channel.",
+    description:
+      "Add or update a per-channel permission overwrite for a single member, allowing and/or denying specific permissions. Merges with the member's existing overwrite. Requires the Manage Roles permission. Use discord_set_role_permission to target a whole role instead.",
+    annotations: { title: "Set member channel permission", readOnlyHint: false, destructiveHint: false, idempotentHint: true, openWorldHint: true },
     inputSchema: {
       type: "object",
       properties: {
-        channel_id: { type: "string" },
-        user_id: { type: "string" },
-        allow: { type: "array", items: { type: "string" } },
-        deny: { type: "array", items: { type: "string" } },
-        reason: { type: "string" },
+        channel_id: { type: "string", description: "ID (snowflake) of the channel to set the overwrite on." },
+        user_id: { type: "string", description: "ID (snowflake) of the member to grant/deny permissions for." },
+        allow: { type: "array", items: { type: "string" }, description: "Permission flag names to allow, e.g. ['ViewChannel']. Uses Discord PermissionsBitField flag names." },
+        deny: { type: "array", items: { type: "string" }, description: "Permission flag names to deny." },
+        reason: { type: "string", description: "Optional reason recorded in the server audit log." },
       },
       required: ["channel_id", "user_id"],
     },
   },
   {
     name: "discord_reset_channel_permissions",
-    description: "Remove ALL permission overwrites on a channel (reset to inherited).",
+    description:
+      "Remove ALL permission overwrites on a channel, resetting it to inherit from its category/server defaults. IRREVERSIBLE — the cleared overwrites cannot be recovered. Requires the Manage Roles permission.",
+    annotations: { title: "Reset channel permissions", readOnlyHint: false, destructiveHint: true, idempotentHint: true, openWorldHint: true },
     inputSchema: {
       type: "object",
       properties: {
-        channel_id: { type: "string" },
-        reason: { type: "string" },
+        channel_id: { type: "string", description: "ID (snowflake) of the channel whose overwrites will be cleared." },
+        reason: { type: "string", description: "Optional reason recorded in the server audit log." },
       },
       required: ["channel_id"],
     },
   },
   {
     name: "discord_copy_permissions",
-    description: "Copy all permission overwrites from one channel to another.",
+    description:
+      "Replace the target channel's permission overwrites with a copy of the source channel's. The target's existing overwrites are overwritten. Requires the Manage Roles permission. Returns a confirmation.",
+    annotations: { title: "Copy channel permissions", readOnlyHint: false, destructiveHint: false, idempotentHint: true, openWorldHint: true },
     inputSchema: {
       type: "object",
       properties: {
-        source_channel_id: { type: "string" },
-        target_channel_id: { type: "string" },
-        reason: { type: "string" },
+        source_channel_id: { type: "string", description: "ID (snowflake) of the channel to copy overwrites from." },
+        target_channel_id: { type: "string", description: "ID (snowflake) of the channel whose overwrites will be replaced." },
+        reason: { type: "string", description: "Optional reason recorded in the server audit log." },
       },
       required: ["source_channel_id", "target_channel_id"],
     },
   },
   {
     name: "discord_audit_permissions",
-    description: "Generate a full permission audit report for a guild: who can access what on every channel.",
+    description:
+      "Generate a server-wide permission report: for every channel that has overwrites, lists each role/member and their allowed/denied permissions (entity names resolved). Read-only. Returns a JSON array. Use discord_get_channel_permissions for a single channel.",
+    annotations: { title: "Audit permissions", readOnlyHint: true, openWorldHint: true },
     inputSchema: {
       type: "object",
-      properties: { guild_id: { type: "string" } },
+      properties: { guild_id: { type: "string", description: "Discord server (guild) ID (snowflake) to audit." } },
       required: ["guild_id"],
     },
   },

--- a/src/tools/roles.ts
+++ b/src/tools/roles.ts
@@ -6,122 +6,140 @@ import type { ToolModule, ToolResult } from "./types.js";
 export const definitions = [
   {
     name: "discord_list_roles",
-    description: "List all roles in a guild with permissions and member count.",
+    description:
+      "List all roles in a server (excluding @everyone), highest-first, with color, position, member count, and permissions. Read-only. Returns a JSON array. Use discord_get_role_members to see who holds a given role.",
+    annotations: { title: "List roles", readOnlyHint: true, openWorldHint: true },
     inputSchema: {
       type: "object",
-      properties: { guild_id: { type: "string" } },
+      properties: { guild_id: { type: "string", description: "Discord server (guild) ID (snowflake)." } },
       required: ["guild_id"],
     },
   },
   {
     name: "discord_create_role",
-    description: "Create a new role in a guild.",
+    description:
+      "Create a new role in a server. Requires the Manage Roles permission; the new role is placed below the bot's highest role. Use discord_add_role to then assign it to members. Returns the new role's name and ID.",
+    annotations: { title: "Create role", readOnlyHint: false, destructiveHint: false, idempotentHint: false, openWorldHint: true },
     inputSchema: {
       type: "object",
       properties: {
-        guild_id: { type: "string" },
-        name: { type: "string" },
-        color: { type: "string", description: "Hex color e.g. #FF5733" },
-        hoist: { type: "boolean" },
-        mentionable: { type: "boolean" },
-        permissions: { type: "array", items: { type: "string" }, description: "e.g. ['SendMessages','ViewChannel']" },
+        guild_id: { type: "string", description: "Discord server (guild) ID (snowflake)." },
+        name: { type: "string", description: "Name of the new role (max 100 characters)." },
+        color: { type: "string", description: "Role color as a hex string, e.g. '#FF5733'." },
+        hoist: { type: "boolean", description: "If true, display members with this role separately in the member list." },
+        mentionable: { type: "boolean", description: "If true, anyone can @mention this role." },
+        permissions: { type: "array", items: { type: "string" }, description: "Server-wide permission flag names to grant, e.g. ['SendMessages','ViewChannel']. Uses Discord PermissionsBitField flag names." },
       },
       required: ["guild_id", "name"],
     },
   },
   {
     name: "discord_edit_role",
-    description: "Edit an existing role (name, color, permissions, hoist, mentionable).",
+    description:
+      "Update an existing role's name, color, permissions, hoist, or mentionable flag. Only provided fields change; passing permissions REPLACES the role's full permission set. Requires the Manage Roles permission, and the role must be below the bot's highest role.",
+    annotations: { title: "Edit role", readOnlyHint: false, destructiveHint: false, idempotentHint: true, openWorldHint: true },
     inputSchema: {
       type: "object",
       properties: {
-        guild_id: { type: "string" },
-        role_id: { type: "string" },
-        name: { type: "string" },
-        color: { type: "string" },
-        hoist: { type: "boolean" },
-        mentionable: { type: "boolean" },
-        permissions: { type: "array", items: { type: "string" } },
+        guild_id: { type: "string", description: "Discord server (guild) ID (snowflake)." },
+        role_id: { type: "string", description: "ID (snowflake) of the role to edit." },
+        name: { type: "string", description: "New role name (max 100 characters)." },
+        color: { type: "string", description: "New role color as a hex string, e.g. '#FF5733'." },
+        hoist: { type: "boolean", description: "If true, display members with this role separately in the member list." },
+        mentionable: { type: "boolean", description: "If true, anyone can @mention this role." },
+        permissions: { type: "array", items: { type: "string" }, description: "Permission flag names. Providing this REPLACES the role's entire permission set. Uses Discord PermissionsBitField flag names." },
       },
       required: ["guild_id", "role_id"],
     },
   },
   {
     name: "discord_delete_role",
-    description: "Delete a role from a guild.",
+    description:
+      "Permanently delete a role from the server; it is automatically removed from every member who held it. IRREVERSIBLE. Requires the Manage Roles permission, and the role must be below the bot's highest role.",
+    annotations: { title: "Delete role", readOnlyHint: false, destructiveHint: true, idempotentHint: false, openWorldHint: true },
     inputSchema: {
       type: "object",
       properties: {
-        guild_id: { type: "string" },
-        role_id: { type: "string" },
-        reason: { type: "string" },
+        guild_id: { type: "string", description: "Discord server (guild) ID (snowflake)." },
+        role_id: { type: "string", description: "ID (snowflake) of the role to delete." },
+        reason: { type: "string", description: "Optional reason recorded in the server audit log." },
       },
       required: ["guild_id", "role_id"],
     },
   },
   {
     name: "discord_add_role",
-    description: "Assign a role to a member.",
+    description:
+      "Assign an existing role to a member. Requires the Manage Roles permission, and the role must be below the bot's highest role. Idempotent: assigning a role the member already has has no effect. Use discord_remove_role to undo.",
+    annotations: { title: "Add role to member", readOnlyHint: false, destructiveHint: false, idempotentHint: true, openWorldHint: true },
     inputSchema: {
       type: "object",
       properties: {
-        guild_id: { type: "string" },
-        user_id: { type: "string" },
-        role_id: { type: "string" },
-        reason: { type: "string" },
+        guild_id: { type: "string", description: "Discord server (guild) ID (snowflake)." },
+        user_id: { type: "string", description: "Discord user ID (snowflake) of the member to give the role to." },
+        role_id: { type: "string", description: "ID (snowflake) of the role to assign." },
+        reason: { type: "string", description: "Optional reason recorded in the server audit log." },
       },
       required: ["guild_id", "user_id", "role_id"],
     },
   },
   {
     name: "discord_remove_role",
-    description: "Remove a role from a member.",
+    description:
+      "Remove a role from a member. Requires the Manage Roles permission, and the role must be below the bot's highest role. Idempotent: removing a role the member doesn't have has no effect. Reverses discord_add_role.",
+    annotations: { title: "Remove role from member", readOnlyHint: false, destructiveHint: false, idempotentHint: true, openWorldHint: true },
     inputSchema: {
       type: "object",
       properties: {
-        guild_id: { type: "string" },
-        user_id: { type: "string" },
-        role_id: { type: "string" },
-        reason: { type: "string" },
+        guild_id: { type: "string", description: "Discord server (guild) ID (snowflake)." },
+        user_id: { type: "string", description: "Discord user ID (snowflake) of the member to remove the role from." },
+        role_id: { type: "string", description: "ID (snowflake) of the role to remove." },
+        reason: { type: "string", description: "Optional reason recorded in the server audit log." },
       },
       required: ["guild_id", "user_id", "role_id"],
     },
   },
   {
     name: "discord_get_role_members",
-    description: "List all members that have a specific role.",
+    description:
+      "List every member who currently holds a specific role. Returns a JSON array (id, username, nickname). Read-only. Use discord_list_roles to discover role IDs first.",
+    annotations: { title: "Get role members", readOnlyHint: true, openWorldHint: true },
     inputSchema: {
       type: "object",
       properties: {
-        guild_id: { type: "string" },
-        role_id: { type: "string" },
+        guild_id: { type: "string", description: "Discord server (guild) ID (snowflake)." },
+        role_id: { type: "string", description: "ID (snowflake) of the role to list holders of." },
       },
       required: ["guild_id", "role_id"],
     },
   },
   {
     name: "discord_set_role_position",
-    description: "Change a role's position in the hierarchy.",
+    description:
+      "Move a role up or down in the server's role hierarchy, which determines permission precedence and member-list ordering. Higher position = higher in the list. Requires the Manage Roles permission, and the target position must be below the bot's highest role.",
+    annotations: { title: "Set role position", readOnlyHint: false, destructiveHint: false, idempotentHint: true, openWorldHint: true },
     inputSchema: {
       type: "object",
       properties: {
-        guild_id: { type: "string" },
-        role_id: { type: "string" },
-        position: { type: "number" },
+        guild_id: { type: "string", description: "Discord server (guild) ID (snowflake)." },
+        role_id: { type: "string", description: "ID (snowflake) of the role to reposition." },
+        position: { type: "number", description: "New hierarchy position (0 = lowest, just above @everyone). Higher numbers rank higher." },
       },
       required: ["guild_id", "role_id", "position"],
     },
   },
   {
     name: "discord_set_role_icon",
-    description: "Set a custom icon or unicode emoji on a role (requires server boost level 2+).",
+    description:
+      "Set or clear a role's icon — either a custom image or a unicode emoji. Requires the server to be Boost Level 2+ (the ROLE_ICONS feature) and the Manage Roles permission. Pass null to either field to remove that icon. Returns a confirmation.",
+    annotations: { title: "Set role icon", readOnlyHint: false, destructiveHint: false, idempotentHint: true, openWorldHint: true },
     inputSchema: {
       type: "object",
       properties: {
-        guild_id: { type: "string" },
-        role_id: { type: "string" },
-        icon: { type: "string", description: "Image URL for the role icon. Set to null to remove." },
-        unicode_emoji: { type: "string", description: "Unicode emoji for the role. Set to null to remove." },
+        guild_id: { type: "string", description: "Discord server (guild) ID (snowflake)." },
+        role_id: { type: "string", description: "ID (snowflake) of the role to set the icon on." },
+        icon: { type: "string", description: "Image URL for the role icon, or null to remove it." },
+        unicode_emoji: { type: "string", description: "Unicode emoji to use as the role icon, or null to remove it." },
       },
       required: ["guild_id", "role_id"],
     },

--- a/src/tools/scheduledEvents.ts
+++ b/src/tools/scheduledEvents.ts
@@ -7,23 +7,27 @@ import type { ToolModule, ToolResult } from "./types.js";
 export const definitions = [
   {
     name: "discord_list_scheduled_events",
-    description: "List all scheduled events in a guild.",
+    description:
+      "List all scheduled events in a server (id, name, status, type, time, location, interested count). Read-only. Use discord_get_scheduled_event for one event's full details.",
+    annotations: { title: "List scheduled events", readOnlyHint: true, openWorldHint: true },
     inputSchema: {
       type: "object",
       properties: {
-        guild_id: { type: "string" },
+        guild_id: { type: "string", description: "Discord server (guild) ID (snowflake)." },
       },
       required: ["guild_id"],
     },
   },
   {
     name: "discord_get_scheduled_event",
-    description: "Get detailed info about a specific scheduled event.",
+    description:
+      "Get full details for one scheduled event: name, description, status, type, channel/location, start/end times, creator, and interested-user count. Read-only. Returns a JSON object.",
+    annotations: { title: "Get scheduled event", readOnlyHint: true, openWorldHint: true },
     inputSchema: {
       type: "object",
       properties: {
-        guild_id: { type: "string" },
-        event_id: { type: "string" },
+        guild_id: { type: "string", description: "Discord server (guild) ID (snowflake)." },
+        event_id: { type: "string", description: "ID (snowflake) of the scheduled event." },
       },
       required: ["guild_id", "event_id"],
     },
@@ -31,56 +35,61 @@ export const definitions = [
   {
     name: "discord_create_scheduled_event",
     description:
-      "Create a scheduled event in a guild. Use entity_type 'VOICE' or 'STAGE_INSTANCE' with a channel_id, or 'EXTERNAL' with a location and scheduled_end_time.",
+      "Create a scheduled event. For 'VOICE'/'STAGE_INSTANCE' events provide channel_id; for 'EXTERNAL' events provide location AND scheduled_end_time. Requires the Manage Events permission. Returns the new event's name and ID.",
+    annotations: { title: "Create scheduled event", readOnlyHint: false, destructiveHint: false, idempotentHint: false, openWorldHint: true },
     inputSchema: {
       type: "object",
       properties: {
-        guild_id: { type: "string" },
-        name: { type: "string" },
-        description: { type: "string" },
+        guild_id: { type: "string", description: "Discord server (guild) ID (snowflake)." },
+        name: { type: "string", description: "Event name (max 100 characters)." },
+        description: { type: "string", description: "Optional event description (max 1000 characters)." },
         entity_type: {
           type: "string",
-          description: "'VOICE', 'STAGE_INSTANCE', or 'EXTERNAL'.",
+          enum: ["VOICE", "STAGE_INSTANCE", "EXTERNAL"],
+          description: "Where the event happens: 'VOICE' or 'STAGE_INSTANCE' (needs channel_id), or 'EXTERNAL' (needs location + scheduled_end_time).",
         },
         scheduled_start_time: {
           type: "string",
-          description: "ISO 8601 datetime (e.g. '2025-06-01T20:00:00Z').",
+          description: "Event start as an ISO 8601 datetime, e.g. '2026-06-01T20:00:00Z'. Must be in the future.",
         },
         scheduled_end_time: {
           type: "string",
-          description: "ISO 8601 datetime. Required for EXTERNAL events.",
+          description: "Event end as an ISO 8601 datetime. Required for EXTERNAL events.",
         },
         channel_id: {
           type: "string",
-          description: "Voice or stage channel ID. Required for VOICE/STAGE_INSTANCE.",
+          description: "Voice or stage channel ID (snowflake). Required for VOICE/STAGE_INSTANCE events.",
         },
         location: {
           type: "string",
-          description: "Location string. Required for EXTERNAL events.",
+          description: "Free-text location (e.g. a URL or place). Required for EXTERNAL events.",
         },
-        image: { type: "string", description: "Cover image URL." },
+        image: { type: "string", description: "Optional cover image URL." },
       },
       required: ["guild_id", "name", "entity_type", "scheduled_start_time"],
     },
   },
   {
     name: "discord_edit_scheduled_event",
-    description: "Edit an existing scheduled event. Only provided fields are updated.",
+    description:
+      "Update a scheduled event; only provided fields change. Use the status field to start ('ACTIVE'), end ('COMPLETED'), or cancel ('CANCELED') an event — note Discord only allows certain status transitions. Requires the Manage Events permission.",
+    annotations: { title: "Edit scheduled event", readOnlyHint: false, destructiveHint: false, idempotentHint: true, openWorldHint: true },
     inputSchema: {
       type: "object",
       properties: {
-        guild_id: { type: "string" },
-        event_id: { type: "string" },
-        name: { type: "string" },
-        description: { type: "string" },
-        scheduled_start_time: { type: "string", description: "ISO 8601 datetime." },
-        scheduled_end_time: { type: "string", description: "ISO 8601 datetime." },
-        channel_id: { type: "string" },
-        location: { type: "string" },
-        image: { type: "string", description: "Cover image URL." },
+        guild_id: { type: "string", description: "Discord server (guild) ID (snowflake)." },
+        event_id: { type: "string", description: "ID (snowflake) of the event to edit." },
+        name: { type: "string", description: "New event name (max 100 characters)." },
+        description: { type: "string", description: "New event description (max 1000 characters)." },
+        scheduled_start_time: { type: "string", description: "New start time as an ISO 8601 datetime." },
+        scheduled_end_time: { type: "string", description: "New end time as an ISO 8601 datetime." },
+        channel_id: { type: "string", description: "New voice/stage channel ID (snowflake) for VOICE/STAGE_INSTANCE events." },
+        location: { type: "string", description: "New free-text location for EXTERNAL events." },
+        image: { type: "string", description: "New cover image URL." },
         status: {
           type: "string",
-          description: "'SCHEDULED', 'ACTIVE', 'COMPLETED', or 'CANCELED'.",
+          enum: ["SCHEDULED", "ACTIVE", "COMPLETED", "CANCELED"],
+          description: "Change event status. Allowed transitions only: SCHEDULED→ACTIVE→COMPLETED, or SCHEDULED→CANCELED.",
         },
       },
       required: ["guild_id", "event_id"],
@@ -88,40 +97,46 @@ export const definitions = [
   },
   {
     name: "discord_delete_scheduled_event",
-    description: "Delete a scheduled event.",
+    description:
+      "Permanently delete a scheduled event. IRREVERSIBLE. To cancel an event while keeping a record, use discord_edit_scheduled_event with status:'CANCELED' instead. Requires the Manage Events permission.",
+    annotations: { title: "Delete scheduled event", readOnlyHint: false, destructiveHint: true, idempotentHint: false, openWorldHint: true },
     inputSchema: {
       type: "object",
       properties: {
-        guild_id: { type: "string" },
-        event_id: { type: "string" },
+        guild_id: { type: "string", description: "Discord server (guild) ID (snowflake)." },
+        event_id: { type: "string", description: "ID (snowflake) of the event to delete." },
       },
       required: ["guild_id", "event_id"],
     },
   },
   {
     name: "discord_get_event_subscribers",
-    description: "Get users who marked 'Interested' in a scheduled event.",
+    description:
+      "List the users who marked themselves 'Interested' in a scheduled event (user_id, username, avatar). Read-only. Returns a JSON array.",
+    annotations: { title: "Get event subscribers", readOnlyHint: true, openWorldHint: true },
     inputSchema: {
       type: "object",
       properties: {
-        guild_id: { type: "string" },
-        event_id: { type: "string" },
-        limit: { type: "number", description: "1–100, default 25." },
+        guild_id: { type: "string", description: "Discord server (guild) ID (snowflake)." },
+        event_id: { type: "string", description: "ID (snowflake) of the scheduled event." },
+        limit: { type: "number", description: "Max subscribers to return (1–100). Default 25." },
       },
       required: ["guild_id", "event_id"],
     },
   },
   {
     name: "discord_create_event_invite",
-    description: "Create an invite URL linked to a scheduled event.",
+    description:
+      "Create a shareable invite URL that points to a scheduled event, so recipients land on the event when joining. Requires the Create Instant Invite permission. Returns the invite URL.",
+    annotations: { title: "Create event invite", readOnlyHint: false, destructiveHint: false, idempotentHint: false, openWorldHint: true },
     inputSchema: {
       type: "object",
       properties: {
-        guild_id: { type: "string" },
-        event_id: { type: "string" },
-        channel_id: { type: "string", description: "Channel for the invite. Uses the first text channel if omitted." },
-        max_age: { type: "number", description: "Invite duration in seconds (0 = never). Default 86400." },
-        max_uses: { type: "number", description: "Max uses (0 = unlimited). Default 0." },
+        guild_id: { type: "string", description: "Discord server (guild) ID (snowflake)." },
+        event_id: { type: "string", description: "ID (snowflake) of the scheduled event to link the invite to." },
+        channel_id: { type: "string", description: "Channel (snowflake) the invite points to. Defaults to the server's first text channel if omitted." },
+        max_age: { type: "number", description: "Invite lifetime in seconds; 0 means it never expires. Default 86400 (24h)." },
+        max_uses: { type: "number", description: "Maximum number of uses; 0 means unlimited. Default 0." },
       },
       required: ["guild_id", "event_id"],
     },

--- a/src/tools/screening.ts
+++ b/src/tools/screening.ts
@@ -5,30 +5,34 @@ import type { ToolModule, ToolResult } from "./types.js";
 export const definitions = [
   {
     name: "discord_get_membership_screening",
-    description: "Get the current membership screening form (rules/questions new members must complete).",
+    description:
+      "Fetch the server's membership screening form — the rules/questions new members must accept before gaining access. Requires the server to have the Community feature enabled. Read-only. Returns the raw form as JSON (including its version, needed by the update tool).",
+    annotations: { title: "Get membership screening", readOnlyHint: true, openWorldHint: true },
     inputSchema: {
       type: "object",
-      properties: { guild_id: { type: "string" } },
+      properties: { guild_id: { type: "string", description: "Discord server (guild) ID (snowflake)." } },
       required: ["guild_id"],
     },
   },
   {
     name: "discord_update_membership_screening",
-    description: "Update the membership screening form: set a description and rules/questions that new members must agree to before joining.",
+    description:
+      "Update the server's membership screening form: set the welcome description and the rules new members must agree to. Only provided fields change. Requires the Community feature and the Manage Server permission. Returns the updated form.",
+    annotations: { title: "Update membership screening", readOnlyHint: false, destructiveHint: false, idempotentHint: true, openWorldHint: true },
     inputSchema: {
       type: "object",
       properties: {
-        guild_id: { type: "string" },
+        guild_id: { type: "string", description: "Discord server (guild) ID (snowflake)." },
         description: { type: "string", description: "Welcome message shown at the top of the screening form." },
         form_fields: {
           type: "array",
-          description: "List of rules/questions. Each item has: label (the rule title), values (array of rule lines), required (boolean).",
+          description: "Rules/agreement blocks new members must accept. Replaces the existing fields when provided.",
           items: {
             type: "object",
             properties: {
-              label: { type: "string", description: "Title/question for this field." },
-              values: { type: "array", items: { type: "string" }, description: "Array of rule lines or answer options." },
-              required: { type: "boolean", description: "Whether this field is required (default true)." },
+              label: { type: "string", description: "Title of this rules block." },
+              values: { type: "array", items: { type: "string" }, description: "Individual rule lines shown under the label." },
+              required: { type: "boolean", description: "Whether the member must agree to this block. Default true." },
             },
             required: ["label", "values"],
           },

--- a/src/tools/stats.ts
+++ b/src/tools/stats.ts
@@ -6,10 +6,12 @@ import type { ToolModule, ToolResult } from "./types.js";
 export const definitions = [
   {
     name: "discord_get_server_stats",
-    description: "Get server statistics: member count (humans vs bots), channels, roles, boost level.",
+    description:
+      "Get a snapshot of server metrics: total members (humans vs cached bots), channel breakdown (text/voice/category), role count, boost tier and count, and creation date. Read-only. Returns a JSON object. Note: the bot count reflects only members currently in cache.",
+    annotations: { title: "Get server stats", readOnlyHint: true, openWorldHint: true },
     inputSchema: {
       type: "object",
-      properties: { guild_id: { type: "string" } },
+      properties: { guild_id: { type: "string", description: "Discord server (guild) ID (snowflake)." } },
       required: ["guild_id"],
     },
   },

--- a/src/tools/types.ts
+++ b/src/tools/types.ts
@@ -1,8 +1,24 @@
+/**
+ * MCP tool behavioral hints (advisory, not guarantees). See the MCP spec
+ * "tool annotations": readOnlyHint (only reads, never mutates), destructiveHint
+ * (may perform irreversible updates — delete/ban/prune), idempotentHint (repeat
+ * calls with same args add no effect), openWorldHint (talks to an external API —
+ * always true here). title is a human-readable display name.
+ */
+export interface ToolAnnotations {
+  title?: string;
+  readOnlyHint?: boolean;
+  destructiveHint?: boolean;
+  idempotentHint?: boolean;
+  openWorldHint?: boolean;
+}
+
 /** Schema definition for a single MCP tool, describing its name, purpose, and expected input. */
 export interface ToolDefinition {
   name: string;
   description: string;
   inputSchema: Record<string, unknown>;
+  annotations?: ToolAnnotations;
 }
 
 /** Standard response returned by every tool handler. */

--- a/src/tools/webhooks.ts
+++ b/src/tools/webhooks.ts
@@ -2,150 +2,158 @@ import { WebhookClient, EmbedBuilder, ColorResolvable } from "discord.js";
 import { discord, validateId } from "../client.js";
 import type { ToolModule, ToolResult } from "./types.js";
 
+/** Embed input-schema fragment for webhook messages (shared by send/edit webhook-message tools). */
+const WEBHOOK_EMBED_PROPS = {
+  type: "array",
+  description: "Up to 10 embed objects to attach to the webhook message.",
+  items: {
+    type: "object",
+    properties: {
+      title: { type: "string", description: "Embed title shown in bold at the top." },
+      url: { type: "string", description: "URL that makes the title clickable." },
+      description: { type: "string", description: "Main body text of the embed (supports Markdown)." },
+      color: { type: "string", description: "Side-bar color as a hex string, e.g. '#5865F2'." },
+      fields: {
+        type: "array",
+        description: "Up to 25 name/value field blocks.",
+        items: {
+          type: "object",
+          properties: {
+            name: { type: "string", description: "Field heading." },
+            value: { type: "string", description: "Field body text." },
+            inline: { type: "boolean", description: "If true, render side-by-side with adjacent inline fields." },
+          },
+          required: ["name", "value"],
+        },
+      },
+      footer: { type: "string", description: "Footer text shown at the bottom of the embed." },
+      image_url: { type: "string", description: "Large image shown below the embed body." },
+      thumbnail_url: { type: "string", description: "Small image shown in the top-right corner." },
+      timestamp: { type: "boolean", description: "If true, stamp the embed with the current time." },
+    },
+  },
+} as const;
+
 /** Tool definitions for creating, sending via, editing, deleting, and listing webhooks. */
 export const definitions = [
   {
     name: "discord_create_webhook",
-    description: "Create a webhook on a channel.",
+    description:
+      "Create a webhook on a channel and return its ID and token. SECURITY: the returned token grants anyone the ability to post as this webhook without authentication — treat it as a secret. Requires the Manage Webhooks permission. Use the returned id+token with discord_send_webhook_message.",
+    annotations: { title: "Create webhook", readOnlyHint: false, destructiveHint: false, idempotentHint: false, openWorldHint: true },
     inputSchema: {
       type: "object",
       properties: {
-        channel_id: { type: "string" },
-        name: { type: "string", description: "Name for the webhook." },
-        avatar: { type: "string", description: "Optional avatar URL for the webhook." },
+        channel_id: { type: "string", description: "ID (snowflake) of the channel to attach the webhook to." },
+        name: { type: "string", description: "Display name for the webhook (max 80 characters)." },
+        avatar: { type: "string", description: "Optional avatar image URL for the webhook." },
       },
       required: ["channel_id", "name"],
     },
   },
   {
     name: "discord_send_webhook_message",
-    description: "Send a message via a webhook using its ID and token.",
+    description:
+      "Send a message through a webhook using its ID and token (no bot permissions needed — the token authorizes the send). Supports per-message username/avatar overrides and up to 10 embeds. At least one of content or embeds is required. Returns the new message ID.",
+    annotations: { title: "Send webhook message", readOnlyHint: false, destructiveHint: false, idempotentHint: false, openWorldHint: true },
     inputSchema: {
       type: "object",
       properties: {
-        webhook_id: { type: "string" },
-        webhook_token: { type: "string" },
-        content: { type: "string", description: "Text content of the message." },
-        username: { type: "string", description: "Override the webhook's default username." },
-        avatar_url: { type: "string", description: "Override the webhook's default avatar." },
-        embeds: {
-          type: "array",
-          description: "Optional array of embed objects.",
-          items: {
-            type: "object",
-            properties: {
-              title: { type: "string" },
-              url: { type: "string" },
-              description: { type: "string" },
-              color: { type: "string", description: "Hex color e.g. #5865F2" },
-              fields: {
-                type: "array",
-                items: {
-                  type: "object",
-                  properties: {
-                    name: { type: "string" },
-                    value: { type: "string" },
-                    inline: { type: "boolean" },
-                  },
-                  required: ["name", "value"],
-                },
-              },
-              footer: { type: "string" },
-              image_url: { type: "string" },
-              thumbnail_url: { type: "string" },
-              timestamp: { type: "boolean" },
-            },
-          },
-        },
+        webhook_id: { type: "string", description: "ID (snowflake) of the webhook to send through." },
+        webhook_token: { type: "string", description: "Secret token of the webhook (from discord_create_webhook or discord_list_webhooks)." },
+        content: { type: "string", description: "Plain-text body of the message (max 2000 characters). Optional if embeds are provided." },
+        username: { type: "string", description: "Override the webhook's default display name for this message." },
+        avatar_url: { type: "string", description: "Override the webhook's default avatar for this message." },
+        embeds: WEBHOOK_EMBED_PROPS,
       },
       required: ["webhook_id", "webhook_token"],
     },
   },
   {
     name: "discord_edit_webhook",
-    description: "Edit a webhook's name, avatar, or channel.",
+    description:
+      "Update a webhook's name, avatar, or the channel it posts to. Only provided fields change. Requires the Manage Webhooks permission. Returns a confirmation.",
+    annotations: { title: "Edit webhook", readOnlyHint: false, destructiveHint: false, idempotentHint: true, openWorldHint: true },
     inputSchema: {
       type: "object",
       properties: {
-        webhook_id: { type: "string" },
-        name: { type: "string", description: "New name for the webhook." },
-        avatar: { type: "string", description: "New avatar URL for the webhook." },
-        channel_id: { type: "string", description: "Move the webhook to a different channel." },
+        webhook_id: { type: "string", description: "ID (snowflake) of the webhook to edit." },
+        name: { type: "string", description: "New display name for the webhook (max 80 characters)." },
+        avatar: { type: "string", description: "New avatar image URL for the webhook." },
+        channel_id: { type: "string", description: "ID (snowflake) of a channel to move the webhook to." },
       },
       required: ["webhook_id"],
     },
   },
   {
     name: "discord_delete_webhook",
-    description: "Delete a webhook.",
+    description:
+      "Permanently delete a webhook by its ID, invalidating its token. IRREVERSIBLE — any integrations using the old token will stop working. Requires the Manage Webhooks permission.",
+    annotations: { title: "Delete webhook", readOnlyHint: false, destructiveHint: true, idempotentHint: false, openWorldHint: true },
     inputSchema: {
       type: "object",
       properties: {
-        webhook_id: { type: "string" },
+        webhook_id: { type: "string", description: "ID (snowflake) of the webhook to delete." },
       },
       required: ["webhook_id"],
     },
   },
   {
     name: "discord_list_webhooks",
-    description: "List all webhooks for a channel or guild. Provide either channel_id or guild_id.",
+    description:
+      "List the webhooks in a single channel or across a whole server (id, name, channel, token when visible, creator). Provide exactly one of channel_id or guild_id. Requires the Manage Webhooks permission. Read-only.",
+    annotations: { title: "List webhooks", readOnlyHint: true, openWorldHint: true },
     inputSchema: {
       type: "object",
       properties: {
-        channel_id: { type: "string", description: "List webhooks for a specific channel." },
-        guild_id: { type: "string", description: "List all webhooks in a guild." },
+        channel_id: { type: "string", description: "ID (snowflake) of a channel to list webhooks for. Mutually exclusive with guild_id." },
+        guild_id: { type: "string", description: "Discord server (guild) ID (snowflake) to list all webhooks for. Mutually exclusive with channel_id." },
       },
     },
   },
   {
     name: "discord_edit_webhook_message",
-    description: "Edit a message previously sent by a webhook.",
+    description:
+      "Edit a message previously sent through a webhook, using the webhook's ID and token. Replaces the provided fields. Requires the original webhook token. Returns a confirmation.",
+    annotations: { title: "Edit webhook message", readOnlyHint: false, destructiveHint: false, idempotentHint: true, openWorldHint: true },
     inputSchema: {
       type: "object",
       properties: {
-        webhook_id: { type: "string" },
-        webhook_token: { type: "string" },
-        message_id: { type: "string" },
-        content: { type: "string" },
-        embeds: {
-          type: "array",
-          description: "Optional array of embed objects.",
-          items: {
-            type: "object",
-            properties: {
-              title: { type: "string" }, url: { type: "string" }, description: { type: "string" },
-              color: { type: "string", description: "Hex color e.g. #5865F2" },
-              fields: { type: "array", items: { type: "object", properties: { name: { type: "string" }, value: { type: "string" }, inline: { type: "boolean" } }, required: ["name", "value"] } },
-              footer: { type: "string" }, image_url: { type: "string" }, thumbnail_url: { type: "string" }, timestamp: { type: "boolean" },
-            },
-          },
-        },
+        webhook_id: { type: "string", description: "ID (snowflake) of the webhook that sent the message." },
+        webhook_token: { type: "string", description: "Secret token of the webhook." },
+        message_id: { type: "string", description: "ID of the webhook message to edit." },
+        content: { type: "string", description: "New plain-text content for the message (max 2000 characters)." },
+        embeds: WEBHOOK_EMBED_PROPS,
       },
       required: ["webhook_id", "webhook_token", "message_id"],
     },
   },
   {
     name: "discord_delete_webhook_message",
-    description: "Delete a message sent by a webhook.",
+    description:
+      "Permanently delete a message that was sent through a webhook, using the webhook's ID and token. IRREVERSIBLE. Requires the original webhook token.",
+    annotations: { title: "Delete webhook message", readOnlyHint: false, destructiveHint: true, idempotentHint: false, openWorldHint: true },
     inputSchema: {
       type: "object",
       properties: {
-        webhook_id: { type: "string" },
-        webhook_token: { type: "string" },
-        message_id: { type: "string" },
+        webhook_id: { type: "string", description: "ID (snowflake) of the webhook that sent the message." },
+        webhook_token: { type: "string", description: "Secret token of the webhook." },
+        message_id: { type: "string", description: "ID of the webhook message to delete." },
       },
       required: ["webhook_id", "webhook_token", "message_id"],
     },
   },
   {
     name: "discord_fetch_webhook_message",
-    description: "Fetch a specific message sent by a webhook.",
+    description:
+      "Fetch a single message sent through a webhook (id, content, embed count, timestamp), using the webhook's ID and token. Read-only. Requires the original webhook token.",
+    annotations: { title: "Fetch webhook message", readOnlyHint: true, openWorldHint: true },
     inputSchema: {
       type: "object",
       properties: {
-        webhook_id: { type: "string" },
-        webhook_token: { type: "string" },
-        message_id: { type: "string" },
+        webhook_id: { type: "string", description: "ID (snowflake) of the webhook that sent the message." },
+        webhook_token: { type: "string", description: "Secret token of the webhook." },
+        message_id: { type: "string", description: "ID of the webhook message to fetch." },
       },
       required: ["webhook_id", "webhook_token", "message_id"],
     },


### PR DESCRIPTION
## Summary
Raises the Glama **Tool Definition Quality** score (currently C, dragging overall Quality to B) by enriching all **97 tools** across the 14 modules. Glama scores the server as `60% mean + 40% minimum` per-tool, so every tool — not just the worst — was brought up to a consistent bar.

## Changes
- **Annotations** — every tool now carries MCP `annotations` (`readOnlyHint`, `destructiveHint`, `idempotentHint`, `openWorldHint`, `title`). New `ToolAnnotations` type + optional `annotations` field on `ToolDefinition`.
- **Descriptions** — rewritten to include: action statement, when to use vs. similar tools, required Discord permissions, side effects / destructive behavior, and the return value.
- **Parameters** — 100% of input-schema properties now have a `description` with format/constraints, including nested embed/field properties.
- **DRY** — shared schema fragments `EMBED_FIELD_PROPS` (messages) and `WEBHOOK_EMBED_PROPS` (webhooks).
- **Docs** — CONTRIBUTING documents the tool-definition quality bar; `package.json` description updated to `95+ tools`.
- **Version** — bumped to `1.6.0`.

No runtime behavior change: only `definitions` metadata was touched; all `handle()` logic is unchanged.

## Verification
- `npm run build` (tsc) clean.
- Programmatic check: 97 tools, 0 missing annotations, 0 short descriptions, 0 params without a description.
- Built server boots over stdio and serves all 97 tools with annotations (MCP forwarding confirmed).
- Live smoke test against the real bot: full send → edit → read → delete cycle passed in a test channel.

## Note
The Glama score only updates after `1.6.0` is published to npm and Glama re-scans.