### PR TITLE
fix: correct discord_pin_message permission (Pin Messages)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [1.6.1] - 2026-05-29
+
+### Fixed
+- `discord_pin_message` description no longer claims "Requires the Manage Messages permission". Discord introduced a dedicated **Pin Messages** permission in early 2026 (separate from Manage Messages), and discord.js dropped the Manage Messages check from `Message#pinnable`. The tool now points at the correct permission so the model expects the right one (#21)
+
 ## [1.6.0] - 2026-05-28
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@pasympa/discord-mcp",
-  "version": "1.6.0",
+  "version": "1.6.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@pasympa/discord-mcp",
-      "version": "1.6.0",
+      "version": "1.6.1",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.27.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pasympa/discord-mcp",
-  "version": "1.6.0",
+  "version": "1.6.1",
   "description": "A lightweight, multi-guild Discord MCP server with 95+ tools",
   "main": "dist/index.js",
   "type": "commonjs",

--- a/src/tools/messages.ts
+++ b/src/tools/messages.ts
@@ -219,7 +219,7 @@ export const definitions = [
   {
     name: "discord_pin_message",
     description:
-      "Pin or unpin a message in a channel, controlled by the pin flag. Requires the Manage Messages permission. A channel holds at most 50 pins. Idempotent: pinning an already-pinned message (or unpinning an unpinned one) has no additional effect.",
+      "Pin or unpin a message in a channel, controlled by the pin flag. Requires the Pin Messages permission (a dedicated permission since early 2026, separate from Manage Messages). A channel holds at most 50 pins. Idempotent: pinning an already-pinned message (or unpinning an unpinned one) has no additional effect.",
     annotations: { title: "Pin or unpin message", readOnlyHint: false, destructiveHint: false, idempotentHint: true, openWorldHint: true },
     inputSchema: {
       type: "object",


### PR DESCRIPTION
## Summary
Fixes #21 (filed by the discord.js version watcher). The `discord_pin_message` tool description claimed *"Requires the Manage Messages permission"*, which became inaccurate in early 2026: Discord introduced a dedicated **Pin Messages** permission (separate from Manage Messages), and discord.js dropped the Manage Messages check from `Message#pinnable`. Since tool descriptions drive the model's behavior, the stale text could make the assistant expect/request the wrong permission.

## Changes
- **`src/tools/messages.ts`** — `discord_pin_message` description now points at the **Pin Messages** permission (a dedicated permission since early 2026, separate from Manage Messages). No handler change: the tool calls `msg.pin()` / `msg.unpin()` directly.
- **Version** — bumped to `1.6.1` + CHANGELOG entry.

## Verification
- `npm run build` (tsc) clean.
- Confirmed `PermissionsBitField.Flags.PinMessages` (`1 << 51`) is already exposed by the pinned `discord.js@14.25.1`, so no dependency change is required for this fix.

## Note
A separate dependency bump `discord.js ^14.25.1 → ^14.26.x` (hygiene, to align `Message#pinnable` with Discord's new model) is deferred to its own PR — it needs `npm install` to resolve the lockfile, which is currently blocked by network access here. The runtime behavior of this tool is unaffected either way (it doesn't use `pinnable`).