### PR TITLE
chore: gitignore local cruft

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,12 @@
 node_modules/
 dist/
 .env
+
+# OS / editor cruft
+.DS_Store
+
+# Local Claude Code config & artifacts
+.claude/
+
+# Local-only files (not part of the published package)
+.mcp.json


### PR DESCRIPTION
Ignore local-only files that shouldn't be tracked or published:
- `.DS_Store` — macOS Finder cruft
- `.claude/` — local Claude Code config & session artifacts
- `.mcp.json` — local test config (points at `dist/index.js`)

No source or package changes.