### PR TITLE
refactor: drop unused intents, share embed builder, fix custom emoji reactions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,6 @@ dist/
 
 # Local-only files (not part of the published package)
 .mcp.json
+
+# Local audit / review artifacts
+AUDIT_VERIFICATION.md

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## [1.6.2] - 2026-05-29
+
+### Fixed
+- `discord_get_reactions` / `discord_remove_reactions` now resolve custom emoji passed as `name:id`. The reaction cache is keyed by the emoji id (custom) or the unicode char (standard) — not the `name:id` form the tool schema accepts — so custom-emoji lookups previously failed with "No reaction found" even when the reaction existed. A new `findReaction()` helper normalizes the emoji to the cache key (handles `name:id`, `<:name:id>`, `<a:name:id>`, raw id, and unicode) (#25)
+- The role tools (`discord_edit_role`, `discord_delete_role`, `discord_get_role_members`, `discord_set_role_position`, `discord_set_role_icon`) now return a clear "Role not found" error for an unknown `role_id` instead of crashing on a null dereference — removed the misleading `as Role` cast that hid the `| null` return of `guild.roles.fetch()` (#25)
+
+### Changed
+- Dropped the unused `GuildModeration` and `GuildInvites` gateway intents. All ban/invite operations are REST-only and no code subscribes to their gateway events, so requesting them only widened the gateway footprint. `MessageContent`, `GuildMembers`, and `GuildScheduledEvents` are kept (actually consumed) (#25)
+- Extracted a shared `buildEmbed()` + `EMBED_FIELD_PROPS` into `src/embeds.ts`, removing three drifting copies across the message, DM, and webhook tools (#25)
+- Added a `deserializePermissions()` helper (inverse of `serializePermissions`), reused by `discord_create_role` and `discord_edit_role` instead of an inline `PermissionsBitField` expression duplicated twice (#25)
+
 ## [1.6.1] - 2026-05-29
 
 ### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@pasympa/discord-mcp",
-  "version": "1.6.1",
+  "version": "1.6.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@pasympa/discord-mcp",
-      "version": "1.6.1",
+      "version": "1.6.2",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.27.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pasympa/discord-mcp",
-  "version": "1.6.1",
+  "version": "1.6.2",
   "description": "A lightweight, multi-guild Discord MCP server with 95+ tools",
   "main": "dist/index.js",
   "type": "commonjs",

--- a/src/client.ts
+++ b/src/client.ts
@@ -21,9 +21,7 @@ export const discord = new Client({
     GatewayIntentBits.GuildMessages,
     GatewayIntentBits.MessageContent,
     GatewayIntentBits.GuildMembers,
-    GatewayIntentBits.GuildModeration,
     GatewayIntentBits.GuildScheduledEvents,
-    GatewayIntentBits.GuildInvites,
   ],
 });
 
@@ -112,5 +110,17 @@ export function validateId(value: unknown, label: string): string {
 export function serializePermissions(perms: Readonly<PermissionsBitField>): string[] {
   return Object.keys(PermissionsBitField.Flags).filter((flag) =>
     perms.has(flag as keyof typeof PermissionsBitField.Flags)
+  );
+}
+
+/**
+ * Builds a PermissionsBitField from an array of permission flag names.
+ * Inverse of {@link serializePermissions}.
+ * @param names - Permission flag names (e.g. ["SendMessages", "ViewChannel"]).
+ * @returns A PermissionsBitField with those flags set.
+ */
+export function deserializePermissions(names: string[]): PermissionsBitField {
+  return new PermissionsBitField(
+    names.map((p) => PermissionsBitField.Flags[p as keyof typeof PermissionsBitField.Flags])
   );
 }

--- a/src/embeds.ts
+++ b/src/embeds.ts
@@ -1,0 +1,61 @@
+import { EmbedBuilder, ColorResolvable } from "discord.js";
+
+/**
+ * Builds an EmbedBuilder from a flat args object.
+ * Shared by the message, DM, and webhook embed tools.
+ */
+export function buildEmbed(args: Record<string, unknown>): EmbedBuilder {
+  const embed = new EmbedBuilder();
+  if (args.title) embed.setTitle(args.title as string);
+  if (args.url) embed.setURL(args.url as string);
+  if (args.description) embed.setDescription(args.description as string);
+  if (args.color) embed.setColor(args.color as ColorResolvable);
+  if (args.footer) embed.setFooter({ text: args.footer as string });
+  if (args.image_url) embed.setImage(args.image_url as string);
+  if (args.thumbnail_url) embed.setThumbnail(args.thumbnail_url as string);
+  if (args.timestamp) embed.setTimestamp();
+  if (args.author) {
+    const a = args.author as { name: string; icon_url?: string; url?: string };
+    embed.setAuthor({ name: a.name, iconURL: a.icon_url, url: a.url });
+  }
+  if (args.fields) {
+    const fields = args.fields as { name: string; value: string; inline?: boolean }[];
+    embed.addFields(fields.map((f) => ({ name: f.name, value: f.value, inline: f.inline ?? false })));
+  }
+  return embed;
+}
+
+/** Reusable input-schema fragment for a rich embed's fields (shared by send/edit/multiple embed tools). */
+export const EMBED_FIELD_PROPS = {
+  title: { type: "string", description: "Embed title shown in bold at the top." },
+  url: { type: "string", description: "URL that makes the title clickable." },
+  description: { type: "string", description: "Main body text of the embed (supports Markdown)." },
+  color: { type: "string", description: "Side-bar color as a hex string, e.g. '#5865F2'." },
+  fields: {
+    type: "array",
+    description: "Up to 25 name/value field blocks. Set inline:true on a field to render it side-by-side with adjacent inline fields (up to 3 per row).",
+    items: {
+      type: "object",
+      properties: {
+        name: { type: "string", description: "Field heading." },
+        value: { type: "string", description: "Field body text." },
+        inline: { type: "boolean", description: "If true, render this field side-by-side with adjacent inline fields." },
+      },
+      required: ["name", "value"],
+    },
+  },
+  author: {
+    type: "object",
+    description: "Author block shown at the top of the embed.",
+    properties: {
+      name: { type: "string", description: "Author display name." },
+      icon_url: { type: "string", description: "Small icon shown next to the author name." },
+      url: { type: "string", description: "URL the author name links to." },
+    },
+    required: ["name"],
+  },
+  thumbnail_url: { type: "string", description: "Small image shown in the top-right corner." },
+  footer: { type: "string", description: "Footer text shown at the bottom of the embed." },
+  image_url: { type: "string", description: "Large image shown below the embed body." },
+  timestamp: { type: "boolean", description: "If true, stamp the embed with the current time." },
+} as const;

--- a/src/tools/dm.ts
+++ b/src/tools/dm.ts
@@ -1,63 +1,6 @@
-import { EmbedBuilder, ColorResolvable } from "discord.js";
 import { discord, validateId } from "../client.js";
+import { buildEmbed, EMBED_FIELD_PROPS } from "../embeds.js";
 import type { ToolModule, ToolResult } from "./types.js";
-
-/** Builds an EmbedBuilder from a flat args object. */
-function buildEmbed(args: Record<string, unknown>): EmbedBuilder {
-  const embed = new EmbedBuilder();
-  if (args.title) embed.setTitle(args.title as string);
-  if (args.url) embed.setURL(args.url as string);
-  if (args.description) embed.setDescription(args.description as string);
-  if (args.color) embed.setColor(args.color as ColorResolvable);
-  if (args.footer) embed.setFooter({ text: args.footer as string });
-  if (args.image_url) embed.setImage(args.image_url as string);
-  if (args.thumbnail_url) embed.setThumbnail(args.thumbnail_url as string);
-  if (args.timestamp) embed.setTimestamp();
-  if (args.author) {
-    const a = args.author as { name: string; icon_url?: string; url?: string };
-    embed.setAuthor({ name: a.name, iconURL: a.icon_url, url: a.url });
-  }
-  if (args.fields) {
-    const fields = args.fields as { name: string; value: string; inline?: boolean }[];
-    embed.addFields(fields.map((f) => ({ name: f.name, value: f.value, inline: f.inline ?? false })));
-  }
-  return embed;
-}
-
-/** Embed input schema properties (shared across embed tools). */
-const embedProperties = {
-  title: { type: "string", description: "Embed title shown in bold at the top." },
-  url: { type: "string", description: "URL that makes the title clickable." },
-  description: { type: "string", description: "Main body text of the embed (supports Markdown)." },
-  color: { type: "string", description: "Side-bar color as a hex string, e.g. '#5865F2'." },
-  fields: {
-    type: "array",
-    description: "Up to 25 name/value field blocks. Set inline:true to render up to 3 side-by-side.",
-    items: {
-      type: "object",
-      properties: {
-        name: { type: "string", description: "Field heading." },
-        value: { type: "string", description: "Field body text." },
-        inline: { type: "boolean", description: "If true, render this field side-by-side with adjacent inline fields." },
-      },
-      required: ["name", "value"],
-    },
-  },
-  author: {
-    type: "object",
-    description: "Author block shown at the top of the embed.",
-    properties: {
-      name: { type: "string", description: "Author display name." },
-      icon_url: { type: "string", description: "Small icon shown next to the author name." },
-      url: { type: "string", description: "URL the author name links to." },
-    },
-    required: ["name"],
-  },
-  thumbnail_url: { type: "string", description: "Small image shown in the top-right corner." },
-  footer: { type: "string", description: "Footer text shown at the bottom of the embed." },
-  image_url: { type: "string", description: "Large image shown below the embed body." },
-  timestamp: { type: "boolean", description: "If true, stamp the embed with the current time." },
-} as const;
 
 const userIdProp = {
   user_id: { type: "string", description: "Discord user ID (snowflake) of the DM recipient." },
@@ -93,7 +36,7 @@ export const definitions = [
       properties: {
         ...userIdProp,
         content: { type: "string", description: "Optional plain text shown above the embed." },
-        ...embedProperties,
+        ...EMBED_FIELD_PROPS,
       },
       required: ["user_id"],
     },
@@ -124,7 +67,7 @@ export const definitions = [
         ...userIdProp,
         ...messageIdProp,
         content: { type: "string", description: "Optional new plain text shown above the embed." },
-        ...embedProperties,
+        ...EMBED_FIELD_PROPS,
       },
       required: ["user_id", "message_id"],
     },

--- a/src/tools/messages.ts
+++ b/src/tools/messages.ts
@@ -1,49 +1,15 @@
 import {
-  EmbedBuilder,
-  ColorResolvable,
   ChannelType,
   TextChannel,
   PublicThreadChannel,
   PrivateThreadChannel,
+  Message,
+  MessageReaction,
 } from "discord.js";
 import { discord, getTextChannel } from "../client.js";
 import { MAX_FETCH_LIMIT, DEFAULTS } from "../constants.js";
+import { buildEmbed, EMBED_FIELD_PROPS } from "../embeds.js";
 import type { ToolModule, ToolResult } from "./types.js";
-
-/** Reusable input-schema fragment for a rich embed's fields (shared by send/edit/multiple embed tools). */
-const EMBED_FIELD_PROPS = {
-  title: { type: "string", description: "Embed title shown in bold at the top." },
-  url: { type: "string", description: "URL that makes the title clickable." },
-  description: { type: "string", description: "Main body text of the embed (supports Markdown)." },
-  color: { type: "string", description: "Side-bar color as a hex string, e.g. '#5865F2'." },
-  fields: {
-    type: "array",
-    description: "Up to 25 name/value field blocks rendered as a grid.",
-    items: {
-      type: "object",
-      properties: {
-        name: { type: "string", description: "Field heading." },
-        value: { type: "string", description: "Field body text." },
-        inline: { type: "boolean", description: "If true, render this field side-by-side with adjacent inline fields." },
-      },
-      required: ["name", "value"],
-    },
-  },
-  author: {
-    type: "object",
-    description: "Author block shown at the top of the embed.",
-    properties: {
-      name: { type: "string", description: "Author display name." },
-      icon_url: { type: "string", description: "Small icon shown next to the author name." },
-      url: { type: "string", description: "URL the author name links to." },
-    },
-    required: ["name"],
-  },
-  thumbnail_url: { type: "string", description: "Small image shown in the top-right corner." },
-  footer: { type: "string", description: "Footer text shown at the bottom of the embed." },
-  image_url: { type: "string", description: "Large image shown below the embed body." },
-  timestamp: { type: "boolean", description: "If true, stamp the embed with the current time." },
-} as const;
 
 /** Tool definitions for reading, sending, replying, editing, reacting, threading, embedding, deleting, pinning, and searching messages. */
 export const definitions = [
@@ -322,26 +288,16 @@ export const definitions = [
   },
 ];
 
-/** Builds an EmbedBuilder from a flat args object. */
-function buildEmbed(args: Record<string, unknown>): EmbedBuilder {
-  const embed = new EmbedBuilder();
-  if (args.title) embed.setTitle(args.title as string);
-  if (args.url) embed.setURL(args.url as string);
-  if (args.description) embed.setDescription(args.description as string);
-  if (args.color) embed.setColor(args.color as ColorResolvable);
-  if (args.footer) embed.setFooter({ text: args.footer as string });
-  if (args.image_url) embed.setImage(args.image_url as string);
-  if (args.thumbnail_url) embed.setThumbnail(args.thumbnail_url as string);
-  if (args.timestamp) embed.setTimestamp();
-  if (args.author) {
-    const a = args.author as { name: string; icon_url?: string; url?: string };
-    embed.setAuthor({ name: a.name, iconURL: a.icon_url, url: a.url });
-  }
-  if (args.fields) {
-    const fields = args.fields as { name: string; value: string; inline?: boolean }[];
-    embed.addFields(fields.map((f) => ({ name: f.name, value: f.value, inline: f.inline ?? false })));
-  }
-  return embed;
+/**
+ * Looks up a reaction on a message by emoji argument.
+ * The reaction cache is keyed by the emoji id (snowflake) for custom emoji and
+ * by the raw unicode char for standard emoji — NOT by the "name:id" / "<:name:id>"
+ * form the tool schema accepts — so a custom emoji is normalized to its id first.
+ */
+function findReaction(msg: Message, emoji: string): MessageReaction | undefined {
+  const customId = emoji.match(/^<a?:[^:]+:(\d{17,20})>$|^[^:]+:(\d{17,20})$/);
+  const key = customId ? (customId[1] ?? customId[2]) : emoji;
+  return msg.reactions.cache.get(key);
 }
 
 /**
@@ -489,7 +445,7 @@ export async function handle(name: string, args: Record<string, unknown>): Promi
         await msg.reactions.removeAll();
         return { content: [{ type: "text", text: `✅ All reactions removed from message ${msg.id}.` }] };
       }
-      const reaction = msg.reactions.cache.get(args.emoji as string);
+      const reaction = findReaction(msg, args.emoji as string);
       if (!reaction) throw new Error(`No reaction found for emoji "${args.emoji}" on message ${msg.id}.`);
       if (args.user_id) {
         await reaction.users.remove(args.user_id as string);
@@ -502,7 +458,7 @@ export async function handle(name: string, args: Record<string, unknown>): Promi
     case "discord_get_reactions": {
       const channel = await getTextChannel(args.channel_id as string);
       const msg = await channel.messages.fetch(args.message_id as string);
-      const reaction = msg.reactions.cache.get(args.emoji as string);
+      const reaction = findReaction(msg, args.emoji as string);
       if (!reaction) throw new Error(`No reaction found for emoji "${args.emoji}" on message ${msg.id}.`);
       const limit = Math.min(Number(args.limit ?? DEFAULTS.LIMIT), MAX_FETCH_LIMIT);
       const users = await reaction.users.fetch({ limit });

--- a/src/tools/roles.ts
+++ b/src/tools/roles.ts
@@ -1,5 +1,5 @@
-import { PermissionsBitField, ColorResolvable, Role } from "discord.js";
-import { discord, serializePermissions, validateId } from "../client.js";
+import { ColorResolvable, Role, Guild } from "discord.js";
+import { discord, serializePermissions, deserializePermissions, validateId } from "../client.js";
 import type { ToolModule, ToolResult } from "./types.js";
 
 /** Tool definitions for creating, editing, deleting, and assigning roles. */
@@ -157,6 +157,17 @@ function parsePerms(raw: unknown): string[] | undefined {
 }
 
 /**
+ * Validates a role_id argument, fetches the role, and guarantees it exists.
+ * @throws {Error} If the id is not a valid snowflake or the role is not found.
+ */
+async function fetchRole(guild: Guild, rawId: unknown): Promise<Role> {
+  const id = validateId(rawId, "role_id");
+  const role = await guild.roles.fetch(id);
+  if (!role) throw new Error(`Role ${id} not found in this server.`);
+  return role;
+}
+
+/**
  * Handles role tools: list all roles, CRUD operations,
  * assign/remove from members, and list members by role.
  */
@@ -184,32 +195,28 @@ export async function handle(name: string, args: Record<string, unknown>): Promi
         color: args.color as ColorResolvable | undefined,
         hoist: args.hoist as boolean | undefined,
         mentionable: args.mentionable as boolean | undefined,
-        permissions: perms
-          ? new PermissionsBitField(perms.map((p) => PermissionsBitField.Flags[p as keyof typeof PermissionsBitField.Flags]))
-          : undefined,
+        permissions: perms ? deserializePermissions(perms) : undefined,
       });
       return { content: [{ type: "text", text: `✅ Role "${role.name}" created (id: ${role.id}).` }] };
     }
 
     case "discord_edit_role": {
       const guild = await discord.guilds.fetch(validateId(args.guild_id, "guild_id"));
-      const role = await guild.roles.fetch(args.role_id as string) as Role;
+      const role = await fetchRole(guild, args.role_id);
       const perms = parsePerms(args.permissions);
       await role.edit({
         name: args.name as string | undefined,
         color: args.color as ColorResolvable | undefined,
         hoist: args.hoist as boolean | undefined,
         mentionable: args.mentionable as boolean | undefined,
-        permissions: perms
-          ? new PermissionsBitField(perms.map((p) => PermissionsBitField.Flags[p as keyof typeof PermissionsBitField.Flags]))
-          : undefined,
+        permissions: perms ? deserializePermissions(perms) : undefined,
       });
       return { content: [{ type: "text", text: `✅ Role "${role.name}" updated.` }] };
     }
 
     case "discord_delete_role": {
       const guild = await discord.guilds.fetch(validateId(args.guild_id, "guild_id"));
-      const role = await guild.roles.fetch(args.role_id as string) as Role;
+      const role = await fetchRole(guild, args.role_id);
       await role.delete(args.reason as string | undefined);
       return { content: [{ type: "text", text: `✅ Role "${role.name}" deleted.` }] };
     }
@@ -231,21 +238,21 @@ export async function handle(name: string, args: Record<string, unknown>): Promi
     case "discord_get_role_members": {
       const guild = await discord.guilds.fetch(validateId(args.guild_id, "guild_id"));
       await guild.members.list({ limit: 1000 });
-      const role = await guild.roles.fetch(args.role_id as string) as Role;
+      const role = await fetchRole(guild, args.role_id);
       const members = role.members.map((m) => ({ id: m.id, username: m.user.tag, nickname: m.nickname }));
       return { content: [{ type: "text", text: JSON.stringify(members, null, 2) }] };
     }
 
     case "discord_set_role_position": {
       const guild = await discord.guilds.fetch(validateId(args.guild_id, "guild_id"));
-      const role = await guild.roles.fetch(args.role_id as string) as Role;
+      const role = await fetchRole(guild, args.role_id);
       await role.setPosition(args.position as number);
       return { content: [{ type: "text", text: `✅ Role "${role.name}" moved to position ${args.position}.` }] };
     }
 
     case "discord_set_role_icon": {
       const guild = await discord.guilds.fetch(validateId(args.guild_id, "guild_id"));
-      const role = await guild.roles.fetch(args.role_id as string) as Role;
+      const role = await fetchRole(guild, args.role_id);
       if (args.icon !== undefined) {
         await role.setIcon(args.icon === "null" || args.icon === null ? null : args.icon as string);
       }

--- a/src/tools/webhooks.ts
+++ b/src/tools/webhooks.ts
@@ -1,5 +1,6 @@
-import { WebhookClient, EmbedBuilder, ColorResolvable } from "discord.js";
+import { WebhookClient } from "discord.js";
 import { discord, validateId } from "../client.js";
+import { buildEmbed } from "../embeds.js";
 import type { ToolModule, ToolResult } from "./types.js";
 
 /** Embed input-schema fragment for webhook messages (shared by send/edit webhook-message tools). */
@@ -160,24 +161,6 @@ export const definitions = [
   },
 ];
 
-/** Builds an EmbedBuilder from a webhook embed arg object. */
-function buildWebhookEmbed(args: Record<string, unknown>): EmbedBuilder {
-  const embed = new EmbedBuilder();
-  if (args.title) embed.setTitle(args.title as string);
-  if (args.url) embed.setURL(args.url as string);
-  if (args.description) embed.setDescription(args.description as string);
-  if (args.color) embed.setColor(args.color as ColorResolvable);
-  if (args.footer) embed.setFooter({ text: args.footer as string });
-  if (args.image_url) embed.setImage(args.image_url as string);
-  if (args.thumbnail_url) embed.setThumbnail(args.thumbnail_url as string);
-  if (args.timestamp) embed.setTimestamp();
-  if (args.fields) {
-    const fields = args.fields as { name: string; value: string; inline?: boolean }[];
-    embed.addFields(fields.map((f) => ({ name: f.name, value: f.value, inline: f.inline ?? false })));
-  }
-  return embed;
-}
-
 /**
  * Handles webhook tools: create, send message via webhook,
  * edit, delete, and list webhooks.
@@ -212,7 +195,7 @@ export async function handle(name: string, args: Record<string, unknown>): Promi
         if (args.embeds) {
           const embedArgs = args.embeds as Record<string, unknown>[];
           if (embedArgs.length > 10) throw new Error("Discord allows a maximum of 10 embeds per message.");
-          sendOptions.embeds = embedArgs.map((e) => buildWebhookEmbed(e));
+          sendOptions.embeds = embedArgs.map((e) => buildEmbed(e));
         }
         if (!sendOptions.content && !sendOptions.embeds) {
           throw new Error("At least one of content or embeds is required.");
@@ -282,7 +265,7 @@ export async function handle(name: string, args: Record<string, unknown>): Promi
         if (args.content !== undefined) editOptions.content = args.content as string;
         if (args.embeds) {
           const embedArgs = args.embeds as Record<string, unknown>[];
-          editOptions.embeds = embedArgs.map((e) => buildWebhookEmbed(e));
+          editOptions.embeds = embedArgs.map((e) => buildEmbed(e));
         }
         await client.editMessage(args.message_id as string, editOptions);
         return { content: [{ type: "text", text: `✅ Webhook message ${args.message_id} edited.` }] };


### PR DESCRIPTION
Issues #1 et #2 de l'audit. **Ne pas merger sans review.**

## #1 — Quick wins (faible risque)

- **`client.ts` — retrait des intents `GuildModeration` + `GuildInvites`.** Les intents ne contrôlent que les *événements* gateway poussés au bot, pas les appels REST. Le serveur est REST-only (seul listener : `ready`), et aucun code ne s'abonne aux événements ban/invite. Les outils `ban_member`, `list/create/delete_invite`, etc. fonctionnent à l'identique. `MessageContent`, `GuildMembers`, `GuildScheduledEvents` sont conservés (réellement consommés).
- **`src/embeds.ts` (nouveau) — `buildEmbed()` + `EMBED_FIELD_PROPS` partagés.** Supprime les 3 copies (`messages.ts`, `dm.ts`, `webhooks.ts`) qui avaient déjà divergé (descriptions des `fields`). Note : `webhooks.ts` utilise désormais le builder partagé (qui supporte `author`) ; le schéma `WEBHOOK_EMBED_PROPS` reste inchangé donc aucune modif de surface advertised.
- **`client.ts` — `deserializePermissions()`** (symétrique de `serializePermissions`), réutilisé dans `roles.ts` create/edit au lieu de l'expression `PermissionsBitField` inline dupliquée 2×.

## #2 — Corrections

- **`messages.ts` — bug réactions emoji custom.** `discord_get_reactions` / `discord_remove_reactions` faisaient `msg.reactions.cache.get(emoji)`, mais le cache est indexé par **id d'emoji** (custom) ou **char unicode** — pas le format `name:id` que le schéma accepte. Résultat : un emoji custom passé en `name:id` ratait toujours le cache → « No reaction found » alors que la réaction existe. Confirmé par la doc discord.js (`ReactionManager` keyé `Snowflake | string`). Nouveau `findReaction()` normalise vers la clé du cache (gère `name:id`, `<:name:id>`, `<a:name:id>`, id brut, unicode).
- **`roles.ts` — null-guard.** Suppression du cast `as Role` sur `guild.roles.fetch()` qui masquait le `| null` (un `role_id` inexistant crashait en « Cannot read properties of null » au lieu d'un message clair). Nouveau helper `fetchRole()` valide le snowflake et lève « Role <id> not found ».

## Vérifications

- `npm run build` ✅
- Aucune référence morte (`buildWebhookEmbed`, `embedProperties`, …)
- Regex `findReaction` testée sur 6 cas (unicode, `name:id`, `<:name:id>`, `<a:name:id>`, id brut, drapeau régional)

## Hors scope (audit, à traiter séparément)
`get_role_members` plafonné à 1000, `formatToolError` (codes Discord), résilience de connexion, zod, tests/CI.