### PR TITLE
fix: verified audit findings — pagination, resilience, error codes, validation (1.7.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,23 @@
 # Changelog
 
+## [1.7.0] - 2026-05-29
+
+### Fixed
+- `discord_get_role_members` no longer silently truncates at 1000 members. Discord has no "members of a role" endpoint, so it now paginates the full roster (1000/page, capped at 20 pages) before filtering, and returns a `truncated` flag when the cap is hit on very large servers
+- `discord_list_bans` is now paginated. A single fetch only ever returned the first page (≤1000) while the description claimed it fetched all; it now returns `{ bans, nextCursor }` and accepts an `after` cursor
+- `discord_fetch_pinned_messages` migrated from the deprecated `MessageManager#fetchPinned()` (removed in discord.js v15) to `fetchPins()`, and now also returns `pinnedAt`
+- `discord_timeout_member` and `discord_prune_members` validate their numeric inputs (`duration_minutes`, `days`) instead of casting blindly, rejecting NaN / out-of-range values with a clear error
+
+### Changed
+- Renamed the `ready` gateway listener to `clientReady` — forward-compatible with discord.js v15 (where `ready` no longer fires) and silences the v14 deprecation warning
+- Connection robustness: login now races a 30s READY timeout (no more indefinite hangs), resets its in-flight state on failure so the next call retries, and registers `error` / `shardError` / `invalidated` listeners (an unhandled client error could previously crash the process). REST retries/timeout configured; process-level `unhandledRejection` / `uncaughtException` handlers added
+- Tool errors now surface the underlying `DiscordAPIError` code + HTTP status with a plain-language hint (e.g. 50013 → missing permission, 10008 → unknown message) instead of a bare message
+- Cursor pagination on large lists: `discord_list_members`, `discord_get_event_subscribers`, and `discord_list_forum_threads` now return a cursor (`nextCursor` / `nextBefore` + `hasMore`) and accept `after` / `before` to page, instead of silently returning only the first page. These tools now return an object (`{ items, nextCursor }`) rather than a bare array
+- Uniform snowflake validation: `getTextChannel` / `getGuildChannel` validate `channel_id` internally, and `user_id` / `role_id` are validated in the member and role tools (and `discord_delete_channel`), so malformed IDs give a clear error instead of an opaque API failure
+- Numeric inputs (`limit`, `count`, `delete_message_days`, audit-log/forum/DM limits, …) are coerced and clamped via shared `clampInt` / `validateInt` helpers, preventing NaN from reaching the Discord API
+- Read-only message fetches (`discord_read_messages`, `discord_search_messages`) pass `{ cache: false }` to avoid unbounded message-cache growth
+- `discord_bulk_ban` is now safe-by-default with a `dry_run` flag (previews the resolved user IDs; set `dry_run:false` to actually ban), mirroring `discord_prune_members`, and validates each user ID
+
 ## [1.6.2] - 2026-05-29
 
 ### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@pasympa/discord-mcp",
-  "version": "1.6.2",
+  "version": "1.7.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@pasympa/discord-mcp",
-      "version": "1.6.2",
+      "version": "1.7.0",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.27.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pasympa/discord-mcp",
-  "version": "1.6.2",
+  "version": "1.7.0",
   "description": "A lightweight, multi-guild Discord MCP server with 95+ tools",
   "main": "dist/index.js",
   "type": "commonjs",

--- a/src/client.ts
+++ b/src/client.ts
@@ -1,6 +1,7 @@
 import "dotenv/config";
 import {
   Client,
+  Events,
   GatewayIntentBits,
   TextChannel,
   ThreadChannel,
@@ -15,6 +16,9 @@ import {
 
 const DISCORD_TOKEN = process.env.DISCORD_TOKEN;
 
+/** Maximum time to wait for the gateway to reach READY before giving up. */
+const LOGIN_TIMEOUT_MS = 30_000;
+
 export const discord = new Client({
   intents: [
     GatewayIntentBits.Guilds,
@@ -23,10 +27,20 @@ export const discord = new Client({
     GatewayIntentBits.GuildMembers,
     GatewayIntentBits.GuildScheduledEvents,
   ],
+  rest: { retries: 3, timeout: 15_000 },
 });
 
 let discordReady = false;
 let loginPromise: Promise<void> | null = null;
+
+// Without an 'error' listener, an emitted client error crashes the Node process.
+discord.on(Events.Error, (err) => console.error("Discord client error:", err.message));
+discord.on(Events.ShardError, (err) => console.error("Discord shard error:", err.message));
+discord.on(Events.Invalidated, () => {
+  console.error("Discord session invalidated — connection is dead; the next tool call will re-login.");
+  discordReady = false;
+  loginPromise = null;
+});
 
 // ─── Helpers ───────────────────────────────────────────────────────────────────
 
@@ -45,12 +59,23 @@ export async function ensureConnected(): Promise<void> {
 
   if (!loginPromise) {
     loginPromise = new Promise<void>((resolve, reject) => {
-      discord.once("ready", () => {
+      const onReady = () => {
+        clearTimeout(timer);
         discordReady = true;
         console.error(`✅  Discord bot connected as ${discord.user?.tag}`);
         resolve();
-      });
+      };
+      const timer = setTimeout(() => {
+        discord.off(Events.ClientReady, onReady);
+        loginPromise = null;
+        reject(new Error(
+          `Discord did not reach READY within ${LOGIN_TIMEOUT_MS / 1000}s. Check the token and that the Server Members / Message Content privileged intents are enabled in the Developer Portal.`
+        ));
+      }, LOGIN_TIMEOUT_MS);
+      discord.once(Events.ClientReady, onReady);
       discord.login(DISCORD_TOKEN).catch((err) => {
+        clearTimeout(timer);
+        discord.off(Events.ClientReady, onReady);
         loginPromise = null;
         reject(new Error(`Discord login failed: ${err.message}`));
       });
@@ -70,9 +95,10 @@ export async function ensureConnected(): Promise<void> {
  * @throws {Error} If the channel does not exist or is neither a text channel nor a thread.
  */
 export async function getTextChannel(channelId: string): Promise<TextChannel | ThreadChannel> {
-  const channel = await discord.channels.fetch(channelId);
+  const id = validateId(channelId, "channel_id");
+  const channel = await discord.channels.fetch(id);
   if (!channel || (!(channel instanceof TextChannel) && !(channel instanceof ThreadChannel)))
-    throw new Error(`Channel ${channelId} is not a text or thread channel or doesn't exist.`);
+    throw new Error(`Channel ${id} is not a text or thread channel or doesn't exist.`);
   return channel;
 }
 
@@ -83,9 +109,10 @@ export async function getTextChannel(channelId: string): Promise<TextChannel | T
  * @throws {Error} If the channel does not exist or is not a guild channel.
  */
 export async function getGuildChannel(channelId: string): Promise<GuildChannel> {
-  const channel = await discord.channels.fetch(channelId);
+  const id = validateId(channelId, "channel_id");
+  const channel = await discord.channels.fetch(id);
   if (!channel || !(channel instanceof GuildChannel))
-    throw new Error(`Channel ${channelId} is not a guild channel or doesn't exist.`);
+    throw new Error(`Channel ${id} is not a guild channel or doesn't exist.`);
   return channel;
 }
 
@@ -100,6 +127,35 @@ export function validateId(value: unknown, label: string): string {
   const id = String(value ?? "");
   if (!/^\d{17,20}$/.test(id)) throw new Error(`Invalid ${label}: "${id}". Must be a Discord snowflake ID (17-20 digits).`);
   return id;
+}
+
+/**
+ * Coerces a value to an integer clamped to [min, max], using fallback when it is not a finite number.
+ * @param value - The raw value to coerce.
+ * @param min - Lower bound (inclusive).
+ * @param max - Upper bound (inclusive).
+ * @param fallback - Returned when value is missing or non-numeric.
+ */
+export function clampInt(value: unknown, min: number, max: number, fallback: number): number {
+  const n = Number(value);
+  if (!Number.isFinite(n)) return fallback;
+  return Math.min(Math.max(Math.trunc(n), min), max);
+}
+
+/**
+ * Validates a value is a finite integer within [min, max].
+ * @param value - The raw value to validate.
+ * @param min - Lower bound (inclusive).
+ * @param max - Upper bound (inclusive).
+ * @param label - Human-readable label used in the error message.
+ * @throws {Error} If the value is not an integer in range.
+ */
+export function validateInt(value: unknown, min: number, max: number, label: string): number {
+  const n = Number(value);
+  if (!Number.isInteger(n) || n < min || n > max) {
+    throw new Error(`Invalid ${label}: "${String(value)}". Must be an integer between ${min} and ${max}.`);
+  }
+  return n;
 }
 
 /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,10 +13,35 @@ import {
   ListToolsRequestSchema,
 } from "@modelcontextprotocol/sdk/types.js";
 
+import { DiscordAPIError } from "discord.js";
 import { readFileSync } from "fs";
 import { join } from "path";
 import { ensureConnected, discord } from "./client.js";
 import { getAllDefinitions, handleTool } from "./tools/index.js";
+
+/** Plain-language hints for the Discord API error codes most likely to surface through these tools. */
+const DISCORD_ERROR_HINTS: Record<number, string> = {
+  10003: "Unknown channel — check channel_id.",
+  10004: "Unknown guild — the bot is not in that server or guild_id is wrong.",
+  10008: "Unknown message — wrong message_id, or it was already deleted.",
+  10011: "Unknown role — check role_id.",
+  10013: "Unknown user — check user_id.",
+  10026: "Unknown ban — the user is not banned.",
+  50001: "Missing access — the bot is not in the guild or cannot see this channel.",
+  50013: "Missing permissions — the bot lacks the permission this action requires.",
+  50035: "Invalid form body — one or more arguments are invalid.",
+};
+
+/** Formats an error for the MCP client, surfacing DiscordAPIError code/status and an actionable hint. */
+function formatToolError(err: unknown): string {
+  if (err instanceof DiscordAPIError) {
+    const code = Number(err.code);
+    const hint = DISCORD_ERROR_HINTS[code];
+    const base = `Discord API error ${err.code} (HTTP ${err.status}): ${err.message}`;
+    return hint ? `${base} — ${hint}` : base;
+  }
+  return err instanceof Error ? err.message : String(err);
+}
 
 const pkg = JSON.parse(readFileSync(join(__dirname, "..", "package.json"), "utf-8"));
 const version: string = pkg.version;
@@ -43,8 +68,7 @@ server.setRequestHandler(CallToolRequestSchema, async (req) => {
     await ensureConnected();
     return await handleTool(name, args);
   } catch (err: unknown) {
-    const message = err instanceof Error ? err.message : String(err);
-    return { content: [{ type: "text", text: `❌ Error: ${message}` }], isError: true };
+    return { content: [{ type: "text", text: `❌ Error: ${formatToolError(err)}` }], isError: true };
   }
 });
 
@@ -64,5 +88,7 @@ function shutdown() {
 
 process.on("SIGINT", shutdown);
 process.on("SIGTERM", shutdown);
+process.on("unhandledRejection", (reason) => console.error("Unhandled rejection:", reason));
+process.on("uncaughtException", (err) => console.error("Uncaught exception:", err));
 
 main().catch((err) => { console.error("Fatal:", err); discord.destroy(); process.exit(1); });

--- a/src/tools/channels.ts
+++ b/src/tools/channels.ts
@@ -144,7 +144,7 @@ export async function handle(name: string, args: Record<string, unknown>): Promi
     }
 
     case "discord_delete_channel": {
-      const channel = await discord.channels.fetch(args.channel_id as string);
+      const channel = await discord.channels.fetch(validateId(args.channel_id, "channel_id"));
       if (!channel) throw new Error("Channel not found.");
       const channelName = "name" in channel ? channel.name : channel.id;
       await channel.delete(args.reason as string | undefined);

--- a/src/tools/dm.ts
+++ b/src/tools/dm.ts
@@ -1,4 +1,4 @@
-import { discord, validateId } from "../client.js";
+import { discord, validateId, clampInt } from "../client.js";
 import { buildEmbed, EMBED_FIELD_PROPS } from "../embeds.js";
 import type { ToolModule, ToolResult } from "./types.js";
 
@@ -176,7 +176,7 @@ async function handle(
     case "discord_read_dms": {
       const user = await discord.users.fetch(validateId(args.user_id, "user_id"));
       const dm = await user.createDM();
-      const limit = Math.min(Math.max(Number(args.limit ?? 20), 1), 100);
+      const limit = clampInt(args.limit, 1, 100, 20);
       const messages = await dm.messages.fetch({ limit });
       const result = [...messages.values()]
         .sort((a, b) => a.createdTimestamp - b.createdTimestamp)

--- a/src/tools/forums.ts
+++ b/src/tools/forums.ts
@@ -1,5 +1,5 @@
 import { ChannelType, ForumChannel, ThreadChannel } from "discord.js";
-import { discord, validateId } from "../client.js";
+import { discord, validateId, clampInt } from "../client.js";
 import type { ToolModule, ToolResult } from "./types.js";
 
 /** Tool definitions for managing forum channels, posts, tags, and threads. */
@@ -70,12 +70,14 @@ export const definitions = [
   {
     name: "discord_list_forum_threads",
     description:
-      "List every post in a forum channel, both active and archived (id, name, state, tags, message count). Read-only. Use discord_get_forum_post to read one post's messages.",
+      "List posts in a forum channel. Returns { threads: [...], hasMore, nextBefore }. The first call (no `before`) includes all active posts plus the first page of archived posts; archived posts are paginated, so if hasMore is true pass nextBefore back as `before` to fetch older archived posts. Read-only. Use discord_get_forum_post to read one post's messages.",
     annotations: { title: "List forum threads", readOnlyHint: true, openWorldHint: true },
     inputSchema: {
       type: "object",
       properties: {
         forum_channel_id: { type: "string", description: "ID (snowflake) of the forum channel to list posts from." },
+        limit: { type: "number", description: "Max archived posts per page (1–100). Default 100." },
+        before: { type: "string", description: "Pagination cursor: an ISO timestamp. Pass the previous response's nextBefore to fetch older archived posts. When set, active posts are omitted." },
       },
       required: ["forum_channel_id"],
     },
@@ -232,7 +234,7 @@ export async function handle(name: string, args: Record<string, unknown>): Promi
 
     case "discord_get_forum_post": {
       const thread = await getThreadChannel(args.thread_id as string);
-      const limit = Math.min(Number(args.limit ?? 20), 100);
+      const limit = clampInt(args.limit, 1, 100, 20);
       const messages = await thread.messages.fetch({ limit });
       const result = {
         id: thread.id,
@@ -256,12 +258,16 @@ export async function handle(name: string, args: Record<string, unknown>): Promi
 
     case "discord_list_forum_threads": {
       const forum = await getForumChannel(args.forum_channel_id as string);
-      const active = await forum.threads.fetchActive();
-      const archived = await forum.threads.fetchArchived();
-      const threads = [
-        ...active.threads.values(),
-        ...archived.threads.values(),
-      ].map((t) => ({
+      const limit = clampInt(args.limit, 1, 100, 100);
+      const before = args.before !== undefined ? new Date(String(args.before)) : undefined;
+      const collected: ThreadChannel[] = [];
+      if (before === undefined) {
+        const active = await forum.threads.fetchActive();
+        collected.push(...active.threads.values());
+      }
+      const archived = await forum.threads.fetchArchived({ limit, before });
+      collected.push(...archived.threads.values());
+      const threads = collected.map((t) => ({
         id: t.id,
         name: t.name,
         archived: t.archived,
@@ -270,7 +276,9 @@ export async function handle(name: string, args: Record<string, unknown>): Promi
         appliedTags: t.appliedTags,
         createdAt: t.createdAt?.toISOString(),
       }));
-      return { content: [{ type: "text", text: JSON.stringify(threads, null, 2) }] };
+      const lastArchived = archived.threads.last();
+      const nextBefore = archived.hasMore ? lastArchived?.archivedAt?.toISOString() ?? null : null;
+      return { content: [{ type: "text", text: JSON.stringify({ threads, hasMore: archived.hasMore, nextBefore }, null, 2) }] };
     }
 
     case "discord_reply_to_forum": {

--- a/src/tools/members.ts
+++ b/src/tools/members.ts
@@ -1,5 +1,5 @@
 import { GuildMember } from "discord.js";
-import { discord, serializePermissions, validateId } from "../client.js";
+import { discord, serializePermissions, validateId, clampInt, validateInt } from "../client.js";
 import { MAX_FETCH_LIMIT, DEFAULTS } from "../constants.js";
 import type { ToolModule, ToolResult } from "./types.js";
 
@@ -8,13 +8,14 @@ export const definitions = [
   {
     name: "discord_list_members",
     description:
-      "List members of a server with their roles, in join order. Returns a JSON array (id, username, nickname, roles, join date). Use discord_search_members to find specific members by name, or discord_get_member_info for one member's full details. Read-only.",
+      "List members of a server with their roles, ordered by user ID. Returns { members: [...], nextCursor }. A page holds up to 1000 members; if nextCursor is non-null, pass it back as `after` to fetch the next page. Use discord_search_members to find specific members by name, or discord_get_member_info for one member's full details. Read-only.",
     annotations: { title: "List members", readOnlyHint: true, openWorldHint: true },
     inputSchema: {
       type: "object",
       properties: {
         guild_id: { type: "string", description: "Discord server (guild) ID (snowflake)." },
-        limit: { type: "number", description: "How many members to return (1–1000). Default 50." },
+        limit: { type: "number", description: "How many members per page (1–1000). Default 50." },
+        after: { type: "string", description: "Pagination cursor: a user ID (snowflake). Pass the previous response's nextCursor to fetch the next page." },
       },
       required: ["guild_id"],
     },
@@ -129,13 +130,14 @@ export const definitions = [
   {
     name: "discord_list_bans",
     description:
-      "List the users currently banned from the server, with their ban reasons. Returns a JSON array (user_id, username, reason). Requires the Ban Members permission. Read-only.",
+      "List the users banned from the server, with their ban reasons. Returns { bans: [...], nextCursor }. A page holds up to 1000 bans; if nextCursor is non-null, pass it back as `after` to fetch the next page. Requires the Ban Members permission. Read-only.",
     annotations: { title: "List bans", readOnlyHint: true, openWorldHint: true },
     inputSchema: {
       type: "object",
       properties: {
         guild_id: { type: "string", description: "Discord server (guild) ID (snowflake)." },
-        limit: { type: "number", description: "Optional max number of bans to fetch. Omit to fetch all." },
+        limit: { type: "number", description: "Max bans per page (1–1000). Default 1000." },
+        after: { type: "string", description: "Pagination cursor: a user ID (snowflake). Pass the previous response's nextCursor to fetch the next page." },
       },
       required: ["guild_id"],
     },
@@ -143,7 +145,7 @@ export const definitions = [
   {
     name: "discord_bulk_ban",
     description:
-      "Ban many users in a single call, intended for raid mitigation. Requires the Ban Members permission. Returns counts of banned vs failed users. Use discord_ban_member for a single ban with finer control.",
+      "Ban many users in a single call, intended for raid mitigation. SAFE BY DEFAULT: dry_run is true unless explicitly set to false, so call it first to preview the resolved user IDs, then re-call with dry_run:false to actually ban them. Requires the Ban Members permission. Returns counts of banned vs failed users. Use discord_ban_member for a single ban with finer control.",
     annotations: { title: "Bulk ban", readOnlyHint: false, destructiveHint: true, idempotentHint: false, openWorldHint: true },
     inputSchema: {
       type: "object",
@@ -151,6 +153,7 @@ export const definitions = [
         guild_id: { type: "string", description: "Discord server (guild) ID (snowflake)." },
         user_ids: { type: "array", items: { type: "string" }, description: "Array of user IDs (snowflakes) to ban." },
         delete_message_seconds: { type: "number", description: "Also delete each user's messages from the last N seconds (0–604800, i.e. up to 7 days). Default 0." },
+        dry_run: { type: "boolean", description: "If true (default), only returns the user IDs that would be banned without banning anyone. Set false to actually ban." },
         reason: { type: "string", description: "Optional reason recorded in the server audit log." },
       },
       required: ["guild_id", "user_ids"],
@@ -183,19 +186,21 @@ export async function handle(name: string, args: Record<string, unknown>): Promi
   switch (name) {
     case "discord_list_members": {
       const guild = await discord.guilds.fetch(validateId(args.guild_id, "guild_id"));
-      const limit = Math.min(Number(args.limit ?? DEFAULTS.MEMBERS), DEFAULTS.MEMBERS_MAX);
-      const members = await guild.members.list({ limit });
+      const limit = clampInt(args.limit, 1, DEFAULTS.MEMBERS_MAX, DEFAULTS.MEMBERS);
+      const after = args.after !== undefined ? validateId(args.after, "after") : undefined;
+      const members = await guild.members.list({ limit, after });
       const result = [...members.values()].map((m: GuildMember) => ({
         id: m.id, username: m.user.tag, nickname: m.nickname,
         roles: m.roles.cache.filter((r) => r.name !== "@everyone").map((r) => ({ id: r.id, name: r.name })),
         joinedAt: m.joinedAt?.toISOString(),
       }));
-      return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
+      const nextCursor = members.size === limit ? members.lastKey() ?? null : null;
+      return { content: [{ type: "text", text: JSON.stringify({ members: result, nextCursor }, null, 2) }] };
     }
 
     case "discord_get_member_info": {
       const guild = await discord.guilds.fetch(validateId(args.guild_id, "guild_id"));
-      const member = await guild.members.fetch(args.user_id as string);
+      const member = await guild.members.fetch(validateId(args.user_id, "user_id"));
       return {
         content: [{
           type: "text", text: JSON.stringify({
@@ -211,31 +216,33 @@ export async function handle(name: string, args: Record<string, unknown>): Promi
 
     case "discord_kick_member": {
       const guild = await discord.guilds.fetch(validateId(args.guild_id, "guild_id"));
-      const member = await guild.members.fetch(args.user_id as string);
+      const member = await guild.members.fetch(validateId(args.user_id, "user_id"));
       await member.kick(args.reason as string | undefined);
       return { content: [{ type: "text", text: `✅ ${member.user.tag} has been kicked.` }] };
     }
 
     case "discord_ban_member": {
       const guild = await discord.guilds.fetch(validateId(args.guild_id, "guild_id"));
-      const deleteDays = Math.min(Math.max(Number(args.delete_message_days ?? 0), 0), 7);
-      await guild.members.ban(args.user_id as string, {
+      const userId = validateId(args.user_id, "user_id");
+      const deleteDays = clampInt(args.delete_message_days, 0, 7, 0);
+      await guild.members.ban(userId, {
         reason: args.reason as string | undefined,
         deleteMessageSeconds: deleteDays * 86400,
       });
-      return { content: [{ type: "text", text: `✅ User ${args.user_id} has been banned.` }] };
+      return { content: [{ type: "text", text: `✅ User ${userId} has been banned.` }] };
     }
 
     case "discord_unban_member": {
       const guild = await discord.guilds.fetch(validateId(args.guild_id, "guild_id"));
-      await guild.members.unban(args.user_id as string, args.reason as string | undefined);
-      return { content: [{ type: "text", text: `✅ User ${args.user_id} has been unbanned.` }] };
+      const userId = validateId(args.user_id, "user_id");
+      await guild.members.unban(userId, args.reason as string | undefined);
+      return { content: [{ type: "text", text: `✅ User ${userId} has been unbanned.` }] };
     }
 
     case "discord_timeout_member": {
       const guild = await discord.guilds.fetch(validateId(args.guild_id, "guild_id"));
-      const member = await guild.members.fetch(args.user_id as string);
-      const duration = args.duration_minutes as number;
+      const member = await guild.members.fetch(validateId(args.user_id, "user_id"));
+      const duration = validateInt(args.duration_minutes, 0, 40320, "duration_minutes");
       const until = duration > 0 ? new Date(Date.now() + duration * 60 * 1000) : null;
       await member.disableCommunicationUntil(until, args.reason as string | undefined);
       return {
@@ -248,7 +255,7 @@ export async function handle(name: string, args: Record<string, unknown>): Promi
 
     case "discord_search_members": {
       const guild = await discord.guilds.fetch(validateId(args.guild_id, "guild_id"));
-      const limit = Math.min(Number(args.limit ?? DEFAULTS.LIMIT), MAX_FETCH_LIMIT);
+      const limit = clampInt(args.limit, 1, MAX_FETCH_LIMIT, DEFAULTS.LIMIT);
       const members = await guild.members.search({ query: args.query as string, limit });
       const result = [...members.values()].map((m: GuildMember) => ({
         id: m.id, username: m.user.tag, nickname: m.nickname,
@@ -259,7 +266,7 @@ export async function handle(name: string, args: Record<string, unknown>): Promi
 
     case "discord_set_nickname": {
       const guild = await discord.guilds.fetch(validateId(args.guild_id, "guild_id"));
-      const member = await guild.members.fetch(args.user_id as string);
+      const member = await guild.members.fetch(validateId(args.user_id, "user_id"));
       const nick = args.nickname === null || args.nickname === "null" ? null : String(args.nickname);
       await member.setNickname(nick, args.reason as string | undefined);
       return { content: [{ type: "text", text: nick ? `✅ Nickname for ${member.user.tag} set to "${nick}".` : `✅ Nickname cleared for ${member.user.tag}.` }] };
@@ -267,20 +274,26 @@ export async function handle(name: string, args: Record<string, unknown>): Promi
 
     case "discord_list_bans": {
       const guild = await discord.guilds.fetch(validateId(args.guild_id, "guild_id"));
-      const limit = args.limit ? Number(args.limit) : undefined;
-      const bans = await guild.bans.fetch({ limit, cache: false });
+      const limit = clampInt(args.limit, 1, 1000, 1000);
+      const after = args.after !== undefined ? validateId(args.after, "after") : undefined;
+      const bans = await guild.bans.fetch({ limit, after, cache: false });
       const result = [...bans.values()].map((ban) => ({
         user_id: ban.user.id, username: ban.user.tag, reason: ban.reason ?? null,
       }));
-      return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
+      const nextCursor = bans.size === limit ? bans.lastKey() ?? null : null;
+      return { content: [{ type: "text", text: JSON.stringify({ bans: result, nextCursor }, null, 2) }] };
     }
 
     case "discord_bulk_ban": {
       const guild = await discord.guilds.fetch(validateId(args.guild_id, "guild_id"));
-      const userIds = args.user_ids as string[];
-      if (!Array.isArray(userIds) || userIds.length === 0) throw new Error("user_ids must be a non-empty array.");
+      const rawIds = args.user_ids;
+      if (!Array.isArray(rawIds) || rawIds.length === 0) throw new Error("user_ids must be a non-empty array.");
+      const userIds = rawIds.map((id) => validateId(id, "user_ids[]"));
+      if (args.dry_run !== false) {
+        return { content: [{ type: "text", text: `🔍 Dry run: ${userIds.length} users would be banned:\n${JSON.stringify(userIds, null, 2)}` }] };
+      }
       const result = await guild.members.bulkBan(userIds, {
-        deleteMessageSeconds: Number(args.delete_message_seconds ?? 0),
+        deleteMessageSeconds: clampInt(args.delete_message_seconds, 0, 604800, 0),
         reason: args.reason as string | undefined,
       });
       return { content: [{ type: "text", text: `✅ Bulk ban complete: ${result.bannedUsers.length} banned, ${result.failedUsers.length} failed.` }] };
@@ -288,7 +301,7 @@ export async function handle(name: string, args: Record<string, unknown>): Promi
 
     case "discord_prune_members": {
       const guild = await discord.guilds.fetch(validateId(args.guild_id, "guild_id"));
-      const days = Number(args.days);
+      const days = validateInt(args.days, 1, 30, "days");
       const dryRun = args.dry_run !== false;
       const roles = args.roles as string[] | undefined;
       const pruned = await guild.members.prune({

--- a/src/tools/messages.ts
+++ b/src/tools/messages.ts
@@ -6,7 +6,7 @@ import {
   Message,
   MessageReaction,
 } from "discord.js";
-import { discord, getTextChannel } from "../client.js";
+import { discord, getTextChannel, clampInt } from "../client.js";
 import { MAX_FETCH_LIMIT, DEFAULTS } from "../constants.js";
 import { buildEmbed, EMBED_FIELD_PROPS } from "../embeds.js";
 import type { ToolModule, ToolResult } from "./types.js";
@@ -308,8 +308,8 @@ export async function handle(name: string, args: Record<string, unknown>): Promi
   switch (name) {
     case "discord_read_messages": {
       const channel = await getTextChannel(args.channel_id as string);
-      const limit = Math.min(Number(args.limit ?? DEFAULTS.MESSAGES), MAX_FETCH_LIMIT);
-      const messages = await channel.messages.fetch({ limit });
+      const limit = clampInt(args.limit, 1, MAX_FETCH_LIMIT, DEFAULTS.MESSAGES);
+      const messages = await channel.messages.fetch({ limit, cache: false });
       const result = [...messages.values()]
         .sort((a, b) => a.createdTimestamp - b.createdTimestamp)
         .map((m) => ({
@@ -372,7 +372,7 @@ export async function handle(name: string, args: Record<string, unknown>): Promi
 
     case "discord_bulk_delete_messages": {
       const channel = await getTextChannel(args.channel_id as string);
-      const count = Math.min(Math.max(Number(args.count ?? 2), 2), 100);
+      const count = clampInt(args.count, 2, 100, 2);
       const deleted = await channel.bulkDelete(count, true);
       return { content: [{ type: "text", text: `✅ Deleted ${deleted.size} messages in #${channel.name}.` }] };
     }
@@ -421,8 +421,8 @@ export async function handle(name: string, args: Record<string, unknown>): Promi
 
     case "discord_search_messages": {
       const channel = await getTextChannel(args.channel_id as string);
-      const limit = Math.min(Math.max(Number(args.limit ?? MAX_FETCH_LIMIT), 1), MAX_FETCH_LIMIT);
-      const messages = await channel.messages.fetch({ limit });
+      const limit = clampInt(args.limit, 1, MAX_FETCH_LIMIT, MAX_FETCH_LIMIT);
+      const messages = await channel.messages.fetch({ limit, cache: false });
       const keyword = (args.keyword as string).toLowerCase();
       const matches = [...messages.values()]
         .filter((m) => m.content.toLowerCase().includes(keyword))
@@ -460,7 +460,7 @@ export async function handle(name: string, args: Record<string, unknown>): Promi
       const msg = await channel.messages.fetch(args.message_id as string);
       const reaction = findReaction(msg, args.emoji as string);
       if (!reaction) throw new Error(`No reaction found for emoji "${args.emoji}" on message ${msg.id}.`);
-      const limit = Math.min(Number(args.limit ?? DEFAULTS.LIMIT), MAX_FETCH_LIMIT);
+      const limit = clampInt(args.limit, 1, MAX_FETCH_LIMIT, DEFAULTS.LIMIT);
       const users = await reaction.users.fetch({ limit });
       const result = [...users.values()].map((u) => ({ id: u.id, username: u.username, bot: u.bot }));
       return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
@@ -468,9 +468,10 @@ export async function handle(name: string, args: Record<string, unknown>): Promi
 
     case "discord_fetch_pinned_messages": {
       const channel = await getTextChannel(args.channel_id as string);
-      const pinned = await channel.messages.fetchPinned();
-      const result = [...pinned.values()].map((m) => ({
-        id: m.id, author: m.author.tag, content: m.content, timestamp: m.createdAt.toISOString(),
+      const pinned = await channel.messages.fetchPins();
+      const result = pinned.items.map(({ message: m, pinnedAt }) => ({
+        id: m.id, author: m.author.tag, content: m.content,
+        timestamp: m.createdAt.toISOString(), pinnedAt: pinnedAt.toISOString(),
       }));
       return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
     }

--- a/src/tools/messages.ts
+++ b/src/tools/messages.ts
@@ -261,7 +261,7 @@ export const definitions = [
   {
     name: "discord_fetch_pinned_messages",
     description:
-      "List all pinned messages in a channel as a JSON array (id, author, content, timestamp). Read-only. Use discord_pin_message to change which messages are pinned.",
+      "List all pinned messages in a channel as a JSON array (id, author, content, timestamp, pinnedAt). Read-only. Use discord_pin_message to change which messages are pinned.",
     annotations: { title: "Fetch pinned messages", readOnlyHint: true, openWorldHint: true },
     inputSchema: {
       type: "object",

--- a/src/tools/moderation.ts
+++ b/src/tools/moderation.ts
@@ -1,4 +1,4 @@
-import { discord, validateId } from "../client.js";
+import { discord, validateId, clampInt } from "../client.js";
 import type { ToolModule, ToolResult } from "./types.js";
 
 /** Tool definitions for server moderation (audit log). */
@@ -29,7 +29,7 @@ export async function handle(name: string, args: Record<string, unknown>): Promi
     case "discord_get_audit_log": {
       const guild = await discord.guilds.fetch(validateId(args.guild_id, "guild_id"));
       const logs = await guild.fetchAuditLogs({
-        limit: Math.min(Number(args.limit ?? 25), 100),
+        limit: clampInt(args.limit, 1, 100, 25),
         type: args.action_type as number | undefined,
       });
       const result = logs.entries.map((entry) => ({

--- a/src/tools/roles.ts
+++ b/src/tools/roles.ts
@@ -223,24 +223,36 @@ export async function handle(name: string, args: Record<string, unknown>): Promi
 
     case "discord_add_role": {
       const guild = await discord.guilds.fetch(validateId(args.guild_id, "guild_id"));
-      const member = await guild.members.fetch(args.user_id as string);
-      await member.roles.add(args.role_id as string, args.reason as string | undefined);
+      const member = await guild.members.fetch(validateId(args.user_id, "user_id"));
+      await member.roles.add(validateId(args.role_id, "role_id"), args.reason as string | undefined);
       return { content: [{ type: "text", text: `✅ Role added to ${member.user.tag}.` }] };
     }
 
     case "discord_remove_role": {
       const guild = await discord.guilds.fetch(validateId(args.guild_id, "guild_id"));
-      const member = await guild.members.fetch(args.user_id as string);
-      await member.roles.remove(args.role_id as string, args.reason as string | undefined);
+      const member = await guild.members.fetch(validateId(args.user_id, "user_id"));
+      await member.roles.remove(validateId(args.role_id, "role_id"), args.reason as string | undefined);
       return { content: [{ type: "text", text: `✅ Role removed from ${member.user.tag}.` }] };
     }
 
     case "discord_get_role_members": {
       const guild = await discord.guilds.fetch(validateId(args.guild_id, "guild_id"));
-      await guild.members.list({ limit: 1000 });
       const role = await fetchRole(guild, args.role_id);
+      // No "members of a role" endpoint exists, so populate the cache then filter (1000/page max).
+      const MAX_PAGES = 20;
+      let after: string | undefined;
+      let truncated = true;
+      for (let i = 0; i < MAX_PAGES; i++) {
+        const page = await guild.members.list({ limit: 1000, after });
+        if (page.size < 1000) { truncated = false; break; }
+        after = page.lastKey();
+      }
       const members = role.members.map((m) => ({ id: m.id, username: m.user.tag, nickname: m.nickname }));
-      return { content: [{ type: "text", text: JSON.stringify(members, null, 2) }] };
+      return { content: [{ type: "text", text: JSON.stringify({
+        members,
+        truncated,
+        note: truncated ? `Only the first ${MAX_PAGES * 1000} members were scanned; results may be incomplete on very large servers.` : undefined,
+      }, null, 2) }] };
     }
 
     case "discord_set_role_position": {

--- a/src/tools/scheduledEvents.ts
+++ b/src/tools/scheduledEvents.ts
@@ -1,5 +1,5 @@
 import { GuildScheduledEventEntityType, GuildScheduledEventPrivacyLevel, GuildScheduledEventStatus, type GuildScheduledEventCreateOptions, type GuildScheduledEventEditOptions } from "discord.js";
-import { discord, validateId } from "../client.js";
+import { discord, validateId, clampInt } from "../client.js";
 import { MAX_FETCH_LIMIT, DEFAULTS } from "../constants.js";
 import type { ToolModule, ToolResult } from "./types.js";
 
@@ -112,14 +112,15 @@ export const definitions = [
   {
     name: "discord_get_event_subscribers",
     description:
-      "List the users who marked themselves 'Interested' in a scheduled event (user_id, username, avatar). Read-only. Returns a JSON array.",
+      "List the users who marked themselves 'Interested' in a scheduled event. Returns { subscribers: [...], nextCursor }. A page holds up to 100 users; if nextCursor is non-null, pass it back as `after` to fetch the next page. Read-only.",
     annotations: { title: "Get event subscribers", readOnlyHint: true, openWorldHint: true },
     inputSchema: {
       type: "object",
       properties: {
         guild_id: { type: "string", description: "Discord server (guild) ID (snowflake)." },
         event_id: { type: "string", description: "ID (snowflake) of the scheduled event." },
-        limit: { type: "number", description: "Max subscribers to return (1–100). Default 25." },
+        limit: { type: "number", description: "Max subscribers per page (1–100). Default 25." },
+        after: { type: "string", description: "Pagination cursor: a user ID (snowflake). Pass the previous response's nextCursor to fetch the next page." },
       },
       required: ["guild_id", "event_id"],
     },
@@ -290,14 +291,16 @@ export async function handle(
       const eventId = validateId(args.event_id, "event_id");
       const guild = await discord.guilds.fetch(guildId);
       const event = await guild.scheduledEvents.fetch(eventId);
-      const limit = Math.min(Number(args.limit ?? DEFAULTS.LIMIT), MAX_FETCH_LIMIT);
-      const subscribers = await event.fetchSubscribers({ limit });
+      const limit = clampInt(args.limit, 1, MAX_FETCH_LIMIT, DEFAULTS.LIMIT);
+      const after = args.after !== undefined ? validateId(args.after, "after") : undefined;
+      const subscribers = await event.fetchSubscribers({ limit, after });
       const list = [...subscribers.values()].map((sub) => ({
         user_id: sub.user.id,
         username: sub.user.username,
         avatar: sub.user.displayAvatarURL(),
       }));
-      return { content: [{ type: "text", text: JSON.stringify(list, null, 2) }] };
+      const nextCursor = subscribers.size === limit ? subscribers.lastKey() ?? null : null;
+      return { content: [{ type: "text", text: JSON.stringify({ subscribers: list, nextCursor }, null, 2) }] };
     }
 
     case "discord_create_event_invite": {


### PR DESCRIPTION
Suite de l'audit : findings verifies sur le web (rapport AUDIT_VERIFICATION.md, local). Pas de gros chantier architectural (zod/toolsets/tests -> plus tard). Ne pas merger sans review + live test.

## Pagination (curseur — option B)
Les outils de listing ne renvoient plus silencieusement que la premiere page. Chaque endpoint a ete verifie comme paginable contre la doc Discord :
- discord_list_members, discord_list_bans, discord_get_event_subscribers, discord_list_forum_threads renvoient { items, nextCursor } (ou hasMore/nextBefore) et acceptent un curseur after/before.
- discord_get_role_members : pas d'endpoint "membres d'un role" cote Discord, donc pagination du roster complet (1000/page, cap 20 pages) puis filtrage, avec un flag truncated.

## Deprecations (retirees en discord.js v15)
- evenement ready -> clientReady
- MessageManager#fetchPinned() -> fetchPins() (nouvelle forme paginee ; renvoie aussi pinnedAt)

## Resilience connexion (client.ts / index.ts)
Timeout READY 30s (plus de hang infini), reset de l'etat de login en cas d'echec, listeners error/shardError/invalidated (une erreur client non ecoutee pouvait crasher le process), REST retries, handlers unhandledRejection/uncaughtException.

## Erreurs
formatToolError expose le code DiscordAPIError + statut HTTP + indice en clair (ex. 50013 -> permission manquante, 10008 -> message inconnu).

## Validation
- validateId uniforme sur channel/user/role (via getTextChannel/getGuildChannel en interne + handlers).
- clampInt/validateInt sur toutes les entrees numeriques (plus de NaN vers l'API).
- bulk_ban safe-by-default (dry_run) ; lectures en { cache: false }.

## Changement de forme de reponse
list_members, list_bans, get_event_subscribers, list_forum_threads, get_role_members renvoient desormais un objet ({ items, nextCursor }) au lieu d'un tableau nu.

## Hors scope (laisses volontairement)
get_reactions / get_audit_log sont deja bornes par un limit explicite. max_age/max_uses de creation d'invite : valides cote Discord. Gros chantiers (zod, toolsets, tests/CI) -> PR dediees.