### PR TITLE
feat(tools)!: zod single source of truth + enforced numeric bounds

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,8 @@
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.27.1",
         "discord.js": "^14.25.1",
-        "dotenv": "^17.3.1"
+        "dotenv": "^17.3.1",
+        "zod": "^4.3.6"
       },
       "bin": {
         "discord-mcp": "dist/index.js"

--- a/package.json
+++ b/package.json
@@ -48,7 +48,8 @@
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.27.1",
     "discord.js": "^14.25.1",
-    "dotenv": "^17.3.1"
+    "dotenv": "^17.3.1",
+    "zod": "^4.3.6"
   },
   "devDependencies": {
     "@eslint/js": "^10.0.1",

--- a/src/client.ts
+++ b/src/client.ts
@@ -130,35 +130,6 @@ export function validateId(value: unknown, label: string): string {
 }
 
 /**
- * Coerces a value to an integer clamped to [min, max], using fallback when it is not a finite number.
- * @param value - The raw value to coerce.
- * @param min - Lower bound (inclusive).
- * @param max - Upper bound (inclusive).
- * @param fallback - Returned when value is missing or non-numeric.
- */
-export function clampInt(value: unknown, min: number, max: number, fallback: number): number {
-  const n = Number(value);
-  if (!Number.isFinite(n)) return fallback;
-  return Math.min(Math.max(Math.trunc(n), min), max);
-}
-
-/**
- * Validates a value is a finite integer within [min, max].
- * @param value - The raw value to validate.
- * @param min - Lower bound (inclusive).
- * @param max - Upper bound (inclusive).
- * @param label - Human-readable label used in the error message.
- * @throws {Error} If the value is not an integer in range.
- */
-export function validateInt(value: unknown, min: number, max: number, label: string): number {
-  const n = Number(value);
-  if (!Number.isInteger(n) || n < min || n > max) {
-    throw new Error(`Invalid ${label}: "${String(value)}". Must be an integer between ${min} and ${max}.`);
-  }
-  return n;
-}
-
-/**
  * Converts a PermissionsBitField into a human-readable array of permission names.
  * @param perms - The bitfield to serialize.
  * @returns Array of permission flag names (e.g. ["SendMessages", "ViewChannel"]).

--- a/src/embeds.ts
+++ b/src/embeds.ts
@@ -1,10 +1,58 @@
 import { EmbedBuilder, ColorResolvable } from "discord.js";
+import { z } from "zod";
+
+/**
+ * Zod fields of a rich embed — spread into a tool's `z.object({...})` schema.
+ * The zod source of truth for embeds; {@link EMBED_FIELD_PROPS} is the legacy JSON
+ * mirror still consumed by the not-yet-migrated DM/webhook tools and goes away once
+ * those modules adopt this shape.
+ */
+export const embedFieldsShape = {
+  title: z.string().optional().describe("Embed title shown in bold at the top."),
+  url: z.string().optional().describe("URL that makes the title clickable."),
+  description: z.string().optional().describe("Main body text of the embed (supports Markdown)."),
+  color: z.string().optional().describe("Side-bar color as a hex string, e.g. '#5865F2'."),
+  fields: z
+    .array(
+      z.object({
+        name: z.string().describe("Field heading."),
+        value: z.string().describe("Field body text."),
+        inline: z
+          .boolean()
+          .optional()
+          .describe("If true, render this field side-by-side with adjacent inline fields."),
+      })
+    )
+    .optional()
+    .describe(
+      "Up to 25 name/value field blocks. Set inline:true on a field to render it side-by-side with adjacent inline fields (up to 3 per row)."
+    ),
+  author: z
+    .object({
+      name: z.string().describe("Author display name."),
+      icon_url: z.string().optional().describe("Small icon shown next to the author name."),
+      url: z.string().optional().describe("URL the author name links to."),
+    })
+    .optional()
+    .describe("Author block shown at the top of the embed."),
+  thumbnail_url: z.string().optional().describe("Small image shown in the top-right corner."),
+  footer: z.string().optional().describe("Footer text shown at the bottom of the embed."),
+  image_url: z.string().optional().describe("Large image shown below the embed body."),
+  timestamp: z.boolean().optional().describe("If true, stamp the embed with the current time."),
+} as const;
+
+/** Schema for a single embed object (e.g. an item of `discord_send_multiple_embeds`). */
+export const embedObjectSchema = z.object(embedFieldsShape);
+
+/** Validated embed input — the typed shape `buildEmbed` consumes from migrated tools. */
+export type EmbedInput = z.infer<typeof embedObjectSchema>;
 
 /**
  * Builds an EmbedBuilder from a flat args object.
- * Shared by the message, DM, and webhook embed tools.
+ * Shared by the message, DM, and webhook embed tools. The union param accepts both
+ * a validated {@link EmbedInput} (migrated tools) and a raw bag (legacy callers).
  */
-export function buildEmbed(args: Record<string, unknown>): EmbedBuilder {
+export function buildEmbed(args: EmbedInput | Record<string, unknown>): EmbedBuilder {
   const embed = new EmbedBuilder();
   if (args.title) embed.setTitle(args.title as string);
   if (args.url) embed.setURL(args.url as string);

--- a/src/embeds.ts
+++ b/src/embeds.ts
@@ -3,9 +3,7 @@ import { z } from "zod";
 
 /**
  * Zod fields of a rich embed — spread into a tool's `z.object({...})` schema.
- * The zod source of truth for embeds; {@link EMBED_FIELD_PROPS} is the legacy JSON
- * mirror still consumed by the not-yet-migrated DM/webhook tools and goes away once
- * those modules adopt this shape.
+ * The single source of truth for embed input across the message, DM, and webhook tools.
  */
 export const embedFieldsShape = {
   title: z.string().optional().describe("Embed title shown in bold at the top."),
@@ -48,62 +46,24 @@ export const embedObjectSchema = z.object(embedFieldsShape);
 export type EmbedInput = z.infer<typeof embedObjectSchema>;
 
 /**
- * Builds an EmbedBuilder from a flat args object.
- * Shared by the message, DM, and webhook embed tools. The union param accepts both
- * a validated {@link EmbedInput} (migrated tools) and a raw bag (legacy callers).
+ * Builds an EmbedBuilder from validated embed input.
+ * Shared by the message, DM, and webhook embed tools.
  */
-export function buildEmbed(args: EmbedInput | Record<string, unknown>): EmbedBuilder {
+export function buildEmbed(args: EmbedInput): EmbedBuilder {
   const embed = new EmbedBuilder();
-  if (args.title) embed.setTitle(args.title as string);
-  if (args.url) embed.setURL(args.url as string);
-  if (args.description) embed.setDescription(args.description as string);
+  if (args.title) embed.setTitle(args.title);
+  if (args.url) embed.setURL(args.url);
+  if (args.description) embed.setDescription(args.description);
   if (args.color) embed.setColor(args.color as ColorResolvable);
-  if (args.footer) embed.setFooter({ text: args.footer as string });
-  if (args.image_url) embed.setImage(args.image_url as string);
-  if (args.thumbnail_url) embed.setThumbnail(args.thumbnail_url as string);
+  if (args.footer) embed.setFooter({ text: args.footer });
+  if (args.image_url) embed.setImage(args.image_url);
+  if (args.thumbnail_url) embed.setThumbnail(args.thumbnail_url);
   if (args.timestamp) embed.setTimestamp();
   if (args.author) {
-    const a = args.author as { name: string; icon_url?: string; url?: string };
-    embed.setAuthor({ name: a.name, iconURL: a.icon_url, url: a.url });
+    embed.setAuthor({ name: args.author.name, iconURL: args.author.icon_url, url: args.author.url });
   }
   if (args.fields) {
-    const fields = args.fields as { name: string; value: string; inline?: boolean }[];
-    embed.addFields(fields.map((f) => ({ name: f.name, value: f.value, inline: f.inline ?? false })));
+    embed.addFields(args.fields.map((f) => ({ name: f.name, value: f.value, inline: f.inline ?? false })));
   }
   return embed;
 }
-
-/** Reusable input-schema fragment for a rich embed's fields (shared by send/edit/multiple embed tools). */
-export const EMBED_FIELD_PROPS = {
-  title: { type: "string", description: "Embed title shown in bold at the top." },
-  url: { type: "string", description: "URL that makes the title clickable." },
-  description: { type: "string", description: "Main body text of the embed (supports Markdown)." },
-  color: { type: "string", description: "Side-bar color as a hex string, e.g. '#5865F2'." },
-  fields: {
-    type: "array",
-    description: "Up to 25 name/value field blocks. Set inline:true on a field to render it side-by-side with adjacent inline fields (up to 3 per row).",
-    items: {
-      type: "object",
-      properties: {
-        name: { type: "string", description: "Field heading." },
-        value: { type: "string", description: "Field body text." },
-        inline: { type: "boolean", description: "If true, render this field side-by-side with adjacent inline fields." },
-      },
-      required: ["name", "value"],
-    },
-  },
-  author: {
-    type: "object",
-    description: "Author block shown at the top of the embed.",
-    properties: {
-      name: { type: "string", description: "Author display name." },
-      icon_url: { type: "string", description: "Small icon shown next to the author name." },
-      url: { type: "string", description: "URL the author name links to." },
-    },
-    required: ["name"],
-  },
-  thumbnail_url: { type: "string", description: "Small image shown in the top-right corner." },
-  footer: { type: "string", description: "Footer text shown at the bottom of the embed." },
-  image_url: { type: "string", description: "Large image shown below the embed body." },
-  timestamp: { type: "boolean", description: "If true, stamp the embed with the current time." },
-} as const;

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,6 +14,7 @@ import {
 } from "@modelcontextprotocol/sdk/types.js";
 
 import { DiscordAPIError } from "discord.js";
+import { ZodError } from "zod";
 import { readFileSync } from "fs";
 import { join } from "path";
 import { ensureConnected, discord } from "./client.js";
@@ -34,6 +35,15 @@ const DISCORD_ERROR_HINTS: Record<number, string> = {
 
 /** Formats an error for the MCP client, surfacing DiscordAPIError code/status and an actionable hint. */
 function formatToolError(err: unknown): string {
+  if (err instanceof ZodError) {
+    const detail = err.issues
+      .map((i) => {
+        const path = i.path.join(".");
+        return path ? `${path}: ${i.message}` : i.message;
+      })
+      .join("; ");
+    return `Invalid arguments — ${detail}`;
+  }
   if (err instanceof DiscordAPIError) {
     const code = Number(err.code);
     const hint = DISCORD_ERROR_HINTS[code];

--- a/src/tools/channels.ts
+++ b/src/tools/channels.ts
@@ -1,7 +1,7 @@
 import { ChannelType, NewsChannel } from "discord.js";
 import { z } from "zod";
 import { discord, getGuildChannel } from "../client.js";
-import { defineTool, defineModule, snowflake, guildId } from "./define.js";
+import { defineTool, defineModule, snowflake, guildId, intIn } from "./define.js";
 
 /** Tool definitions for creating, deleting, editing, moving, and cloning channels. */
 const tools = [
@@ -57,7 +57,7 @@ const tools = [
       channel_id: snowflake.describe("ID (snowflake) of the channel to edit."),
       name: z.string().optional().describe("New channel name (max 100 characters)."),
       topic: z.string().optional().describe("New topic/description (text channels only)."),
-      slowmode: z.number().optional().describe("Per-user message cooldown in seconds, 0–21600. 0 disables slowmode."),
+      slowmode: intIn(0, 21600).optional().describe("Per-user message cooldown in seconds, 0–21600. 0 disables slowmode."),
       nsfw: z.boolean().optional().describe("Mark (true) or unmark (false) the channel as age-restricted (NSFW)."),
     }),
     handle: async ({ channel_id, name, topic, slowmode, nsfw }) => {
@@ -108,7 +108,7 @@ const tools = [
     annotations: { title: "Set channel position", readOnlyHint: false, destructiveHint: false, idempotentHint: true, openWorldHint: true },
     schema: z.object({
       channel_id: snowflake.describe("ID (snowflake) of the channel to reposition."),
-      position: z.number().describe("Zero-based position within the category (0 = top)."),
+      position: z.int().min(0).describe("Zero-based position within the category (0 = top)."),
     }),
     handle: async ({ channel_id, position }) => {
       const channel = await getGuildChannel(channel_id);

--- a/src/tools/channels.ts
+++ b/src/tools/channels.ts
@@ -1,201 +1,151 @@
 import { ChannelType, NewsChannel } from "discord.js";
-import { discord, getGuildChannel, validateId } from "../client.js";
-import type { ToolModule, ToolResult } from "./types.js";
+import { z } from "zod";
+import { discord, getGuildChannel } from "../client.js";
+import { defineTool, defineModule, snowflake, guildId } from "./define.js";
 
 /** Tool definitions for creating, deleting, editing, moving, and cloning channels. */
-export const definitions = [
-  {
+const tools = [
+  defineTool({
     name: "discord_create_channel",
     description:
       "Create a text channel, voice channel, or category in a server. Requires the Manage Channels permission. For forum channels use discord_create_forum_channel instead. Returns the new channel's name and ID.",
     annotations: { title: "Create channel", readOnlyHint: false, destructiveHint: false, idempotentHint: false, openWorldHint: true },
-    inputSchema: {
-      type: "object",
-      properties: {
-        guild_id: { type: "string", description: "Discord server (guild) ID (snowflake) to create the channel in." },
-        name: { type: "string", description: "Name of the new channel (max 100 characters)." },
-        type: { type: "string", enum: ["text", "voice", "category"], description: "Channel type to create. Defaults to 'text'." },
-        topic: { type: "string", description: "Optional channel topic/description. Applies to text channels only." },
-        category_id: { type: "string", description: "Optional category (snowflake) to nest the new channel under." },
-      },
-      required: ["guild_id", "name"],
+    schema: z.object({
+      guild_id: guildId.describe("Discord server (guild) ID (snowflake) to create the channel in."),
+      name: z.string().describe("Name of the new channel (max 100 characters)."),
+      type: z.enum(["text", "voice", "category"]).optional().describe("Channel type to create. Defaults to 'text'."),
+      topic: z.string().optional().describe("Optional channel topic/description. Applies to text channels only."),
+      category_id: snowflake.optional().describe("Optional category (snowflake) to nest the new channel under."),
+    }),
+    handle: async ({ guild_id, name, type, topic, category_id }) => {
+      const guild = await discord.guilds.fetch(guild_id);
+      const typeMap: Record<string, ChannelType> = {
+        text: ChannelType.GuildText, voice: ChannelType.GuildVoice, category: ChannelType.GuildCategory,
+      };
+      const channelType = typeMap[type ?? "text"] ?? ChannelType.GuildText;
+      const created = await guild.channels.create({
+        name, type: channelType as ChannelType.GuildText | ChannelType.GuildVoice | ChannelType.GuildCategory,
+        topic: channelType === ChannelType.GuildText ? topic : undefined,
+        parent: category_id,
+      });
+      return { content: [{ type: "text", text: `✅ Channel #${created.name} created (id: ${created.id}).` }] };
     },
-  },
-  {
+  }),
+  defineTool({
     name: "discord_delete_channel",
     description:
       "Permanently delete a channel and all of its messages. IRREVERSIBLE. Requires the Manage Channels permission. An optional reason is recorded in the audit log. Returns a confirmation.",
     annotations: { title: "Delete channel", readOnlyHint: false, destructiveHint: true, idempotentHint: false, openWorldHint: true },
-    inputSchema: {
-      type: "object",
-      properties: {
-        channel_id: { type: "string", description: "ID (snowflake) of the channel to delete." },
-        reason: { type: "string", description: "Optional reason recorded in the server audit log." },
-      },
-      required: ["channel_id"],
+    schema: z.object({
+      channel_id: snowflake.describe("ID (snowflake) of the channel to delete."),
+      reason: z.string().optional().describe("Optional reason recorded in the server audit log."),
+    }),
+    handle: async ({ channel_id, reason }) => {
+      const channel = await discord.channels.fetch(channel_id);
+      if (!channel) throw new Error("Channel not found.");
+      const channelName = "name" in channel ? channel.name : channel.id;
+      await channel.delete(reason);
+      return { content: [{ type: "text", text: `✅ Channel #${channelName} deleted.` }] };
     },
-  },
-  {
+  }),
+  defineTool({
     name: "discord_edit_channel",
     description:
       "Update a channel's name, topic, slowmode, or NSFW flag. Only provided fields change; topic and slowmode apply to text channels only. Requires the Manage Channels permission. Returns a confirmation.",
     annotations: { title: "Edit channel", readOnlyHint: false, destructiveHint: false, idempotentHint: true, openWorldHint: true },
-    inputSchema: {
-      type: "object",
-      properties: {
-        channel_id: { type: "string", description: "ID (snowflake) of the channel to edit." },
-        name: { type: "string", description: "New channel name (max 100 characters)." },
-        topic: { type: "string", description: "New topic/description (text channels only)." },
-        slowmode: { type: "number", description: "Per-user message cooldown in seconds, 0–21600. 0 disables slowmode." },
-        nsfw: { type: "boolean", description: "Mark (true) or unmark (false) the channel as age-restricted (NSFW)." },
-      },
-      required: ["channel_id"],
+    schema: z.object({
+      channel_id: snowflake.describe("ID (snowflake) of the channel to edit."),
+      name: z.string().optional().describe("New channel name (max 100 characters)."),
+      topic: z.string().optional().describe("New topic/description (text channels only)."),
+      slowmode: z.number().optional().describe("Per-user message cooldown in seconds, 0–21600. 0 disables slowmode."),
+      nsfw: z.boolean().optional().describe("Mark (true) or unmark (false) the channel as age-restricted (NSFW)."),
+    }),
+    handle: async ({ channel_id, name, topic, slowmode, nsfw }) => {
+      const channel = await getGuildChannel(channel_id);
+      const editOptions: Record<string, unknown> = {};
+      if (name !== undefined) editOptions.name = name;
+      if (topic !== undefined && channel.type === ChannelType.GuildText) editOptions.topic = topic;
+      if (slowmode !== undefined && channel.type === ChannelType.GuildText) editOptions.rateLimitPerUser = slowmode;
+      if (nsfw !== undefined) editOptions.nsfw = nsfw;
+      await channel.edit(editOptions);
+      return { content: [{ type: "text", text: `✅ Channel #${channel.name} updated.` }] };
     },
-  },
-  {
+  }),
+  defineTool({
     name: "discord_move_channel",
     description:
       "Move a channel into a category, or remove it from its category when category_id is omitted. Requires the Manage Channels permission. Use discord_set_channel_position to reorder within a category. Returns a confirmation.",
     annotations: { title: "Move channel", readOnlyHint: false, destructiveHint: false, idempotentHint: true, openWorldHint: true },
-    inputSchema: {
-      type: "object",
-      properties: {
-        channel_id: { type: "string", description: "ID (snowflake) of the channel to move." },
-        category_id: { type: "string", description: "Target category (snowflake). Omit to move the channel out of any category." },
-      },
-      required: ["channel_id"],
+    schema: z.object({
+      channel_id: snowflake.describe("ID (snowflake) of the channel to move."),
+      category_id: snowflake.optional().describe("Target category (snowflake). Omit to move the channel out of any category."),
+    }),
+    handle: async ({ channel_id, category_id }) => {
+      const channel = await getGuildChannel(channel_id);
+      await channel.edit({ parent: category_id ?? null });
+      return { content: [{ type: "text", text: `✅ Channel #${channel.name} moved.` }] };
     },
-  },
-  {
+  }),
+  defineTool({
     name: "discord_clone_channel",
     description:
       "Create a copy of a channel, including its name, topic, and permission overwrites (but not its messages). Requires the Manage Channels permission. Returns the cloned channel's name and ID.",
     annotations: { title: "Clone channel", readOnlyHint: false, destructiveHint: false, idempotentHint: false, openWorldHint: true },
-    inputSchema: {
-      type: "object",
-      properties: {
-        channel_id: { type: "string", description: "ID (snowflake) of the channel to clone." },
-        new_name: { type: "string", description: "Optional name for the clone. Defaults to the source channel's name." },
-      },
-      required: ["channel_id"],
+    schema: z.object({
+      channel_id: snowflake.describe("ID (snowflake) of the channel to clone."),
+      new_name: z.string().optional().describe("Optional name for the clone. Defaults to the source channel's name."),
+    }),
+    handle: async ({ channel_id, new_name }) => {
+      const channel = await getGuildChannel(channel_id);
+      const cloned = await channel.clone({ name: new_name });
+      return { content: [{ type: "text", text: `✅ Channel cloned as #${cloned.name} (id: ${cloned.id}).` }] };
     },
-  },
-  {
+  }),
+  defineTool({
     name: "discord_set_channel_position",
     description:
       "Set a channel's display order within its category. Use discord_move_channel to change which category it belongs to. Requires the Manage Channels permission. Returns a confirmation.",
     annotations: { title: "Set channel position", readOnlyHint: false, destructiveHint: false, idempotentHint: true, openWorldHint: true },
-    inputSchema: {
-      type: "object",
-      properties: {
-        channel_id: { type: "string", description: "ID (snowflake) of the channel to reposition." },
-        position: { type: "number", description: "Zero-based position within the category (0 = top)." },
-      },
-      required: ["channel_id", "position"],
+    schema: z.object({
+      channel_id: snowflake.describe("ID (snowflake) of the channel to reposition."),
+      position: z.number().describe("Zero-based position within the category (0 = top)."),
+    }),
+    handle: async ({ channel_id, position }) => {
+      const channel = await getGuildChannel(channel_id);
+      await channel.setPosition(position);
+      return { content: [{ type: "text", text: `✅ Channel #${channel.name} moved to position ${position}.` }] };
     },
-  },
-  {
+  }),
+  defineTool({
     name: "discord_follow_announcement_channel",
     description:
       "Subscribe a target channel to an announcement (news) channel, so the source's published messages are reposted into the target. The source must be an announcement channel. Requires the Manage Webhooks permission in the target. Returns a confirmation.",
     annotations: { title: "Follow announcement channel", readOnlyHint: false, destructiveHint: false, idempotentHint: false, openWorldHint: true },
-    inputSchema: {
-      type: "object",
-      properties: {
-        source_channel_id: { type: "string", description: "ID (snowflake) of the announcement channel to follow." },
-        target_channel_id: { type: "string", description: "ID (snowflake) of the channel that will receive published messages." },
-      },
-      required: ["source_channel_id", "target_channel_id"],
+    schema: z.object({
+      source_channel_id: snowflake.describe("ID (snowflake) of the announcement channel to follow."),
+      target_channel_id: snowflake.describe("ID (snowflake) of the channel that will receive published messages."),
+    }),
+    handle: async ({ source_channel_id, target_channel_id }) => {
+      const source = await discord.channels.fetch(source_channel_id);
+      if (!source || !(source instanceof NewsChannel)) throw new Error("Source channel is not an announcement channel.");
+      await source.addFollower(target_channel_id);
+      return { content: [{ type: "text", text: `✅ Now following announcement channel in target channel.` }] };
     },
-  },
-  {
+  }),
+  defineTool({
     name: "discord_lock_channel_permissions",
     description:
       "Reset a channel's permission overwrites to exactly match its parent category (Discord's 'sync permissions'). The channel must be inside a category. Requires the Manage Roles permission. Returns a confirmation.",
     annotations: { title: "Sync channel permissions", readOnlyHint: false, destructiveHint: false, idempotentHint: true, openWorldHint: true },
-    inputSchema: {
-      type: "object",
-      properties: {
-        channel_id: { type: "string", description: "ID (snowflake) of the channel to sync with its parent category." },
-      },
-      required: ["channel_id"],
-    },
-  },
-];
-
-/**
- * Handles channel management tools: create (text/voice/category),
- * delete, edit (name/topic/slowmode), move between categories, and clone.
- */
-export async function handle(name: string, args: Record<string, unknown>): Promise<ToolResult | null> {
-  switch (name) {
-    case "discord_create_channel": {
-      const guild = await discord.guilds.fetch(validateId(args.guild_id, "guild_id"));
-      const typeMap: Record<string, ChannelType> = {
-        text: ChannelType.GuildText, voice: ChannelType.GuildVoice, category: ChannelType.GuildCategory,
-      };
-      const channelType = typeMap[(args.type as string) ?? "text"] ?? ChannelType.GuildText;
-      const created = await guild.channels.create({
-        name: args.name as string, type: channelType as ChannelType.GuildText | ChannelType.GuildVoice | ChannelType.GuildCategory,
-        topic: channelType === ChannelType.GuildText ? (args.topic as string | undefined) : undefined,
-        parent: args.category_id as string | undefined,
-      });
-      return { content: [{ type: "text", text: `✅ Channel #${created.name} created (id: ${created.id}).` }] };
-    }
-
-    case "discord_delete_channel": {
-      const channel = await discord.channels.fetch(validateId(args.channel_id, "channel_id"));
-      if (!channel) throw new Error("Channel not found.");
-      const channelName = "name" in channel ? channel.name : channel.id;
-      await channel.delete(args.reason as string | undefined);
-      return { content: [{ type: "text", text: `✅ Channel #${channelName} deleted.` }] };
-    }
-
-    case "discord_edit_channel": {
-      const channel = await getGuildChannel(args.channel_id as string);
-      const editOptions: Record<string, unknown> = {};
-      if (args.name !== undefined) editOptions.name = args.name as string;
-      if (args.topic !== undefined && channel.type === ChannelType.GuildText) editOptions.topic = args.topic as string;
-      if (args.slowmode !== undefined && channel.type === ChannelType.GuildText) editOptions.rateLimitPerUser = args.slowmode as number;
-      if (args.nsfw !== undefined) editOptions.nsfw = args.nsfw as boolean;
-      await channel.edit(editOptions);
-      return { content: [{ type: "text", text: `✅ Channel #${channel.name} updated.` }] };
-    }
-
-    case "discord_move_channel": {
-      const channel = await getGuildChannel(args.channel_id as string);
-      await channel.edit({ parent: (args.category_id as string | undefined) ?? null });
-      return { content: [{ type: "text", text: `✅ Channel #${channel.name} moved.` }] };
-    }
-
-    case "discord_clone_channel": {
-      const channel = await getGuildChannel(args.channel_id as string);
-      const cloned = await channel.clone({ name: args.new_name as string | undefined });
-      return { content: [{ type: "text", text: `✅ Channel cloned as #${cloned.name} (id: ${cloned.id}).` }] };
-    }
-
-    case "discord_set_channel_position": {
-      const channel = await getGuildChannel(args.channel_id as string);
-      await channel.setPosition(args.position as number);
-      return { content: [{ type: "text", text: `✅ Channel #${channel.name} moved to position ${args.position}.` }] };
-    }
-
-    case "discord_follow_announcement_channel": {
-      const source = await discord.channels.fetch(validateId(args.source_channel_id, "source_channel_id"));
-      if (!source || !(source instanceof NewsChannel)) throw new Error("Source channel is not an announcement channel.");
-      await source.addFollower(validateId(args.target_channel_id, "target_channel_id"));
-      return { content: [{ type: "text", text: `✅ Now following announcement channel in target channel.` }] };
-    }
-
-    case "discord_lock_channel_permissions": {
-      const channel = await getGuildChannel(args.channel_id as string);
+    schema: z.object({
+      channel_id: snowflake.describe("ID (snowflake) of the channel to sync with its parent category."),
+    }),
+    handle: async ({ channel_id }) => {
+      const channel = await getGuildChannel(channel_id);
       await channel.lockPermissions();
       return { content: [{ type: "text", text: `✅ Channel #${channel.name} permissions synced with parent category.` }] };
-    }
+    },
+  }),
+];
 
-    default:
-      return null;
-  }
-}
-
-export default { definitions, handle } satisfies ToolModule;
+export default defineModule(tools);

--- a/src/tools/define.ts
+++ b/src/tools/define.ts
@@ -1,0 +1,73 @@
+import { z } from "zod";
+import type { ToolModule, ToolDefinition, ToolResult, ToolAnnotations } from "./types.js";
+
+/** A Discord snowflake ID: a 17–20 digit string. Reused by every tool that takes an ID. */
+export const snowflake = z
+  .string()
+  .regex(/^\d{17,20}$/, "Must be a Discord snowflake ID (17-20 digits).");
+
+/**
+ * Converts a zod schema into the JSON Schema shape MCP sends over the wire.
+ * `io: "input"` emits the input view (so `.default()`s stay optional); the `$schema`
+ * key zod adds is stripped because MCP `inputSchema` is a bare object schema.
+ */
+function toInputSchema(schema: z.ZodType): Record<string, unknown> {
+  const json = z.toJSONSchema(schema, { io: "input" }) as Record<string, unknown>;
+  delete json.$schema;
+  return json;
+}
+
+/**
+ * A registered tool: its public metadata plus a `run` that validates raw args
+ * with its zod schema before handing typed values to the handler.
+ */
+interface RegisteredTool {
+  name: string;
+  description: string;
+  annotations?: ToolAnnotations;
+  inputSchema: Record<string, unknown>;
+  run(args: Record<string, unknown>): Promise<ToolResult>;
+}
+
+/**
+ * Declares one tool from a single source of truth: the zod `schema` derives the
+ * client-facing `inputSchema` and validates incoming args, so `handle` receives
+ * values already typed and checked — no `as` casts, no schema/handler drift.
+ */
+export function defineTool<S extends z.ZodType>(tool: {
+  name: string;
+  description: string;
+  annotations?: ToolAnnotations;
+  schema: S;
+  handle(args: z.infer<S>): Promise<ToolResult>;
+}): RegisteredTool {
+  return {
+    name: tool.name,
+    description: tool.description,
+    annotations: tool.annotations,
+    inputSchema: toInputSchema(tool.schema),
+    run: (args) => tool.handle(tool.schema.parse(args)),
+  };
+}
+
+/**
+ * Assembles a list of {@link defineTool} tools into a {@link ToolModule}, exposing
+ * their definitions and routing a call to the matching tool (or `null` if none owns
+ * the name, per the module contract). Validation runs inside each tool's `run`.
+ */
+export function defineModule(tools: RegisteredTool[]): ToolModule {
+  const byName = new Map(tools.map((t) => [t.name, t]));
+  const definitions: ToolDefinition[] = tools.map((t) => ({
+    name: t.name,
+    description: t.description,
+    annotations: t.annotations,
+    inputSchema: t.inputSchema,
+  }));
+
+  async function handle(name: string, args: Record<string, unknown>): Promise<ToolResult | null> {
+    const tool = byName.get(name);
+    return tool ? tool.run(args) : null;
+  }
+
+  return { definitions, handle };
+}

--- a/src/tools/define.ts
+++ b/src/tools/define.ts
@@ -10,6 +10,14 @@ export const snowflake = z
 export const guildId = snowflake.describe("Discord server (guild) ID (snowflake).");
 
 /**
+ * A bounded integer field: rejects non-integers and out-of-range values at parse
+ * time and emits `type: "integer"` + `minimum`/`maximum` into the JSON Schema, so
+ * the advertised input contract matches what the handler actually accepts. Append
+ * `.default(n)` for an optional field with a default, or `.optional()` for one with none.
+ */
+export const intIn = (min: number, max: number) => z.int().min(min).max(max);
+
+/**
  * Converts a zod schema into the JSON Schema shape MCP sends over the wire.
  * `io: "input"` emits the input view (so `.default()`s stay optional); the `$schema`
  * key zod adds is stripped because MCP `inputSchema` is a bare object schema.

--- a/src/tools/define.ts
+++ b/src/tools/define.ts
@@ -6,6 +6,9 @@ export const snowflake = z
   .string()
   .regex(/^\d{17,20}$/, "Must be a Discord snowflake ID (17-20 digits).");
 
+/** The `guild_id` field, identical across nearly every guild-scoped tool. */
+export const guildId = snowflake.describe("Discord server (guild) ID (snowflake).");
+
 /**
  * Converts a zod schema into the JSON Schema shape MCP sends over the wire.
  * `io: "input"` emits the input view (so `.default()`s stay optional); the `$schema`

--- a/src/tools/discovery.ts
+++ b/src/tools/discovery.ts
@@ -1,69 +1,33 @@
 import { ChannelType, CategoryChannel, GuildChannel } from "discord.js";
-import { discord, validateId } from "../client.js";
-import type { ToolModule, ToolResult } from "./types.js";
+import { z } from "zod";
+import { discord } from "../client.js";
+import { defineTool, defineModule, guildId } from "./define.js";
 
 /** Tool definitions for server/guild discovery and channel navigation. */
-export const definitions = [
-  {
+const tools = [
+  defineTool({
     name: "discord_list_guilds",
     description:
       "List every Discord server (guild) the bot is a member of (id, name, member count, icon). Takes no arguments. Read-only. Start here to discover the guild_id needed by most other tools.",
     annotations: { title: "List servers", readOnlyHint: true, openWorldHint: true },
-    inputSchema: { type: "object", properties: {} },
-  },
-  {
-    name: "discord_get_guild_info",
-    description:
-      "Get details about one server: name, description, member/channel/role counts, boost tier, owner, and creation date. Read-only. Use discord_get_server_stats for a finer breakdown (humans vs bots, channel types).",
-    annotations: { title: "Get server info", readOnlyHint: true, openWorldHint: true },
-    inputSchema: {
-      type: "object",
-      properties: { guild_id: { type: "string", description: "Discord server (guild) ID (snowflake)." } },
-      required: ["guild_id"],
-    },
-  },
-  {
-    name: "discord_list_channels",
-    description:
-      "List all channels in a server, grouped by their parent category and ordered by position. Returns a JSON object keyed by category name. Read-only. Use discord_find_channel_by_name to locate a specific channel.",
-    annotations: { title: "List channels", readOnlyHint: true, openWorldHint: true },
-    inputSchema: {
-      type: "object",
-      properties: { guild_id: { type: "string", description: "Discord server (guild) ID (snowflake)." } },
-      required: ["guild_id"],
-    },
-  },
-  {
-    name: "discord_find_channel_by_name",
-    description:
-      "Find channels whose name contains a substring (case-insensitive). Returns matching channels (id, name, type) as a JSON array. Read-only. Useful for resolving a channel_id when you only know the channel's name.",
-    annotations: { title: "Find channel by name", readOnlyHint: true, openWorldHint: true },
-    inputSchema: {
-      type: "object",
-      properties: {
-        guild_id: { type: "string", description: "Discord server (guild) ID (snowflake)." },
-        name: { type: "string", description: "Case-insensitive substring to match against channel names." },
-      },
-      required: ["guild_id", "name"],
-    },
-  },
-];
-
-/**
- * Handles discovery tools: listing guilds, fetching guild info,
- * listing channels by category, and searching channels by name.
- */
-export async function handle(name: string, args: Record<string, unknown>): Promise<ToolResult | null> {
-  switch (name) {
-    case "discord_list_guilds": {
+    schema: z.object({}),
+    handle: async () => {
       const guilds = discord.guilds.cache.map((g) => ({
         id: g.id, name: g.name, memberCount: g.memberCount, icon: g.iconURL(),
       }));
       return { content: [{ type: "text", text: JSON.stringify(guilds, null, 2) }] };
-    }
-
-    case "discord_get_guild_info": {
-      const guild = await (await discord.guilds.fetch(validateId(args.guild_id, "guild_id"))).fetch();
+    },
+  }),
+  defineTool({
+    name: "discord_get_guild_info",
+    description:
+      "Get details about one server: name, description, member/channel/role counts, boost tier, owner, and creation date. Read-only. Use discord_get_server_stats for a finer breakdown (humans vs bots, channel types).",
+    annotations: { title: "Get server info", readOnlyHint: true, openWorldHint: true },
+    schema: z.object({
+      guild_id: guildId,
+    }),
+    handle: async ({ guild_id }) => {
+      const guild = await (await discord.guilds.fetch(guild_id)).fetch();
       return {
         content: [{
           type: "text", text: JSON.stringify({
@@ -74,10 +38,18 @@ export async function handle(name: string, args: Record<string, unknown>): Promi
           }, null, 2),
         }],
       };
-    }
-
-    case "discord_list_channels": {
-      const guild = await discord.guilds.fetch(validateId(args.guild_id, "guild_id"));
+    },
+  }),
+  defineTool({
+    name: "discord_list_channels",
+    description:
+      "List all channels in a server, grouped by their parent category and ordered by position. Returns a JSON object keyed by category name. Read-only. Use discord_find_channel_by_name to locate a specific channel.",
+    annotations: { title: "List channels", readOnlyHint: true, openWorldHint: true },
+    schema: z.object({
+      guild_id: guildId,
+    }),
+    handle: async ({ guild_id }) => {
+      const guild = await discord.guilds.fetch(guild_id);
       await guild.channels.fetch();
       const categories = guild.channels.cache
         .filter((c) => c.type === ChannelType.GuildCategory)
@@ -97,21 +69,27 @@ export async function handle(name: string, args: Record<string, unknown>): Promi
         });
 
       return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
-    }
-
-    case "discord_find_channel_by_name": {
-      const guild = await discord.guilds.fetch(validateId(args.guild_id, "guild_id"));
+    },
+  }),
+  defineTool({
+    name: "discord_find_channel_by_name",
+    description:
+      "Find channels whose name contains a substring (case-insensitive). Returns matching channels (id, name, type) as a JSON array. Read-only. Useful for resolving a channel_id when you only know the channel's name.",
+    annotations: { title: "Find channel by name", readOnlyHint: true, openWorldHint: true },
+    schema: z.object({
+      guild_id: guildId,
+      name: z.string().describe("Case-insensitive substring to match against channel names."),
+    }),
+    handle: async ({ guild_id, name }) => {
+      const guild = await discord.guilds.fetch(guild_id);
       await guild.channels.fetch();
-      const keyword = (args.name as string).toLowerCase();
+      const keyword = name.toLowerCase();
       const matches = guild.channels.cache
         .filter((c) => c.name.toLowerCase().includes(keyword))
         .map((c) => ({ id: c.id, name: c.name, type: ChannelType[c.type] }));
       return { content: [{ type: "text", text: JSON.stringify(matches, null, 2) }] };
-    }
+    },
+  }),
+];
 
-    default:
-      return null;
-  }
-}
-
-export default { definitions, handle } satisfies ToolModule;
+export default defineModule(tools);

--- a/src/tools/dm.ts
+++ b/src/tools/dm.ts
@@ -1,183 +1,120 @@
-import { discord, validateId, clampInt } from "../client.js";
-import { buildEmbed, EMBED_FIELD_PROPS } from "../embeds.js";
-import type { ToolModule, ToolResult } from "./types.js";
+import { z } from "zod";
+import { discord, clampInt } from "../client.js";
+import { buildEmbed, embedFieldsShape } from "../embeds.js";
+import { defineTool, defineModule, snowflake } from "./define.js";
 
-const userIdProp = {
-  user_id: { type: "string", description: "Discord user ID (snowflake) of the DM recipient." },
-} as const;
-
-const messageIdProp = {
-  message_id: { type: "string", description: "ID of the target message within the DM conversation." },
-} as const;
+const userId = snowflake.describe("Discord user ID (snowflake) of the DM recipient.");
+const messageId = snowflake.describe("ID of the target message within the DM conversation.");
 
 /** Tool definitions for direct messages. */
-export const definitions = [
-  {
+const tools = [
+  defineTool({
     name: "discord_send_dm",
     description:
       "Send a private direct message to a user by their user ID. Use discord_send_message to post in a server channel instead. Requires the bot to share at least one server with the user, and the user must allow DMs from server members (otherwise Discord rejects the send). Returns the new message ID.",
     annotations: { title: "Send DM", readOnlyHint: false, destructiveHint: false, idempotentHint: false, openWorldHint: true },
-    inputSchema: {
-      type: "object",
-      properties: {
-        ...userIdProp,
-        content: { type: "string", description: "Plain-text body of the DM (max 2000 characters)." },
-      },
-      required: ["user_id", "content"],
+    schema: z.object({
+      user_id: userId,
+      content: z.string().describe("Plain-text body of the DM (max 2000 characters)."),
+    }),
+    handle: async ({ user_id, content }) => {
+      const user = await discord.users.fetch(user_id);
+      const sent = await user.send(content);
+      return { content: [{ type: "text", text: `✅ DM sent to ${user.username} (message id: ${sent.id}).` }] };
     },
-  },
-  {
+  }),
+  defineTool({
     name: "discord_send_dm_embed",
     description:
       "Send a rich embed as a private direct message to a user. Use discord_send_dm for plain text, or discord_send_embed to post an embed in a channel. Requires the bot to share a server with the user, and the user must allow DMs from server members. Returns the new message ID.",
     annotations: { title: "Send DM embed", readOnlyHint: false, destructiveHint: false, idempotentHint: false, openWorldHint: true },
-    inputSchema: {
-      type: "object",
-      properties: {
-        ...userIdProp,
-        content: { type: "string", description: "Optional plain text shown above the embed." },
-        ...EMBED_FIELD_PROPS,
-      },
-      required: ["user_id"],
+    schema: z.object({
+      user_id: userId,
+      content: z.string().optional().describe("Optional plain text shown above the embed."),
+      ...embedFieldsShape,
+    }),
+    handle: async ({ user_id, content, ...embedArgs }) => {
+      const user = await discord.users.fetch(user_id);
+      const sent = await user.send({
+        content: content || undefined,
+        embeds: [buildEmbed(embedArgs)],
+      });
+      return { content: [{ type: "text", text: `✅ DM embed sent to ${user.username} (message id: ${sent.id}).` }] };
     },
-  },
-  {
+  }),
+  defineTool({
     name: "discord_edit_dm",
     description:
       "Edit the text content of a DM message previously sent by this bot. Only the bot's own DM messages can be edited. Use discord_edit_dm_embed for embed messages. Returns a confirmation.",
     annotations: { title: "Edit DM", readOnlyHint: false, destructiveHint: false, idempotentHint: true, openWorldHint: true },
-    inputSchema: {
-      type: "object",
-      properties: {
-        ...userIdProp,
-        ...messageIdProp,
-        content: { type: "string", description: "New plain-text content that fully replaces the existing message (max 2000 characters)." },
-      },
-      required: ["user_id", "message_id", "content"],
+    schema: z.object({
+      user_id: userId,
+      message_id: messageId,
+      content: z.string().describe("New plain-text content that fully replaces the existing message (max 2000 characters)."),
+    }),
+    handle: async ({ user_id, message_id, content }) => {
+      const user = await discord.users.fetch(user_id);
+      const dm = await user.createDM();
+      const msg = await dm.messages.fetch(message_id);
+      if (msg.author.id !== discord.user?.id) throw new Error("Can only edit messages sent by the bot.");
+      await msg.edit(content);
+      return { content: [{ type: "text", text: `✅ DM message ${message_id} edited for ${user.username}.` }] };
     },
-  },
-  {
+  }),
+  defineTool({
     name: "discord_edit_dm_embed",
     description:
       "Replace the embed on a DM message previously sent by this bot. Only the bot's own messages can be edited. Full replace, not merge: provided fields are applied and omitted fields are dropped. Returns a confirmation.",
     annotations: { title: "Edit DM embed", readOnlyHint: false, destructiveHint: false, idempotentHint: true, openWorldHint: true },
-    inputSchema: {
-      type: "object",
-      properties: {
-        ...userIdProp,
-        ...messageIdProp,
-        content: { type: "string", description: "Optional new plain text shown above the embed." },
-        ...EMBED_FIELD_PROPS,
-      },
-      required: ["user_id", "message_id"],
+    schema: z.object({
+      user_id: userId,
+      message_id: messageId,
+      content: z.string().optional().describe("Optional new plain text shown above the embed."),
+      ...embedFieldsShape,
+    }),
+    handle: async ({ user_id, message_id, content, ...embedArgs }) => {
+      const user = await discord.users.fetch(user_id);
+      const dm = await user.createDM();
+      const msg = await dm.messages.fetch(message_id);
+      if (msg.author.id !== discord.user?.id) throw new Error("Can only edit embeds sent by the bot.");
+      await msg.edit({
+        content: content || undefined,
+        embeds: [buildEmbed(embedArgs)],
+      });
+      return { content: [{ type: "text", text: `✅ DM embed edited on message ${message_id} for ${user.username}.` }] };
     },
-  },
-  {
+  }),
+  defineTool({
     name: "discord_delete_dm",
     description:
       "Permanently delete a DM message previously sent by this bot. IRREVERSIBLE. The bot can only delete its own DM messages, not the recipient's. Returns a confirmation.",
     annotations: { title: "Delete DM", readOnlyHint: false, destructiveHint: true, idempotentHint: false, openWorldHint: true },
-    inputSchema: {
-      type: "object",
-      properties: {
-        ...userIdProp,
-        ...messageIdProp,
-      },
-      required: ["user_id", "message_id"],
+    schema: z.object({
+      user_id: userId,
+      message_id: messageId,
+    }),
+    handle: async ({ user_id, message_id }) => {
+      const user = await discord.users.fetch(user_id);
+      const dm = await user.createDM();
+      const msg = await dm.messages.fetch(message_id);
+      if (msg.author.id !== discord.user?.id) throw new Error("Can only delete messages sent by the bot.");
+      await msg.delete();
+      return { content: [{ type: "text", text: `✅ DM message ${message_id} deleted for ${user.username}.` }] };
     },
-  },
-  {
+  }),
+  defineTool({
     name: "discord_read_dms",
     description:
       "Read the most recent messages from the bot's DM conversation with a user, oldest-to-newest. Returns a JSON array (id, author, content, embed count, timestamp). Read-only.",
     annotations: { title: "Read DMs", readOnlyHint: true, openWorldHint: true },
-    inputSchema: {
-      type: "object",
-      properties: {
-        ...userIdProp,
-        limit: { type: "number", description: "How many recent messages to fetch (1–100). Default 20." },
-      },
-      required: ["user_id"],
-    },
-  },
-  {
-    name: "discord_reply_dm",
-    description:
-      "Reply to a specific message in a DM, attaching a quoted reply reference. Unlike the edit/delete DM tools, this works on any message in the conversation (the bot's or the user's). Use discord_send_dm for a standalone DM with no reference. Returns the new reply's message ID.",
-    annotations: { title: "Reply to DM", readOnlyHint: false, destructiveHint: false, idempotentHint: false, openWorldHint: true },
-    inputSchema: {
-      type: "object",
-      properties: {
-        ...userIdProp,
-        ...messageIdProp,
-        content: { type: "string", description: "Plain-text body of the reply (max 2000 characters)." },
-      },
-      required: ["user_id", "message_id", "content"],
-    },
-  },
-];
-
-/** Handles direct message tools. */
-async function handle(
-  name: string,
-  args: Record<string, unknown>
-): Promise<ToolResult | null> {
-  switch (name) {
-    case "discord_send_dm": {
-      const user = await discord.users.fetch(validateId(args.user_id, "user_id"));
-      const sent = await user.send(args.content as string);
-      return { content: [{ type: "text", text: `✅ DM sent to ${user.username} (message id: ${sent.id}).` }] };
-    }
-
-    case "discord_send_dm_embed": {
-      const user = await discord.users.fetch(validateId(args.user_id, "user_id"));
-      const embed = buildEmbed(args);
-      const sent = await user.send({
-        content: (args.content as string) || undefined,
-        embeds: [embed],
-      });
-      return { content: [{ type: "text", text: `✅ DM embed sent to ${user.username} (message id: ${sent.id}).` }] };
-    }
-
-    case "discord_edit_dm": {
-      const user = await discord.users.fetch(validateId(args.user_id, "user_id"));
+    schema: z.object({
+      user_id: userId,
+      limit: z.number().optional().describe("How many recent messages to fetch (1–100). Default 20."),
+    }),
+    handle: async ({ user_id, limit }) => {
+      const user = await discord.users.fetch(user_id);
       const dm = await user.createDM();
-      const msgId = validateId(args.message_id, "message_id");
-      const msg = await dm.messages.fetch(msgId);
-      if (msg.author.id !== discord.user?.id) throw new Error("Can only edit messages sent by the bot.");
-      await msg.edit(args.content as string);
-      return { content: [{ type: "text", text: `✅ DM message ${msgId} edited for ${user.username}.` }] };
-    }
-
-    case "discord_edit_dm_embed": {
-      const user = await discord.users.fetch(validateId(args.user_id, "user_id"));
-      const dm = await user.createDM();
-      const msgId = validateId(args.message_id, "message_id");
-      const msg = await dm.messages.fetch(msgId);
-      if (msg.author.id !== discord.user?.id) throw new Error("Can only edit embeds sent by the bot.");
-      const embed = buildEmbed(args);
-      await msg.edit({
-        content: (args.content as string) || undefined,
-        embeds: [embed],
-      });
-      return { content: [{ type: "text", text: `✅ DM embed edited on message ${msgId} for ${user.username}.` }] };
-    }
-
-    case "discord_delete_dm": {
-      const user = await discord.users.fetch(validateId(args.user_id, "user_id"));
-      const dm = await user.createDM();
-      const msgId = validateId(args.message_id, "message_id");
-      const msg = await dm.messages.fetch(msgId);
-      if (msg.author.id !== discord.user?.id) throw new Error("Can only delete messages sent by the bot.");
-      await msg.delete();
-      return { content: [{ type: "text", text: `✅ DM message ${msgId} deleted for ${user.username}.` }] };
-    }
-
-    case "discord_read_dms": {
-      const user = await discord.users.fetch(validateId(args.user_id, "user_id"));
-      const dm = await user.createDM();
-      const limit = clampInt(args.limit, 1, 100, 20);
-      const messages = await dm.messages.fetch({ limit });
+      const messages = await dm.messages.fetch({ limit: clampInt(limit, 1, 100, 20) });
       const result = [...messages.values()]
         .sort((a, b) => a.createdTimestamp - b.createdTimestamp)
         .map((m) => ({
@@ -188,20 +125,26 @@ async function handle(
           timestamp: m.createdAt.toISOString(),
         }));
       return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
-    }
-
-    case "discord_reply_dm": {
-      const user = await discord.users.fetch(validateId(args.user_id, "user_id"));
+    },
+  }),
+  defineTool({
+    name: "discord_reply_dm",
+    description:
+      "Reply to a specific message in a DM, attaching a quoted reply reference. Unlike the edit/delete DM tools, this works on any message in the conversation (the bot's or the user's). Use discord_send_dm for a standalone DM with no reference. Returns the new reply's message ID.",
+    annotations: { title: "Reply to DM", readOnlyHint: false, destructiveHint: false, idempotentHint: false, openWorldHint: true },
+    schema: z.object({
+      user_id: userId,
+      message_id: messageId,
+      content: z.string().describe("Plain-text body of the reply (max 2000 characters)."),
+    }),
+    handle: async ({ user_id, message_id, content }) => {
+      const user = await discord.users.fetch(user_id);
       const dm = await user.createDM();
-      const msgId = validateId(args.message_id, "message_id");
-      const target = await dm.messages.fetch(msgId);
-      const sent = await target.reply(args.content as string);
+      const target = await dm.messages.fetch(message_id);
+      const sent = await target.reply(content);
       return { content: [{ type: "text", text: `✅ DM reply sent to ${user.username} (message id: ${sent.id}).` }] };
-    }
+    },
+  }),
+];
 
-    default:
-      return null;
-  }
-}
-
-export default { definitions, handle } satisfies ToolModule;
+export default defineModule(tools);

--- a/src/tools/dm.ts
+++ b/src/tools/dm.ts
@@ -1,7 +1,7 @@
 import { z } from "zod";
-import { discord, clampInt } from "../client.js";
+import { discord } from "../client.js";
 import { buildEmbed, embedFieldsShape } from "../embeds.js";
-import { defineTool, defineModule, snowflake } from "./define.js";
+import { defineTool, defineModule, snowflake, intIn } from "./define.js";
 
 const userId = snowflake.describe("Discord user ID (snowflake) of the DM recipient.");
 const messageId = snowflake.describe("ID of the target message within the DM conversation.");
@@ -109,12 +109,12 @@ const tools = [
     annotations: { title: "Read DMs", readOnlyHint: true, openWorldHint: true },
     schema: z.object({
       user_id: userId,
-      limit: z.number().optional().describe("How many recent messages to fetch (1–100). Default 20."),
+      limit: intIn(1, 100).default(20).describe("How many recent messages to fetch (1–100). Default 20."),
     }),
     handle: async ({ user_id, limit }) => {
       const user = await discord.users.fetch(user_id);
       const dm = await user.createDM();
-      const messages = await dm.messages.fetch({ limit: clampInt(limit, 1, 100, 20) });
+      const messages = await dm.messages.fetch({ limit });
       const result = [...messages.values()]
         .sort((a, b) => a.createdTimestamp - b.createdTimestamp)
         .map((m) => ({

--- a/src/tools/forums.ts
+++ b/src/tools/forums.ts
@@ -1,7 +1,7 @@
 import { ChannelType, ForumChannel, ThreadChannel } from "discord.js";
 import { z } from "zod";
-import { discord, clampInt } from "../client.js";
-import { defineTool, defineModule, snowflake, guildId } from "./define.js";
+import { discord } from "../client.js";
+import { defineTool, defineModule, snowflake, guildId, intIn } from "./define.js";
 
 const threadId = snowflake.describe("ID (snowflake) of the forum post (thread).");
 
@@ -99,12 +99,11 @@ const tools = [
     annotations: { title: "Get forum post", readOnlyHint: true, openWorldHint: true },
     schema: z.object({
       thread_id: threadId.describe("ID (snowflake) of the forum post (thread)."),
-      limit: z.number().optional().describe("How many recent messages to include (1–100). Default 20."),
+      limit: intIn(1, 100).default(20).describe("How many recent messages to include (1–100). Default 20."),
     }),
     handle: async ({ thread_id, limit }) => {
       const thread = await getThreadChannel(thread_id);
-      const max = clampInt(limit, 1, 100, 20);
-      const messages = await thread.messages.fetch({ limit: max });
+      const messages = await thread.messages.fetch({ limit });
       const result = {
         id: thread.id,
         name: thread.name,
@@ -132,19 +131,18 @@ const tools = [
     annotations: { title: "List forum threads", readOnlyHint: true, openWorldHint: true },
     schema: z.object({
       forum_channel_id: snowflake.describe("ID (snowflake) of the forum channel to list posts from."),
-      limit: z.number().optional().describe("Max archived posts per page (1–100). Default 100."),
+      limit: intIn(1, 100).default(100).describe("Max archived posts per page (1–100). Default 100."),
       before: z.string().optional().describe("Pagination cursor: an ISO timestamp. Pass the previous response's nextBefore to fetch older archived posts. When set, active posts are omitted."),
     }),
     handle: async ({ forum_channel_id, limit, before }) => {
       const forum = await getForumChannel(forum_channel_id);
-      const max = clampInt(limit, 1, 100, 100);
       const beforeDate = before !== undefined ? new Date(before) : undefined;
       const collected: ThreadChannel[] = [];
       if (beforeDate === undefined) {
         const active = await forum.threads.fetchActive();
         collected.push(...active.threads.values());
       }
-      const archived = await forum.threads.fetchArchived({ limit: max, before: beforeDate });
+      const archived = await forum.threads.fetchArchived({ limit, before: beforeDate });
       collected.push(...archived.threads.values());
       const threads = collected.map((t) => ({
         id: t.id,

--- a/src/tools/forums.ts
+++ b/src/tools/forums.ts
@@ -1,181 +1,15 @@
 import { ChannelType, ForumChannel, ThreadChannel } from "discord.js";
-import { discord, validateId, clampInt } from "../client.js";
-import type { ToolModule, ToolResult } from "./types.js";
+import { z } from "zod";
+import { discord, clampInt } from "../client.js";
+import { defineTool, defineModule, snowflake, guildId } from "./define.js";
 
-/** Tool definitions for managing forum channels, posts, tags, and threads. */
-export const definitions = [
-  {
-    name: "discord_get_forum_channels",
-    description:
-      "List the forum channels in a server (id, name, topic, parent category). Read-only. Use discord_get_forum_tags to see a forum's available tags, or discord_list_forum_threads for its posts.",
-    annotations: { title: "List forum channels", readOnlyHint: true, openWorldHint: true },
-    inputSchema: {
-      type: "object",
-      properties: {
-        guild_id: { type: "string", description: "Discord server (guild) ID (snowflake)." },
-      },
-      required: ["guild_id"],
-    },
-  },
-  {
-    name: "discord_create_forum_channel",
-    description:
-      "Create a new forum channel in a server. A forum holds posts (threads) rather than a linear message feed. Requires the Manage Channels permission. Use discord_create_channel for text/voice channels instead. Returns the new channel's name and ID.",
-    annotations: { title: "Create forum channel", readOnlyHint: false, destructiveHint: false, idempotentHint: false, openWorldHint: true },
-    inputSchema: {
-      type: "object",
-      properties: {
-        guild_id: { type: "string", description: "Discord server (guild) ID (snowflake)." },
-        name: { type: "string", description: "Name of the new forum channel (max 100 characters)." },
-        topic: { type: "string", description: "Guidelines/topic text shown at the top of the forum." },
-        category_id: { type: "string", description: "Optional category (snowflake) to nest the forum under." },
-      },
-      required: ["guild_id", "name"],
-    },
-  },
-  {
-    name: "discord_create_forum_post",
-    description:
-      "Create a new post (a thread with a starter message) in a forum channel. Requires the Send Messages and Create Public Threads permissions. Use discord_reply_to_forum to add follow-up messages. Returns the new post's name and thread ID.",
-    annotations: { title: "Create forum post", readOnlyHint: false, destructiveHint: false, idempotentHint: false, openWorldHint: true },
-    inputSchema: {
-      type: "object",
-      properties: {
-        forum_channel_id: { type: "string", description: "ID (snowflake) of the forum channel to post in." },
-        title: { type: "string", description: "Title of the post, used as the thread name (max 100 characters)." },
-        content: { type: "string", description: "Body of the post's starter message (max 2000 characters)." },
-        applied_tags: {
-          type: "array",
-          items: { type: "string" },
-          description: "Optional tag IDs to apply. Get valid IDs from discord_get_forum_tags.",
-        },
-      },
-      required: ["forum_channel_id", "title", "content"],
-    },
-  },
-  {
-    name: "discord_get_forum_post",
-    description:
-      "Get a forum post's details (title, archived/locked state, applied tags, message count) plus its recent messages, oldest-to-newest. Read-only. Pass the post's thread_id. Returns a JSON object.",
-    annotations: { title: "Get forum post", readOnlyHint: true, openWorldHint: true },
-    inputSchema: {
-      type: "object",
-      properties: {
-        thread_id: { type: "string", description: "ID (snowflake) of the forum post (thread)." },
-        limit: { type: "number", description: "How many recent messages to include (1–100). Default 20." },
-      },
-      required: ["thread_id"],
-    },
-  },
-  {
-    name: "discord_list_forum_threads",
-    description:
-      "List posts in a forum channel. Returns { threads: [...], hasMore, nextBefore }. The first call (no `before`) includes all active posts plus the first page of archived posts; archived posts are paginated, so if hasMore is true pass nextBefore back as `before` to fetch older archived posts. Read-only. Use discord_get_forum_post to read one post's messages.",
-    annotations: { title: "List forum threads", readOnlyHint: true, openWorldHint: true },
-    inputSchema: {
-      type: "object",
-      properties: {
-        forum_channel_id: { type: "string", description: "ID (snowflake) of the forum channel to list posts from." },
-        limit: { type: "number", description: "Max archived posts per page (1–100). Default 100." },
-        before: { type: "string", description: "Pagination cursor: an ISO timestamp. Pass the previous response's nextBefore to fetch older archived posts. When set, active posts are omitted." },
-      },
-      required: ["forum_channel_id"],
-    },
-  },
-  {
-    name: "discord_reply_to_forum",
-    description:
-      "Post a follow-up message inside an existing forum post (thread). Requires the Send Messages permission. Use discord_create_forum_post to start a new post instead. Returns the new message ID.",
-    annotations: { title: "Reply to forum post", readOnlyHint: false, destructiveHint: false, idempotentHint: false, openWorldHint: true },
-    inputSchema: {
-      type: "object",
-      properties: {
-        thread_id: { type: "string", description: "ID (snowflake) of the forum post (thread) to reply in." },
-        content: { type: "string", description: "Plain-text body of the reply (max 2000 characters)." },
-      },
-      required: ["thread_id", "content"],
-    },
-  },
-  {
-    name: "discord_delete_forum_post",
-    description:
-      "Permanently delete a forum post (thread) and all its messages. IRREVERSIBLE. To merely close it without deleting, use discord_update_forum_post with archived:true. Requires the Manage Threads permission (or thread ownership).",
-    annotations: { title: "Delete forum post", readOnlyHint: false, destructiveHint: true, idempotentHint: false, openWorldHint: true },
-    inputSchema: {
-      type: "object",
-      properties: {
-        thread_id: { type: "string", description: "ID (snowflake) of the forum post (thread) to delete." },
-      },
-      required: ["thread_id"],
-    },
-  },
-  {
-    name: "discord_get_forum_tags",
-    description:
-      "List the tags available on a forum channel (id, name, emoji, moderated flag). Read-only. Use these IDs with discord_create_forum_post or discord_update_forum_post; manage the tag set with discord_set_forum_tags.",
-    annotations: { title: "Get forum tags", readOnlyHint: true, openWorldHint: true },
-    inputSchema: {
-      type: "object",
-      properties: {
-        forum_channel_id: { type: "string", description: "ID (snowflake) of the forum channel to read tags from." },
-      },
-      required: ["forum_channel_id"],
-    },
-  },
-  {
-    name: "discord_set_forum_tags",
-    description:
-      "Replace the full set of available tags on a forum channel with the provided list. This overwrites existing tags, so include every tag you want to keep. Requires the Manage Channels permission. Returns a confirmation.",
-    annotations: { title: "Set forum tags", readOnlyHint: false, destructiveHint: false, idempotentHint: true, openWorldHint: true },
-    inputSchema: {
-      type: "object",
-      properties: {
-        forum_channel_id: { type: "string", description: "ID (snowflake) of the forum channel to set tags on." },
-        tags: {
-          type: "array",
-          description: "Complete list of tags to set (replaces all existing tags).",
-          items: {
-            type: "object",
-            properties: {
-              name: { type: "string", description: "Tag label (max 20 characters)." },
-              emoji_name: { type: "string", description: "Optional unicode emoji shown on the tag." },
-              moderated: { type: "boolean", description: "If true, only members with Manage Threads can apply this tag. Default false." },
-            },
-            required: ["name"],
-          },
-        },
-      },
-      required: ["forum_channel_id", "tags"],
-    },
-  },
-  {
-    name: "discord_update_forum_post",
-    description:
-      "Update a forum post's title, archived/locked state, or applied tags. Only provided fields change; passing applied_tags replaces the post's tags. Set archived:true to close a post without deleting it. Requires the Manage Threads permission (or thread ownership).",
-    annotations: { title: "Update forum post", readOnlyHint: false, destructiveHint: false, idempotentHint: true, openWorldHint: true },
-    inputSchema: {
-      type: "object",
-      properties: {
-        thread_id: { type: "string", description: "ID (snowflake) of the forum post (thread) to update." },
-        title: { type: "string", description: "New title/thread name (max 100 characters)." },
-        archived: { type: "boolean", description: "true to archive (close) the post, false to reopen it." },
-        locked: { type: "boolean", description: "true to lock the post so only moderators can reply." },
-        applied_tags: {
-          type: "array",
-          items: { type: "string" },
-          description: "Tag IDs to apply; replaces the post's current tags. Get valid IDs from discord_get_forum_tags.",
-        },
-      },
-      required: ["thread_id"],
-    },
-  },
-];
+const threadId = snowflake.describe("ID (snowflake) of the forum post (thread).");
 
 /**
  * Fetches a channel by ID and guarantees it is a forum channel.
  */
 async function getForumChannel(channelId: string): Promise<ForumChannel> {
-  const channel = await discord.channels.fetch(validateId(channelId, "forum_channel_id"));
+  const channel = await discord.channels.fetch(channelId);
   if (!channel || channel.type !== ChannelType.GuildForum)
     throw new Error(`Channel ${channelId} is not a forum channel or doesn't exist.`);
   return channel as ForumChannel;
@@ -184,21 +18,25 @@ async function getForumChannel(channelId: string): Promise<ForumChannel> {
 /**
  * Fetches a channel by ID and guarantees it is a thread channel.
  */
-async function getThreadChannel(threadId: string): Promise<ThreadChannel> {
-  const channel = await discord.channels.fetch(validateId(threadId, "thread_id"));
+async function getThreadChannel(id: string): Promise<ThreadChannel> {
+  const channel = await discord.channels.fetch(id);
   if (!channel || !channel.isThread())
-    throw new Error(`Channel ${threadId} is not a thread or doesn't exist.`);
+    throw new Error(`Channel ${id} is not a thread or doesn't exist.`);
   return channel as ThreadChannel;
 }
 
-/**
- * Handles all forum-related tools: list forums, create forum channels,
- * create/get/list/reply/delete/update forum posts, and manage forum tags.
- */
-export async function handle(name: string, args: Record<string, unknown>): Promise<ToolResult | null> {
-  switch (name) {
-    case "discord_get_forum_channels": {
-      const guild = await discord.guilds.fetch(validateId(args.guild_id, "guild_id"));
+/** Tool definitions for managing forum channels, posts, tags, and threads. */
+const tools = [
+  defineTool({
+    name: "discord_get_forum_channels",
+    description:
+      "List the forum channels in a server (id, name, topic, parent category). Read-only. Use discord_get_forum_tags to see a forum's available tags, or discord_list_forum_threads for its posts.",
+    annotations: { title: "List forum channels", readOnlyHint: true, openWorldHint: true },
+    schema: z.object({
+      guild_id: guildId,
+    }),
+    handle: async ({ guild_id }) => {
+      const guild = await discord.guilds.fetch(guild_id);
       const channels = await guild.channels.fetch();
       const forums = [...channels.values()]
         .filter((c) => c && c.type === ChannelType.GuildForum)
@@ -209,33 +47,64 @@ export async function handle(name: string, args: Record<string, unknown>): Promi
           parentId: c!.parentId,
         }));
       return { content: [{ type: "text", text: JSON.stringify(forums, null, 2) }] };
-    }
-
-    case "discord_create_forum_channel": {
-      const guild = await discord.guilds.fetch(validateId(args.guild_id, "guild_id"));
+    },
+  }),
+  defineTool({
+    name: "discord_create_forum_channel",
+    description:
+      "Create a new forum channel in a server. A forum holds posts (threads) rather than a linear message feed. Requires the Manage Channels permission. Use discord_create_channel for text/voice channels instead. Returns the new channel's name and ID.",
+    annotations: { title: "Create forum channel", readOnlyHint: false, destructiveHint: false, idempotentHint: false, openWorldHint: true },
+    schema: z.object({
+      guild_id: guildId,
+      name: z.string().describe("Name of the new forum channel (max 100 characters)."),
+      topic: z.string().optional().describe("Guidelines/topic text shown at the top of the forum."),
+      category_id: snowflake.optional().describe("Optional category (snowflake) to nest the forum under."),
+    }),
+    handle: async ({ guild_id, name, topic, category_id }) => {
+      const guild = await discord.guilds.fetch(guild_id);
       const created = await guild.channels.create({
-        name: args.name as string,
+        name,
         type: ChannelType.GuildForum,
-        topic: args.topic as string | undefined,
-        parent: args.category_id as string | undefined,
+        topic,
+        parent: category_id,
       });
       return { content: [{ type: "text", text: `✅ Forum channel #${created.name} created (id: ${created.id}).` }] };
-    }
-
-    case "discord_create_forum_post": {
-      const forum = await getForumChannel(args.forum_channel_id as string);
+    },
+  }),
+  defineTool({
+    name: "discord_create_forum_post",
+    description:
+      "Create a new post (a thread with a starter message) in a forum channel. Requires the Send Messages and Create Public Threads permissions. Use discord_reply_to_forum to add follow-up messages. Returns the new post's name and thread ID.",
+    annotations: { title: "Create forum post", readOnlyHint: false, destructiveHint: false, idempotentHint: false, openWorldHint: true },
+    schema: z.object({
+      forum_channel_id: snowflake.describe("ID (snowflake) of the forum channel to post in."),
+      title: z.string().describe("Title of the post, used as the thread name (max 100 characters)."),
+      content: z.string().describe("Body of the post's starter message (max 2000 characters)."),
+      applied_tags: z.array(z.string()).optional().describe("Optional tag IDs to apply. Get valid IDs from discord_get_forum_tags."),
+    }),
+    handle: async ({ forum_channel_id, title, content, applied_tags }) => {
+      const forum = await getForumChannel(forum_channel_id);
       const thread = await forum.threads.create({
-        name: args.title as string,
-        message: { content: args.content as string },
-        appliedTags: (args.applied_tags as string[] | undefined) ?? [],
+        name: title,
+        message: { content },
+        appliedTags: applied_tags ?? [],
       });
       return { content: [{ type: "text", text: `✅ Forum post "${thread.name}" created (id: ${thread.id}) in #${forum.name}.` }] };
-    }
-
-    case "discord_get_forum_post": {
-      const thread = await getThreadChannel(args.thread_id as string);
-      const limit = clampInt(args.limit, 1, 100, 20);
-      const messages = await thread.messages.fetch({ limit });
+    },
+  }),
+  defineTool({
+    name: "discord_get_forum_post",
+    description:
+      "Get a forum post's details (title, archived/locked state, applied tags, message count) plus its recent messages, oldest-to-newest. Read-only. Pass the post's thread_id. Returns a JSON object.",
+    annotations: { title: "Get forum post", readOnlyHint: true, openWorldHint: true },
+    schema: z.object({
+      thread_id: threadId.describe("ID (snowflake) of the forum post (thread)."),
+      limit: z.number().optional().describe("How many recent messages to include (1–100). Default 20."),
+    }),
+    handle: async ({ thread_id, limit }) => {
+      const thread = await getThreadChannel(thread_id);
+      const max = clampInt(limit, 1, 100, 20);
+      const messages = await thread.messages.fetch({ limit: max });
       const result = {
         id: thread.id,
         name: thread.name,
@@ -254,18 +123,28 @@ export async function handle(name: string, args: Record<string, unknown>): Promi
           })),
       };
       return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
-    }
-
-    case "discord_list_forum_threads": {
-      const forum = await getForumChannel(args.forum_channel_id as string);
-      const limit = clampInt(args.limit, 1, 100, 100);
-      const before = args.before !== undefined ? new Date(String(args.before)) : undefined;
+    },
+  }),
+  defineTool({
+    name: "discord_list_forum_threads",
+    description:
+      "List posts in a forum channel. Returns { threads: [...], hasMore, nextBefore }. The first call (no `before`) includes all active posts plus the first page of archived posts; archived posts are paginated, so if hasMore is true pass nextBefore back as `before` to fetch older archived posts. Read-only. Use discord_get_forum_post to read one post's messages.",
+    annotations: { title: "List forum threads", readOnlyHint: true, openWorldHint: true },
+    schema: z.object({
+      forum_channel_id: snowflake.describe("ID (snowflake) of the forum channel to list posts from."),
+      limit: z.number().optional().describe("Max archived posts per page (1–100). Default 100."),
+      before: z.string().optional().describe("Pagination cursor: an ISO timestamp. Pass the previous response's nextBefore to fetch older archived posts. When set, active posts are omitted."),
+    }),
+    handle: async ({ forum_channel_id, limit, before }) => {
+      const forum = await getForumChannel(forum_channel_id);
+      const max = clampInt(limit, 1, 100, 100);
+      const beforeDate = before !== undefined ? new Date(before) : undefined;
       const collected: ThreadChannel[] = [];
-      if (before === undefined) {
+      if (beforeDate === undefined) {
         const active = await forum.threads.fetchActive();
         collected.push(...active.threads.values());
       }
-      const archived = await forum.threads.fetchArchived({ limit, before });
+      const archived = await forum.threads.fetchArchived({ limit: max, before: beforeDate });
       collected.push(...archived.threads.values());
       const threads = collected.map((t) => ({
         id: t.id,
@@ -279,23 +158,48 @@ export async function handle(name: string, args: Record<string, unknown>): Promi
       const lastArchived = archived.threads.last();
       const nextBefore = archived.hasMore ? lastArchived?.archivedAt?.toISOString() ?? null : null;
       return { content: [{ type: "text", text: JSON.stringify({ threads, hasMore: archived.hasMore, nextBefore }, null, 2) }] };
-    }
-
-    case "discord_reply_to_forum": {
-      const thread = await getThreadChannel(args.thread_id as string);
-      const sent = await thread.send(args.content as string);
+    },
+  }),
+  defineTool({
+    name: "discord_reply_to_forum",
+    description:
+      "Post a follow-up message inside an existing forum post (thread). Requires the Send Messages permission. Use discord_create_forum_post to start a new post instead. Returns the new message ID.",
+    annotations: { title: "Reply to forum post", readOnlyHint: false, destructiveHint: false, idempotentHint: false, openWorldHint: true },
+    schema: z.object({
+      thread_id: snowflake.describe("ID (snowflake) of the forum post (thread) to reply in."),
+      content: z.string().describe("Plain-text body of the reply (max 2000 characters)."),
+    }),
+    handle: async ({ thread_id, content }) => {
+      const thread = await getThreadChannel(thread_id);
+      const sent = await thread.send(content);
       return { content: [{ type: "text", text: `✅ Reply sent (id: ${sent.id}) in thread "${thread.name}".` }] };
-    }
-
-    case "discord_delete_forum_post": {
-      const thread = await getThreadChannel(args.thread_id as string);
+    },
+  }),
+  defineTool({
+    name: "discord_delete_forum_post",
+    description:
+      "Permanently delete a forum post (thread) and all its messages. IRREVERSIBLE. To merely close it without deleting, use discord_update_forum_post with archived:true. Requires the Manage Threads permission (or thread ownership).",
+    annotations: { title: "Delete forum post", readOnlyHint: false, destructiveHint: true, idempotentHint: false, openWorldHint: true },
+    schema: z.object({
+      thread_id: snowflake.describe("ID (snowflake) of the forum post (thread) to delete."),
+    }),
+    handle: async ({ thread_id }) => {
+      const thread = await getThreadChannel(thread_id);
       const threadName = thread.name;
       await thread.delete();
       return { content: [{ type: "text", text: `✅ Forum post "${threadName}" deleted.` }] };
-    }
-
-    case "discord_get_forum_tags": {
-      const forum = await getForumChannel(args.forum_channel_id as string);
+    },
+  }),
+  defineTool({
+    name: "discord_get_forum_tags",
+    description:
+      "List the tags available on a forum channel (id, name, emoji, moderated flag). Read-only. Use these IDs with discord_create_forum_post or discord_update_forum_post; manage the tag set with discord_set_forum_tags.",
+    annotations: { title: "Get forum tags", readOnlyHint: true, openWorldHint: true },
+    schema: z.object({
+      forum_channel_id: snowflake.describe("ID (snowflake) of the forum channel to read tags from."),
+    }),
+    handle: async ({ forum_channel_id }) => {
+      const forum = await getForumChannel(forum_channel_id);
       const tags = forum.availableTags.map((t) => ({
         id: t.id,
         name: t.name,
@@ -303,33 +207,55 @@ export async function handle(name: string, args: Record<string, unknown>): Promi
         moderated: t.moderated,
       }));
       return { content: [{ type: "text", text: JSON.stringify(tags, null, 2) }] };
-    }
-
-    case "discord_set_forum_tags": {
-      const forum = await getForumChannel(args.forum_channel_id as string);
-      const tags = (args.tags as { name: string; emoji_name?: string; moderated?: boolean }[]).map((t) => ({
+    },
+  }),
+  defineTool({
+    name: "discord_set_forum_tags",
+    description:
+      "Replace the full set of available tags on a forum channel with the provided list. This overwrites existing tags, so include every tag you want to keep. Requires the Manage Channels permission. Returns a confirmation.",
+    annotations: { title: "Set forum tags", readOnlyHint: false, destructiveHint: false, idempotentHint: true, openWorldHint: true },
+    schema: z.object({
+      forum_channel_id: snowflake.describe("ID (snowflake) of the forum channel to set tags on."),
+      tags: z.array(z.object({
+        name: z.string().describe("Tag label (max 20 characters)."),
+        emoji_name: z.string().optional().describe("Optional unicode emoji shown on the tag."),
+        moderated: z.boolean().optional().describe("If true, only members with Manage Threads can apply this tag. Default false."),
+      })).describe("Complete list of tags to set (replaces all existing tags)."),
+    }),
+    handle: async ({ forum_channel_id, tags }) => {
+      const forum = await getForumChannel(forum_channel_id);
+      const mapped = tags.map((t) => ({
         name: t.name,
         emoji: t.emoji_name ? { name: t.emoji_name, id: null } : undefined,
         moderated: t.moderated ?? false,
       }));
-      await forum.setAvailableTags(tags);
-      return { content: [{ type: "text", text: `✅ Forum tags updated on #${forum.name} (${tags.length} tags set).` }] };
-    }
-
-    case "discord_update_forum_post": {
-      const thread = await getThreadChannel(args.thread_id as string);
+      await forum.setAvailableTags(mapped);
+      return { content: [{ type: "text", text: `✅ Forum tags updated on #${forum.name} (${mapped.length} tags set).` }] };
+    },
+  }),
+  defineTool({
+    name: "discord_update_forum_post",
+    description:
+      "Update a forum post's title, archived/locked state, or applied tags. Only provided fields change; passing applied_tags replaces the post's tags. Set archived:true to close a post without deleting it. Requires the Manage Threads permission (or thread ownership).",
+    annotations: { title: "Update forum post", readOnlyHint: false, destructiveHint: false, idempotentHint: true, openWorldHint: true },
+    schema: z.object({
+      thread_id: snowflake.describe("ID (snowflake) of the forum post (thread) to update."),
+      title: z.string().optional().describe("New title/thread name (max 100 characters)."),
+      archived: z.boolean().optional().describe("true to archive (close) the post, false to reopen it."),
+      locked: z.boolean().optional().describe("true to lock the post so only moderators can reply."),
+      applied_tags: z.array(z.string()).optional().describe("Tag IDs to apply; replaces the post's current tags. Get valid IDs from discord_get_forum_tags."),
+    }),
+    handle: async ({ thread_id, title, archived, locked, applied_tags }) => {
+      const thread = await getThreadChannel(thread_id);
       const editOptions: Record<string, unknown> = {};
-      if (args.title !== undefined) editOptions.name = args.title as string;
-      if (args.archived !== undefined) editOptions.archived = args.archived as boolean;
-      if (args.locked !== undefined) editOptions.locked = args.locked as boolean;
-      if (args.applied_tags !== undefined) editOptions.appliedTags = args.applied_tags as string[];
+      if (title !== undefined) editOptions.name = title;
+      if (archived !== undefined) editOptions.archived = archived;
+      if (locked !== undefined) editOptions.locked = locked;
+      if (applied_tags !== undefined) editOptions.appliedTags = applied_tags;
       await thread.edit(editOptions);
       return { content: [{ type: "text", text: `✅ Forum post "${thread.name}" updated.` }] };
-    }
+    },
+  }),
+];
 
-    default:
-      return null;
-  }
-}
-
-export default { definitions, handle } satisfies ToolModule;
+export default defineModule(tools);

--- a/src/tools/invites.ts
+++ b/src/tools/invites.ts
@@ -1,6 +1,6 @@
 import { z } from "zod";
 import { discord } from "../client.js";
-import { defineTool, defineModule, snowflake, guildId } from "./define.js";
+import { defineTool, defineModule, snowflake, guildId, intIn } from "./define.js";
 
 // ─── Helpers ────────────────────────────────────────────────────────────────────
 
@@ -61,8 +61,8 @@ const tools = [
     annotations: { title: "Create invite", readOnlyHint: false, destructiveHint: false, idempotentHint: false, openWorldHint: true },
     schema: z.object({
       channel_id: snowflake.describe("ID (snowflake) of the channel the invite leads to."),
-      max_age: z.number().optional().describe("Invite lifetime in seconds; 0 means it never expires. Default 86400 (24h)."),
-      max_uses: z.number().optional().describe("Maximum number of uses; 0 means unlimited. Default 0."),
+      max_age: intIn(0, 604800).default(86400).describe("Invite lifetime in seconds, 0–604800 (7 days); 0 means it never expires. Default 86400 (24h)."),
+      max_uses: intIn(0, 100).default(0).describe("Maximum number of uses, 0–100; 0 means unlimited. Default 0."),
       unique: z.boolean().optional().describe("If true, always mint a fresh invite instead of reusing an equivalent existing one. Default false."),
       temporary: z.boolean().optional().describe("If true, members who join via this invite are removed when they disconnect (unless they get a role). Default false."),
     }),
@@ -72,10 +72,10 @@ const tools = [
         throw new Error(`Channel ${channel_id} does not support invites.`);
       }
       const invite = await (channel as any).createInvite({
-        maxAge: Number(max_age ?? 86400),
-        maxUses: Number(max_uses ?? 0),
-        unique: Boolean(unique ?? false),
-        temporary: Boolean(temporary ?? false),
+        maxAge: max_age,
+        maxUses: max_uses,
+        unique: unique ?? false,
+        temporary: temporary ?? false,
       });
       return {
         content: [{ type: "text", text: `✅ Invite created: ${invite.url} (code: ${invite.code}, max_age: ${invite.maxAge}s, max_uses: ${invite.maxUses}).` }],

--- a/src/tools/invites.ts
+++ b/src/tools/invites.ts
@@ -1,97 +1,6 @@
-import { discord, validateId } from "../client.js";
-import type { ToolModule, ToolResult } from "./types.js";
-
-/** Tool definitions for managing guild invites. */
-export const definitions = [
-  {
-    name: "discord_list_invites",
-    description:
-      "List all active invites across a server (code, url, channel, inviter, uses, expiry). Requires the Manage Server permission. Read-only. Use discord_list_channel_invites to scope to one channel.",
-    annotations: { title: "List invites", readOnlyHint: true, openWorldHint: true },
-    inputSchema: {
-      type: "object",
-      properties: {
-        guild_id: { type: "string", description: "Discord server (guild) ID (snowflake)." },
-      },
-      required: ["guild_id"],
-    },
-  },
-  {
-    name: "discord_get_invite",
-    description:
-      "Look up details for a single invite by its code, including the target server/channel and usage stats. Works for any public invite, not just this server's. Read-only. Returns a JSON object.",
-    annotations: { title: "Get invite", readOnlyHint: true, openWorldHint: true },
-    inputSchema: {
-      type: "object",
-      properties: {
-        invite_code: {
-          type: "string",
-          description: "The invite code, e.g. 'abc123'. A full discord.gg/abc123 URL is also accepted and stripped.",
-        },
-      },
-      required: ["invite_code"],
-    },
-  },
-  {
-    name: "discord_create_invite",
-    description:
-      "Create an invite link for a channel, optionally limiting its lifetime, uses, and membership type. SECURITY: anyone with the returned link can join the server. Requires the Create Instant Invite permission. Returns the invite URL and code.",
-    annotations: { title: "Create invite", readOnlyHint: false, destructiveHint: false, idempotentHint: false, openWorldHint: true },
-    inputSchema: {
-      type: "object",
-      properties: {
-        channel_id: { type: "string", description: "ID (snowflake) of the channel the invite leads to." },
-        max_age: {
-          type: "number",
-          description: "Invite lifetime in seconds; 0 means it never expires. Default 86400 (24h).",
-        },
-        max_uses: {
-          type: "number",
-          description: "Maximum number of uses; 0 means unlimited. Default 0.",
-        },
-        unique: {
-          type: "boolean",
-          description: "If true, always mint a fresh invite instead of reusing an equivalent existing one. Default false.",
-        },
-        temporary: {
-          type: "boolean",
-          description: "If true, members who join via this invite are removed when they disconnect (unless they get a role). Default false.",
-        },
-      },
-      required: ["channel_id"],
-    },
-  },
-  {
-    name: "discord_delete_invite",
-    description:
-      "Revoke an invite by its code so it can no longer be used. IRREVERSIBLE (the code is freed). Requires the Manage Channels permission (or Manage Server). The reason is recorded in the audit log.",
-    annotations: { title: "Delete invite", readOnlyHint: false, destructiveHint: true, idempotentHint: false, openWorldHint: true },
-    inputSchema: {
-      type: "object",
-      properties: {
-        invite_code: {
-          type: "string",
-          description: "The invite code to revoke. A full discord.gg/<code> URL is also accepted.",
-        },
-        reason: { type: "string", description: "Optional reason recorded in the server audit log." },
-      },
-      required: ["invite_code"],
-    },
-  },
-  {
-    name: "discord_list_channel_invites",
-    description:
-      "List the active invites that point to one specific channel. Unlike discord_list_invites (server-wide), this scopes results to a single channel. Requires the Manage Channels permission. Read-only.",
-    annotations: { title: "List channel invites", readOnlyHint: true, openWorldHint: true },
-    inputSchema: {
-      type: "object",
-      properties: {
-        channel_id: { type: "string", description: "ID (snowflake) of the channel to list invites for." },
-      },
-      required: ["channel_id"],
-    },
-  },
-];
+import { z } from "zod";
+import { discord } from "../client.js";
+import { defineTool, defineModule, snowflake, guildId } from "./define.js";
 
 // ─── Helpers ────────────────────────────────────────────────────────────────────
 
@@ -113,70 +22,103 @@ function serializeInvite(invite: import("discord.js").Invite) {
   };
 }
 
-// ─── Handler ────────────────────────────────────────────────────────────────────
-
-export async function handle(
-  name: string,
-  args: Record<string, unknown>,
-): Promise<ToolResult | null> {
-  switch (name) {
-    case "discord_list_invites": {
-      const guildId = validateId(args.guild_id, "guild_id");
-      const guild = await discord.guilds.fetch(guildId);
+/** Tool definitions for managing guild invites. */
+const tools = [
+  defineTool({
+    name: "discord_list_invites",
+    description:
+      "List all active invites across a server (code, url, channel, inviter, uses, expiry). Requires the Manage Server permission. Read-only. Use discord_list_channel_invites to scope to one channel.",
+    annotations: { title: "List invites", readOnlyHint: true, openWorldHint: true },
+    schema: z.object({
+      guild_id: guildId,
+    }),
+    handle: async ({ guild_id }) => {
+      const guild = await discord.guilds.fetch(guild_id);
       const invites = await guild.invites.fetch();
       const list = [...invites.values()].map(serializeInvite);
       return { content: [{ type: "text", text: JSON.stringify(list, null, 2) }] };
-    }
-
-    case "discord_get_invite": {
-      const code = String(args.invite_code ?? "").replace(/^(https?:\/\/)?(discord\.gg\/)?/, "");
+    },
+  }),
+  defineTool({
+    name: "discord_get_invite",
+    description:
+      "Look up details for a single invite by its code, including the target server/channel and usage stats. Works for any public invite, not just this server's. Read-only. Returns a JSON object.",
+    annotations: { title: "Get invite", readOnlyHint: true, openWorldHint: true },
+    schema: z.object({
+      invite_code: z.string().describe("The invite code, e.g. 'abc123'. A full discord.gg/abc123 URL is also accepted and stripped."),
+    }),
+    handle: async ({ invite_code }) => {
+      const code = invite_code.replace(/^(https?:\/\/)?(discord\.gg\/)?/, "");
       if (!code) throw new Error("invite_code is required.");
       const invite = await discord.fetchInvite(code);
       return { content: [{ type: "text", text: JSON.stringify(serializeInvite(invite), null, 2) }] };
-    }
-
-    case "discord_create_invite": {
-      const channelId = validateId(args.channel_id, "channel_id");
-      const channel = await discord.channels.fetch(channelId);
+    },
+  }),
+  defineTool({
+    name: "discord_create_invite",
+    description:
+      "Create an invite link for a channel, optionally limiting its lifetime, uses, and membership type. SECURITY: anyone with the returned link can join the server. Requires the Create Instant Invite permission. Returns the invite URL and code.",
+    annotations: { title: "Create invite", readOnlyHint: false, destructiveHint: false, idempotentHint: false, openWorldHint: true },
+    schema: z.object({
+      channel_id: snowflake.describe("ID (snowflake) of the channel the invite leads to."),
+      max_age: z.number().optional().describe("Invite lifetime in seconds; 0 means it never expires. Default 86400 (24h)."),
+      max_uses: z.number().optional().describe("Maximum number of uses; 0 means unlimited. Default 0."),
+      unique: z.boolean().optional().describe("If true, always mint a fresh invite instead of reusing an equivalent existing one. Default false."),
+      temporary: z.boolean().optional().describe("If true, members who join via this invite are removed when they disconnect (unless they get a role). Default false."),
+    }),
+    handle: async ({ channel_id, max_age, max_uses, unique, temporary }) => {
+      const channel = await discord.channels.fetch(channel_id);
       if (!channel || !("createInvite" in channel)) {
-        throw new Error(`Channel ${channelId} does not support invites.`);
+        throw new Error(`Channel ${channel_id} does not support invites.`);
       }
-
       const invite = await (channel as any).createInvite({
-        maxAge: Number(args.max_age ?? 86400),
-        maxUses: Number(args.max_uses ?? 0),
-        unique: Boolean(args.unique ?? false),
-        temporary: Boolean(args.temporary ?? false),
+        maxAge: Number(max_age ?? 86400),
+        maxUses: Number(max_uses ?? 0),
+        unique: Boolean(unique ?? false),
+        temporary: Boolean(temporary ?? false),
       });
       return {
         content: [{ type: "text", text: `✅ Invite created: ${invite.url} (code: ${invite.code}, max_age: ${invite.maxAge}s, max_uses: ${invite.maxUses}).` }],
       };
-    }
-
-    case "discord_delete_invite": {
-      const code = String(args.invite_code ?? "").replace(/^(https?:\/\/)?(discord\.gg\/)?/, "");
+    },
+  }),
+  defineTool({
+    name: "discord_delete_invite",
+    description:
+      "Revoke an invite by its code so it can no longer be used. IRREVERSIBLE (the code is freed). Requires the Manage Channels permission (or Manage Server). The reason is recorded in the audit log.",
+    annotations: { title: "Delete invite", readOnlyHint: false, destructiveHint: true, idempotentHint: false, openWorldHint: true },
+    schema: z.object({
+      invite_code: z.string().describe("The invite code to revoke. A full discord.gg/<code> URL is also accepted."),
+      reason: z.string().optional().describe("Optional reason recorded in the server audit log."),
+    }),
+    handle: async ({ invite_code, reason }) => {
+      const code = invite_code.replace(/^(https?:\/\/)?(discord\.gg\/)?/, "");
       if (!code) throw new Error("invite_code is required.");
       const invite = await discord.fetchInvite(code);
-      await invite.delete(args.reason ? String(args.reason) : undefined);
+      await invite.delete(reason);
       return {
         content: [{ type: "text", text: `✅ Invite "${code}" deleted.` }],
       };
-    }
-
-    case "discord_list_channel_invites": {
-      const channelId = validateId(args.channel_id, "channel_id");
-      const channel = await discord.channels.fetch(channelId);
+    },
+  }),
+  defineTool({
+    name: "discord_list_channel_invites",
+    description:
+      "List the active invites that point to one specific channel. Unlike discord_list_invites (server-wide), this scopes results to a single channel. Requires the Manage Channels permission. Read-only.",
+    annotations: { title: "List channel invites", readOnlyHint: true, openWorldHint: true },
+    schema: z.object({
+      channel_id: snowflake.describe("ID (snowflake) of the channel to list invites for."),
+    }),
+    handle: async ({ channel_id }) => {
+      const channel = await discord.channels.fetch(channel_id);
       if (!channel || !("fetchInvites" in channel)) {
-        throw new Error(`Channel ${channelId} does not support invites.`);
+        throw new Error(`Channel ${channel_id} does not support invites.`);
       }
       const invites = await (channel as any).fetchInvites();
       const list = [...invites.values()].map(serializeInvite);
       return { content: [{ type: "text", text: JSON.stringify(list, null, 2) }] };
-    }
+    },
+  }),
+];
 
-    default:
-      return null;
-  }
-}
-
-export default { definitions, handle } satisfies ToolModule;
+export default defineModule(tools);

--- a/src/tools/members.ts
+++ b/src/tools/members.ts
@@ -1,206 +1,46 @@
 import { GuildMember } from "discord.js";
-import { discord, serializePermissions, validateId, clampInt, validateInt } from "../client.js";
+import { z } from "zod";
+import { discord, serializePermissions, clampInt, validateInt } from "../client.js";
 import { MAX_FETCH_LIMIT, DEFAULTS } from "../constants.js";
-import type { ToolModule, ToolResult } from "./types.js";
+import { defineTool, defineModule, snowflake, guildId } from "./define.js";
 
 /** Tool definitions for listing, inspecting, and moderating guild members. */
-export const definitions = [
-  {
+const tools = [
+  defineTool({
     name: "discord_list_members",
     description:
       "List members of a server with their roles, ordered by user ID. Returns { members: [...], nextCursor }. A page holds up to 1000 members; if nextCursor is non-null, pass it back as `after` to fetch the next page. Use discord_search_members to find specific members by name, or discord_get_member_info for one member's full details. Read-only.",
     annotations: { title: "List members", readOnlyHint: true, openWorldHint: true },
-    inputSchema: {
-      type: "object",
-      properties: {
-        guild_id: { type: "string", description: "Discord server (guild) ID (snowflake)." },
-        limit: { type: "number", description: "How many members per page (1–1000). Default 50." },
-        after: { type: "string", description: "Pagination cursor: a user ID (snowflake). Pass the previous response's nextCursor to fetch the next page." },
-      },
-      required: ["guild_id"],
-    },
-  },
-  {
-    name: "discord_get_member_info",
-    description:
-      "Get full details for one server member: roles, effective permissions, account/join dates, bot flag, and current timeout status. Read-only. Returns a JSON object.",
-    annotations: { title: "Get member info", readOnlyHint: true, openWorldHint: true },
-    inputSchema: {
-      type: "object",
-      properties: {
-        guild_id: { type: "string", description: "Discord server (guild) ID (snowflake)." },
-        user_id: { type: "string", description: "Discord user ID (snowflake) of the member." },
-      },
-      required: ["guild_id", "user_id"],
-    },
-  },
-  {
-    name: "discord_kick_member",
-    description:
-      "Remove a member from the server. They can rejoin with a new invite (unlike a ban). Requires the Kick Members permission, and the bot's top role must be higher than the target's. Use discord_ban_member to block re-entry. The reason is recorded in the audit log.",
-    annotations: { title: "Kick member", readOnlyHint: false, destructiveHint: true, idempotentHint: false, openWorldHint: true },
-    inputSchema: {
-      type: "object",
-      properties: {
-        guild_id: { type: "string", description: "Discord server (guild) ID (snowflake)." },
-        user_id: { type: "string", description: "Discord user ID (snowflake) of the member to kick." },
-        reason: { type: "string", description: "Optional reason recorded in the server audit log." },
-      },
-      required: ["guild_id", "user_id"],
-    },
-  },
-  {
-    name: "discord_ban_member",
-    description:
-      "Ban a user from the server, blocking re-entry until unbanned. Optionally bulk-deletes their recent messages. Requires the Ban Members permission, and the bot's top role must outrank the target's. Use discord_unban_member to reverse, or discord_kick_member for a non-permanent removal. The reason is recorded in the audit log.",
-    annotations: { title: "Ban member", readOnlyHint: false, destructiveHint: true, idempotentHint: true, openWorldHint: true },
-    inputSchema: {
-      type: "object",
-      properties: {
-        guild_id: { type: "string", description: "Discord server (guild) ID (snowflake)." },
-        user_id: { type: "string", description: "Discord user ID (snowflake) of the user to ban." },
-        reason: { type: "string", description: "Optional reason recorded in the server audit log." },
-        delete_message_days: { type: "number", description: "Also delete the user's messages from the last N days (0–7). Default 0 (delete nothing)." },
-      },
-      required: ["guild_id", "user_id"],
-    },
-  },
-  {
-    name: "discord_unban_member",
-    description:
-      "Lift a ban so the user may rejoin via a new invite. Requires the Ban Members permission. Reverses discord_ban_member. The reason is recorded in the audit log.",
-    annotations: { title: "Unban member", readOnlyHint: false, destructiveHint: false, idempotentHint: true, openWorldHint: true },
-    inputSchema: {
-      type: "object",
-      properties: {
-        guild_id: { type: "string", description: "Discord server (guild) ID (snowflake)." },
-        user_id: { type: "string", description: "Discord user ID (snowflake) of the banned user to unban." },
-        reason: { type: "string", description: "Optional reason recorded in the server audit log." },
-      },
-      required: ["guild_id", "user_id"],
-    },
-  },
-  {
-    name: "discord_timeout_member",
-    description:
-      "Mute a member for a set duration (Discord 'timeout'): they cannot send messages, react, or speak until it expires. Pass duration_minutes = 0 to remove an active timeout early. Max 28 days (40320 minutes). Requires the Moderate Members permission.",
-    annotations: { title: "Timeout member", readOnlyHint: false, destructiveHint: false, idempotentHint: true, openWorldHint: true },
-    inputSchema: {
-      type: "object",
-      properties: {
-        guild_id: { type: "string", description: "Discord server (guild) ID (snowflake)." },
-        user_id: { type: "string", description: "Discord user ID (snowflake) of the member to time out." },
-        duration_minutes: { type: "number", description: "Timeout length in minutes (1–40320, i.e. up to 28 days). Use 0 to clear an existing timeout." },
-        reason: { type: "string", description: "Optional reason recorded in the server audit log." },
-      },
-      required: ["guild_id", "user_id", "duration_minutes"],
-    },
-  },
-  {
-    name: "discord_search_members",
-    description:
-      "Find server members whose username or nickname starts with a query string (prefix match). Returns a JSON array (id, username, nickname, roles). Use discord_list_members to page through everyone. Read-only.",
-    annotations: { title: "Search members", readOnlyHint: true, openWorldHint: true },
-    inputSchema: {
-      type: "object",
-      properties: {
-        guild_id: { type: "string", description: "Discord server (guild) ID (snowflake)." },
-        query: { type: "string", description: "Prefix to match against usernames and nicknames." },
-        limit: { type: "number", description: "Max members to return (1–100). Default 25." },
-      },
-      required: ["guild_id", "query"],
-    },
-  },
-  {
-    name: "discord_set_nickname",
-    description:
-      "Set or clear a member's server nickname. Pass null (or the string 'null') to clear it. Requires the Manage Nicknames permission (or Change Nickname for the bot itself). The reason is recorded in the audit log.",
-    annotations: { title: "Set nickname", readOnlyHint: false, destructiveHint: false, idempotentHint: true, openWorldHint: true },
-    inputSchema: {
-      type: "object",
-      properties: {
-        guild_id: { type: "string", description: "Discord server (guild) ID (snowflake)." },
-        user_id: { type: "string", description: "Discord user ID (snowflake) of the member." },
-        nickname: { type: "string", description: "New nickname (max 32 characters), or null to clear it." },
-        reason: { type: "string", description: "Optional reason recorded in the server audit log." },
-      },
-      required: ["guild_id", "user_id", "nickname"],
-    },
-  },
-  {
-    name: "discord_list_bans",
-    description:
-      "List the users banned from the server, with their ban reasons. Returns { bans: [...], nextCursor }. A page holds up to 1000 bans; if nextCursor is non-null, pass it back as `after` to fetch the next page. Requires the Ban Members permission. Read-only.",
-    annotations: { title: "List bans", readOnlyHint: true, openWorldHint: true },
-    inputSchema: {
-      type: "object",
-      properties: {
-        guild_id: { type: "string", description: "Discord server (guild) ID (snowflake)." },
-        limit: { type: "number", description: "Max bans per page (1–1000). Default 1000." },
-        after: { type: "string", description: "Pagination cursor: a user ID (snowflake). Pass the previous response's nextCursor to fetch the next page." },
-      },
-      required: ["guild_id"],
-    },
-  },
-  {
-    name: "discord_bulk_ban",
-    description:
-      "Ban many users in a single call, intended for raid mitigation. SAFE BY DEFAULT: dry_run is true unless explicitly set to false, so call it first to preview the resolved user IDs, then re-call with dry_run:false to actually ban them. Requires the Ban Members permission. Returns counts of banned vs failed users. Use discord_ban_member for a single ban with finer control.",
-    annotations: { title: "Bulk ban", readOnlyHint: false, destructiveHint: true, idempotentHint: false, openWorldHint: true },
-    inputSchema: {
-      type: "object",
-      properties: {
-        guild_id: { type: "string", description: "Discord server (guild) ID (snowflake)." },
-        user_ids: { type: "array", items: { type: "string" }, description: "Array of user IDs (snowflakes) to ban." },
-        delete_message_seconds: { type: "number", description: "Also delete each user's messages from the last N seconds (0–604800, i.e. up to 7 days). Default 0." },
-        dry_run: { type: "boolean", description: "If true (default), only returns the user IDs that would be banned without banning anyone. Set false to actually ban." },
-        reason: { type: "string", description: "Optional reason recorded in the server audit log." },
-      },
-      required: ["guild_id", "user_ids"],
-    },
-  },
-  {
-    name: "discord_prune_members",
-    description:
-      "Remove members who have been inactive (no roles, not seen) for a number of days. SAFE BY DEFAULT: dry_run is true unless explicitly set to false, so call it first to preview the count, then re-call with dry_run:false to actually remove them. Removal is irreversible (members must rejoin). Requires the Kick Members permission.",
-    annotations: { title: "Prune inactive members", readOnlyHint: false, destructiveHint: true, idempotentHint: false, openWorldHint: true },
-    inputSchema: {
-      type: "object",
-      properties: {
-        guild_id: { type: "string", description: "Discord server (guild) ID (snowflake)." },
-        days: { type: "number", description: "Inactivity threshold in days (1–30)." },
-        roles: { type: "array", items: { type: "string" }, description: "Optional role IDs (snowflakes) to include; by default only members with no roles are counted." },
-        dry_run: { type: "boolean", description: "If true (default), only returns the count that would be pruned without removing anyone. Set false to actually prune." },
-        reason: { type: "string", description: "Optional reason recorded in the server audit log." },
-      },
-      required: ["guild_id", "days"],
-    },
-  },
-];
-
-/**
- * Handles member tools: list with roles, detailed info,
- * kick, ban, unban, and timeout management.
- */
-export async function handle(name: string, args: Record<string, unknown>): Promise<ToolResult | null> {
-  switch (name) {
-    case "discord_list_members": {
-      const guild = await discord.guilds.fetch(validateId(args.guild_id, "guild_id"));
-      const limit = clampInt(args.limit, 1, DEFAULTS.MEMBERS_MAX, DEFAULTS.MEMBERS);
-      const after = args.after !== undefined ? validateId(args.after, "after") : undefined;
-      const members = await guild.members.list({ limit, after });
+    schema: z.object({
+      guild_id: guildId,
+      limit: z.number().optional().describe("How many members per page (1–1000). Default 50."),
+      after: snowflake.optional().describe("Pagination cursor: a user ID (snowflake). Pass the previous response's nextCursor to fetch the next page."),
+    }),
+    handle: async ({ guild_id, limit, after }) => {
+      const guild = await discord.guilds.fetch(guild_id);
+      const max = clampInt(limit, 1, DEFAULTS.MEMBERS_MAX, DEFAULTS.MEMBERS);
+      const members = await guild.members.list({ limit: max, after });
       const result = [...members.values()].map((m: GuildMember) => ({
         id: m.id, username: m.user.tag, nickname: m.nickname,
         roles: m.roles.cache.filter((r) => r.name !== "@everyone").map((r) => ({ id: r.id, name: r.name })),
         joinedAt: m.joinedAt?.toISOString(),
       }));
-      const nextCursor = members.size === limit ? members.lastKey() ?? null : null;
+      const nextCursor = members.size === max ? members.lastKey() ?? null : null;
       return { content: [{ type: "text", text: JSON.stringify({ members: result, nextCursor }, null, 2) }] };
-    }
-
-    case "discord_get_member_info": {
-      const guild = await discord.guilds.fetch(validateId(args.guild_id, "guild_id"));
-      const member = await guild.members.fetch(validateId(args.user_id, "user_id"));
+    },
+  }),
+  defineTool({
+    name: "discord_get_member_info",
+    description:
+      "Get full details for one server member: roles, effective permissions, account/join dates, bot flag, and current timeout status. Read-only. Returns a JSON object.",
+    annotations: { title: "Get member info", readOnlyHint: true, openWorldHint: true },
+    schema: z.object({
+      guild_id: guildId,
+      user_id: snowflake.describe("Discord user ID (snowflake) of the member."),
+    }),
+    handle: async ({ guild_id, user_id }) => {
+      const guild = await discord.guilds.fetch(guild_id);
+      const member = await guild.members.fetch(user_id);
       return {
         content: [{
           type: "text", text: JSON.stringify({
@@ -212,110 +52,198 @@ export async function handle(name: string, args: Record<string, unknown>): Promi
           }, null, 2),
         }],
       };
-    }
-
-    case "discord_kick_member": {
-      const guild = await discord.guilds.fetch(validateId(args.guild_id, "guild_id"));
-      const member = await guild.members.fetch(validateId(args.user_id, "user_id"));
-      await member.kick(args.reason as string | undefined);
+    },
+  }),
+  defineTool({
+    name: "discord_kick_member",
+    description:
+      "Remove a member from the server. They can rejoin with a new invite (unlike a ban). Requires the Kick Members permission, and the bot's top role must be higher than the target's. Use discord_ban_member to block re-entry. The reason is recorded in the audit log.",
+    annotations: { title: "Kick member", readOnlyHint: false, destructiveHint: true, idempotentHint: false, openWorldHint: true },
+    schema: z.object({
+      guild_id: guildId,
+      user_id: snowflake.describe("Discord user ID (snowflake) of the member to kick."),
+      reason: z.string().optional().describe("Optional reason recorded in the server audit log."),
+    }),
+    handle: async ({ guild_id, user_id, reason }) => {
+      const guild = await discord.guilds.fetch(guild_id);
+      const member = await guild.members.fetch(user_id);
+      await member.kick(reason);
       return { content: [{ type: "text", text: `✅ ${member.user.tag} has been kicked.` }] };
-    }
-
-    case "discord_ban_member": {
-      const guild = await discord.guilds.fetch(validateId(args.guild_id, "guild_id"));
-      const userId = validateId(args.user_id, "user_id");
-      const deleteDays = clampInt(args.delete_message_days, 0, 7, 0);
-      await guild.members.ban(userId, {
-        reason: args.reason as string | undefined,
+    },
+  }),
+  defineTool({
+    name: "discord_ban_member",
+    description:
+      "Ban a user from the server, blocking re-entry until unbanned. Optionally bulk-deletes their recent messages. Requires the Ban Members permission, and the bot's top role must outrank the target's. Use discord_unban_member to reverse, or discord_kick_member for a non-permanent removal. The reason is recorded in the audit log.",
+    annotations: { title: "Ban member", readOnlyHint: false, destructiveHint: true, idempotentHint: true, openWorldHint: true },
+    schema: z.object({
+      guild_id: guildId,
+      user_id: snowflake.describe("Discord user ID (snowflake) of the user to ban."),
+      reason: z.string().optional().describe("Optional reason recorded in the server audit log."),
+      delete_message_days: z.number().optional().describe("Also delete the user's messages from the last N days (0–7). Default 0 (delete nothing)."),
+    }),
+    handle: async ({ guild_id, user_id, reason, delete_message_days }) => {
+      const guild = await discord.guilds.fetch(guild_id);
+      const deleteDays = clampInt(delete_message_days, 0, 7, 0);
+      await guild.members.ban(user_id, {
+        reason,
         deleteMessageSeconds: deleteDays * 86400,
       });
-      return { content: [{ type: "text", text: `✅ User ${userId} has been banned.` }] };
-    }
-
-    case "discord_unban_member": {
-      const guild = await discord.guilds.fetch(validateId(args.guild_id, "guild_id"));
-      const userId = validateId(args.user_id, "user_id");
-      await guild.members.unban(userId, args.reason as string | undefined);
-      return { content: [{ type: "text", text: `✅ User ${userId} has been unbanned.` }] };
-    }
-
-    case "discord_timeout_member": {
-      const guild = await discord.guilds.fetch(validateId(args.guild_id, "guild_id"));
-      const member = await guild.members.fetch(validateId(args.user_id, "user_id"));
-      const duration = validateInt(args.duration_minutes, 0, 40320, "duration_minutes");
+      return { content: [{ type: "text", text: `✅ User ${user_id} has been banned.` }] };
+    },
+  }),
+  defineTool({
+    name: "discord_unban_member",
+    description:
+      "Lift a ban so the user may rejoin via a new invite. Requires the Ban Members permission. Reverses discord_ban_member. The reason is recorded in the audit log.",
+    annotations: { title: "Unban member", readOnlyHint: false, destructiveHint: false, idempotentHint: true, openWorldHint: true },
+    schema: z.object({
+      guild_id: guildId,
+      user_id: snowflake.describe("Discord user ID (snowflake) of the banned user to unban."),
+      reason: z.string().optional().describe("Optional reason recorded in the server audit log."),
+    }),
+    handle: async ({ guild_id, user_id, reason }) => {
+      const guild = await discord.guilds.fetch(guild_id);
+      await guild.members.unban(user_id, reason);
+      return { content: [{ type: "text", text: `✅ User ${user_id} has been unbanned.` }] };
+    },
+  }),
+  defineTool({
+    name: "discord_timeout_member",
+    description:
+      "Mute a member for a set duration (Discord 'timeout'): they cannot send messages, react, or speak until it expires. Pass duration_minutes = 0 to remove an active timeout early. Max 28 days (40320 minutes). Requires the Moderate Members permission.",
+    annotations: { title: "Timeout member", readOnlyHint: false, destructiveHint: false, idempotentHint: true, openWorldHint: true },
+    schema: z.object({
+      guild_id: guildId,
+      user_id: snowflake.describe("Discord user ID (snowflake) of the member to time out."),
+      duration_minutes: z.number().describe("Timeout length in minutes (1–40320, i.e. up to 28 days). Use 0 to clear an existing timeout."),
+      reason: z.string().optional().describe("Optional reason recorded in the server audit log."),
+    }),
+    handle: async ({ guild_id, user_id, duration_minutes, reason }) => {
+      const guild = await discord.guilds.fetch(guild_id);
+      const member = await guild.members.fetch(user_id);
+      const duration = validateInt(duration_minutes, 0, 40320, "duration_minutes");
       const until = duration > 0 ? new Date(Date.now() + duration * 60 * 1000) : null;
-      await member.disableCommunicationUntil(until, args.reason as string | undefined);
+      await member.disableCommunicationUntil(until, reason);
       return {
         content: [{
           type: "text",
           text: duration > 0 ? `✅ ${member.user.tag} is in timeout for ${duration} minutes.` : `✅ Timeout removed from ${member.user.tag}.`,
         }],
       };
-    }
-
-    case "discord_search_members": {
-      const guild = await discord.guilds.fetch(validateId(args.guild_id, "guild_id"));
-      const limit = clampInt(args.limit, 1, MAX_FETCH_LIMIT, DEFAULTS.LIMIT);
-      const members = await guild.members.search({ query: args.query as string, limit });
+    },
+  }),
+  defineTool({
+    name: "discord_search_members",
+    description:
+      "Find server members whose username or nickname starts with a query string (prefix match). Returns a JSON array (id, username, nickname, roles). Use discord_list_members to page through everyone. Read-only.",
+    annotations: { title: "Search members", readOnlyHint: true, openWorldHint: true },
+    schema: z.object({
+      guild_id: guildId,
+      query: z.string().describe("Prefix to match against usernames and nicknames."),
+      limit: z.number().optional().describe("Max members to return (1–100). Default 25."),
+    }),
+    handle: async ({ guild_id, query, limit }) => {
+      const guild = await discord.guilds.fetch(guild_id);
+      const max = clampInt(limit, 1, MAX_FETCH_LIMIT, DEFAULTS.LIMIT);
+      const members = await guild.members.search({ query, limit: max });
       const result = [...members.values()].map((m: GuildMember) => ({
         id: m.id, username: m.user.tag, nickname: m.nickname,
         roles: m.roles.cache.filter((r) => r.name !== "@everyone").map((r) => ({ id: r.id, name: r.name })),
       }));
       return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
-    }
-
-    case "discord_set_nickname": {
-      const guild = await discord.guilds.fetch(validateId(args.guild_id, "guild_id"));
-      const member = await guild.members.fetch(validateId(args.user_id, "user_id"));
-      const nick = args.nickname === null || args.nickname === "null" ? null : String(args.nickname);
-      await member.setNickname(nick, args.reason as string | undefined);
+    },
+  }),
+  defineTool({
+    name: "discord_set_nickname",
+    description:
+      "Set or clear a member's server nickname. Pass null (or the string 'null') to clear it. Requires the Manage Nicknames permission (or Change Nickname for the bot itself). The reason is recorded in the audit log.",
+    annotations: { title: "Set nickname", readOnlyHint: false, destructiveHint: false, idempotentHint: true, openWorldHint: true },
+    schema: z.object({
+      guild_id: guildId,
+      user_id: snowflake.describe("Discord user ID (snowflake) of the member."),
+      nickname: z.string().nullable().optional().describe("New nickname (max 32 characters), or null to clear it."),
+      reason: z.string().optional().describe("Optional reason recorded in the server audit log."),
+    }),
+    handle: async ({ guild_id, user_id, nickname, reason }) => {
+      const guild = await discord.guilds.fetch(guild_id);
+      const member = await guild.members.fetch(user_id);
+      const nick = nickname === null || nickname === "null" ? null : (nickname ?? null);
+      await member.setNickname(nick, reason);
       return { content: [{ type: "text", text: nick ? `✅ Nickname for ${member.user.tag} set to "${nick}".` : `✅ Nickname cleared for ${member.user.tag}.` }] };
-    }
-
-    case "discord_list_bans": {
-      const guild = await discord.guilds.fetch(validateId(args.guild_id, "guild_id"));
-      const limit = clampInt(args.limit, 1, 1000, 1000);
-      const after = args.after !== undefined ? validateId(args.after, "after") : undefined;
-      const bans = await guild.bans.fetch({ limit, after, cache: false });
+    },
+  }),
+  defineTool({
+    name: "discord_list_bans",
+    description:
+      "List the users banned from the server, with their ban reasons. Returns { bans: [...], nextCursor }. A page holds up to 1000 bans; if nextCursor is non-null, pass it back as `after` to fetch the next page. Requires the Ban Members permission. Read-only.",
+    annotations: { title: "List bans", readOnlyHint: true, openWorldHint: true },
+    schema: z.object({
+      guild_id: guildId,
+      limit: z.number().optional().describe("Max bans per page (1–1000). Default 1000."),
+      after: snowflake.optional().describe("Pagination cursor: a user ID (snowflake). Pass the previous response's nextCursor to fetch the next page."),
+    }),
+    handle: async ({ guild_id, limit, after }) => {
+      const guild = await discord.guilds.fetch(guild_id);
+      const max = clampInt(limit, 1, 1000, 1000);
+      const bans = await guild.bans.fetch({ limit: max, after, cache: false });
       const result = [...bans.values()].map((ban) => ({
         user_id: ban.user.id, username: ban.user.tag, reason: ban.reason ?? null,
       }));
-      const nextCursor = bans.size === limit ? bans.lastKey() ?? null : null;
+      const nextCursor = bans.size === max ? bans.lastKey() ?? null : null;
       return { content: [{ type: "text", text: JSON.stringify({ bans: result, nextCursor }, null, 2) }] };
-    }
-
-    case "discord_bulk_ban": {
-      const guild = await discord.guilds.fetch(validateId(args.guild_id, "guild_id"));
-      const rawIds = args.user_ids;
-      if (!Array.isArray(rawIds) || rawIds.length === 0) throw new Error("user_ids must be a non-empty array.");
-      const userIds = rawIds.map((id) => validateId(id, "user_ids[]"));
-      if (args.dry_run !== false) {
-        return { content: [{ type: "text", text: `🔍 Dry run: ${userIds.length} users would be banned:\n${JSON.stringify(userIds, null, 2)}` }] };
+    },
+  }),
+  defineTool({
+    name: "discord_bulk_ban",
+    description:
+      "Ban many users in a single call, intended for raid mitigation. SAFE BY DEFAULT: dry_run is true unless explicitly set to false, so call it first to preview the resolved user IDs, then re-call with dry_run:false to actually ban them. Requires the Ban Members permission. Returns counts of banned vs failed users. Use discord_ban_member for a single ban with finer control.",
+    annotations: { title: "Bulk ban", readOnlyHint: false, destructiveHint: true, idempotentHint: false, openWorldHint: true },
+    schema: z.object({
+      guild_id: guildId,
+      user_ids: z.array(snowflake).describe("Array of user IDs (snowflakes) to ban."),
+      delete_message_seconds: z.number().optional().describe("Also delete each user's messages from the last N seconds (0–604800, i.e. up to 7 days). Default 0."),
+      dry_run: z.boolean().optional().describe("If true (default), only returns the user IDs that would be banned without banning anyone. Set false to actually ban."),
+      reason: z.string().optional().describe("Optional reason recorded in the server audit log."),
+    }),
+    handle: async ({ guild_id, user_ids, delete_message_seconds, dry_run, reason }) => {
+      const guild = await discord.guilds.fetch(guild_id);
+      if (user_ids.length === 0) throw new Error("user_ids must be a non-empty array.");
+      if (dry_run !== false) {
+        return { content: [{ type: "text", text: `🔍 Dry run: ${user_ids.length} users would be banned:\n${JSON.stringify(user_ids, null, 2)}` }] };
       }
-      const result = await guild.members.bulkBan(userIds, {
-        deleteMessageSeconds: clampInt(args.delete_message_seconds, 0, 604800, 0),
-        reason: args.reason as string | undefined,
+      const result = await guild.members.bulkBan(user_ids, {
+        deleteMessageSeconds: clampInt(delete_message_seconds, 0, 604800, 0),
+        reason,
       });
       return { content: [{ type: "text", text: `✅ Bulk ban complete: ${result.bannedUsers.length} banned, ${result.failedUsers.length} failed.` }] };
-    }
-
-    case "discord_prune_members": {
-      const guild = await discord.guilds.fetch(validateId(args.guild_id, "guild_id"));
-      const days = validateInt(args.days, 1, 30, "days");
-      const dryRun = args.dry_run !== false;
-      const roles = args.roles as string[] | undefined;
+    },
+  }),
+  defineTool({
+    name: "discord_prune_members",
+    description:
+      "Remove members who have been inactive (no roles, not seen) for a number of days. SAFE BY DEFAULT: dry_run is true unless explicitly set to false, so call it first to preview the count, then re-call with dry_run:false to actually remove them. Removal is irreversible (members must rejoin). Requires the Kick Members permission.",
+    annotations: { title: "Prune inactive members", readOnlyHint: false, destructiveHint: true, idempotentHint: false, openWorldHint: true },
+    schema: z.object({
+      guild_id: guildId,
+      days: z.number().describe("Inactivity threshold in days (1–30)."),
+      roles: z.array(snowflake).optional().describe("Optional role IDs (snowflakes) to include; by default only members with no roles are counted."),
+      dry_run: z.boolean().optional().describe("If true (default), only returns the count that would be pruned without removing anyone. Set false to actually prune."),
+      reason: z.string().optional().describe("Optional reason recorded in the server audit log."),
+    }),
+    handle: async ({ guild_id, days, roles, dry_run, reason }) => {
+      const guild = await discord.guilds.fetch(guild_id);
+      const d = validateInt(days, 1, 30, "days");
+      const dryRun = dry_run !== false;
       const pruned = await guild.members.prune({
-        days,
+        days: d,
         dry: dryRun,
         roles: roles ?? undefined,
-        reason: args.reason as string | undefined,
+        reason,
       });
-      return { content: [{ type: "text", text: dryRun ? `🔍 Dry run: ${pruned} members would be pruned (${days} days inactive).` : `✅ ${pruned} members pruned (${days} days inactive).` }] };
-    }
+      return { content: [{ type: "text", text: dryRun ? `🔍 Dry run: ${pruned} members would be pruned (${d} days inactive).` : `✅ ${pruned} members pruned (${d} days inactive).` }] };
+    },
+  }),
+];
 
-    default:
-      return null;
-  }
-}
-
-export default { definitions, handle } satisfies ToolModule;
+export default defineModule(tools);

--- a/src/tools/members.ts
+++ b/src/tools/members.ts
@@ -1,8 +1,8 @@
 import { GuildMember } from "discord.js";
 import { z } from "zod";
-import { discord, serializePermissions, clampInt, validateInt } from "../client.js";
+import { discord, serializePermissions } from "../client.js";
 import { MAX_FETCH_LIMIT, DEFAULTS } from "../constants.js";
-import { defineTool, defineModule, snowflake, guildId } from "./define.js";
+import { defineTool, defineModule, snowflake, guildId, intIn } from "./define.js";
 
 /** Tool definitions for listing, inspecting, and moderating guild members. */
 const tools = [
@@ -13,19 +13,18 @@ const tools = [
     annotations: { title: "List members", readOnlyHint: true, openWorldHint: true },
     schema: z.object({
       guild_id: guildId,
-      limit: z.number().optional().describe("How many members per page (1–1000). Default 50."),
+      limit: intIn(1, DEFAULTS.MEMBERS_MAX).default(DEFAULTS.MEMBERS).describe("How many members per page (1–1000). Default 50."),
       after: snowflake.optional().describe("Pagination cursor: a user ID (snowflake). Pass the previous response's nextCursor to fetch the next page."),
     }),
     handle: async ({ guild_id, limit, after }) => {
       const guild = await discord.guilds.fetch(guild_id);
-      const max = clampInt(limit, 1, DEFAULTS.MEMBERS_MAX, DEFAULTS.MEMBERS);
-      const members = await guild.members.list({ limit: max, after });
+      const members = await guild.members.list({ limit, after });
       const result = [...members.values()].map((m: GuildMember) => ({
         id: m.id, username: m.user.tag, nickname: m.nickname,
         roles: m.roles.cache.filter((r) => r.name !== "@everyone").map((r) => ({ id: r.id, name: r.name })),
         joinedAt: m.joinedAt?.toISOString(),
       }));
-      const nextCursor = members.size === max ? members.lastKey() ?? null : null;
+      const nextCursor = members.size === limit ? members.lastKey() ?? null : null;
       return { content: [{ type: "text", text: JSON.stringify({ members: result, nextCursor }, null, 2) }] };
     },
   }),
@@ -80,14 +79,13 @@ const tools = [
       guild_id: guildId,
       user_id: snowflake.describe("Discord user ID (snowflake) of the user to ban."),
       reason: z.string().optional().describe("Optional reason recorded in the server audit log."),
-      delete_message_days: z.number().optional().describe("Also delete the user's messages from the last N days (0–7). Default 0 (delete nothing)."),
+      delete_message_days: intIn(0, 7).default(0).describe("Also delete the user's messages from the last N days (0–7). Default 0 (delete nothing)."),
     }),
     handle: async ({ guild_id, user_id, reason, delete_message_days }) => {
       const guild = await discord.guilds.fetch(guild_id);
-      const deleteDays = clampInt(delete_message_days, 0, 7, 0);
       await guild.members.ban(user_id, {
         reason,
-        deleteMessageSeconds: deleteDays * 86400,
+        deleteMessageSeconds: delete_message_days * 86400,
       });
       return { content: [{ type: "text", text: `✅ User ${user_id} has been banned.` }] };
     },
@@ -116,19 +114,18 @@ const tools = [
     schema: z.object({
       guild_id: guildId,
       user_id: snowflake.describe("Discord user ID (snowflake) of the member to time out."),
-      duration_minutes: z.number().describe("Timeout length in minutes (1–40320, i.e. up to 28 days). Use 0 to clear an existing timeout."),
+      duration_minutes: intIn(0, 40320).describe("Timeout length in minutes (0–40320, i.e. up to 28 days). Use 0 to clear an existing timeout."),
       reason: z.string().optional().describe("Optional reason recorded in the server audit log."),
     }),
     handle: async ({ guild_id, user_id, duration_minutes, reason }) => {
       const guild = await discord.guilds.fetch(guild_id);
       const member = await guild.members.fetch(user_id);
-      const duration = validateInt(duration_minutes, 0, 40320, "duration_minutes");
-      const until = duration > 0 ? new Date(Date.now() + duration * 60 * 1000) : null;
+      const until = duration_minutes > 0 ? new Date(Date.now() + duration_minutes * 60 * 1000) : null;
       await member.disableCommunicationUntil(until, reason);
       return {
         content: [{
           type: "text",
-          text: duration > 0 ? `✅ ${member.user.tag} is in timeout for ${duration} minutes.` : `✅ Timeout removed from ${member.user.tag}.`,
+          text: duration_minutes > 0 ? `✅ ${member.user.tag} is in timeout for ${duration_minutes} minutes.` : `✅ Timeout removed from ${member.user.tag}.`,
         }],
       };
     },
@@ -141,12 +138,11 @@ const tools = [
     schema: z.object({
       guild_id: guildId,
       query: z.string().describe("Prefix to match against usernames and nicknames."),
-      limit: z.number().optional().describe("Max members to return (1–100). Default 25."),
+      limit: intIn(1, MAX_FETCH_LIMIT).default(DEFAULTS.LIMIT).describe("Max members to return (1–100). Default 25."),
     }),
     handle: async ({ guild_id, query, limit }) => {
       const guild = await discord.guilds.fetch(guild_id);
-      const max = clampInt(limit, 1, MAX_FETCH_LIMIT, DEFAULTS.LIMIT);
-      const members = await guild.members.search({ query, limit: max });
+      const members = await guild.members.search({ query, limit });
       const result = [...members.values()].map((m: GuildMember) => ({
         id: m.id, username: m.user.tag, nickname: m.nickname,
         roles: m.roles.cache.filter((r) => r.name !== "@everyone").map((r) => ({ id: r.id, name: r.name })),
@@ -180,17 +176,16 @@ const tools = [
     annotations: { title: "List bans", readOnlyHint: true, openWorldHint: true },
     schema: z.object({
       guild_id: guildId,
-      limit: z.number().optional().describe("Max bans per page (1–1000). Default 1000."),
+      limit: intIn(1, DEFAULTS.MEMBERS_MAX).default(DEFAULTS.MEMBERS_MAX).describe("Max bans per page (1–1000). Default 1000."),
       after: snowflake.optional().describe("Pagination cursor: a user ID (snowflake). Pass the previous response's nextCursor to fetch the next page."),
     }),
     handle: async ({ guild_id, limit, after }) => {
       const guild = await discord.guilds.fetch(guild_id);
-      const max = clampInt(limit, 1, 1000, 1000);
-      const bans = await guild.bans.fetch({ limit: max, after, cache: false });
+      const bans = await guild.bans.fetch({ limit, after, cache: false });
       const result = [...bans.values()].map((ban) => ({
         user_id: ban.user.id, username: ban.user.tag, reason: ban.reason ?? null,
       }));
-      const nextCursor = bans.size === max ? bans.lastKey() ?? null : null;
+      const nextCursor = bans.size === limit ? bans.lastKey() ?? null : null;
       return { content: [{ type: "text", text: JSON.stringify({ bans: result, nextCursor }, null, 2) }] };
     },
   }),
@@ -202,7 +197,7 @@ const tools = [
     schema: z.object({
       guild_id: guildId,
       user_ids: z.array(snowflake).describe("Array of user IDs (snowflakes) to ban."),
-      delete_message_seconds: z.number().optional().describe("Also delete each user's messages from the last N seconds (0–604800, i.e. up to 7 days). Default 0."),
+      delete_message_seconds: intIn(0, 604800).default(0).describe("Also delete each user's messages from the last N seconds (0–604800, i.e. up to 7 days). Default 0."),
       dry_run: z.boolean().optional().describe("If true (default), only returns the user IDs that would be banned without banning anyone. Set false to actually ban."),
       reason: z.string().optional().describe("Optional reason recorded in the server audit log."),
     }),
@@ -213,7 +208,7 @@ const tools = [
         return { content: [{ type: "text", text: `🔍 Dry run: ${user_ids.length} users would be banned:\n${JSON.stringify(user_ids, null, 2)}` }] };
       }
       const result = await guild.members.bulkBan(user_ids, {
-        deleteMessageSeconds: clampInt(delete_message_seconds, 0, 604800, 0),
+        deleteMessageSeconds: delete_message_seconds,
         reason,
       });
       return { content: [{ type: "text", text: `✅ Bulk ban complete: ${result.bannedUsers.length} banned, ${result.failedUsers.length} failed.` }] };
@@ -226,22 +221,21 @@ const tools = [
     annotations: { title: "Prune inactive members", readOnlyHint: false, destructiveHint: true, idempotentHint: false, openWorldHint: true },
     schema: z.object({
       guild_id: guildId,
-      days: z.number().describe("Inactivity threshold in days (1–30)."),
+      days: intIn(1, 30).describe("Inactivity threshold in days (1–30)."),
       roles: z.array(snowflake).optional().describe("Optional role IDs (snowflakes) to include; by default only members with no roles are counted."),
       dry_run: z.boolean().optional().describe("If true (default), only returns the count that would be pruned without removing anyone. Set false to actually prune."),
       reason: z.string().optional().describe("Optional reason recorded in the server audit log."),
     }),
     handle: async ({ guild_id, days, roles, dry_run, reason }) => {
       const guild = await discord.guilds.fetch(guild_id);
-      const d = validateInt(days, 1, 30, "days");
       const dryRun = dry_run !== false;
       const pruned = await guild.members.prune({
-        days: d,
+        days,
         dry: dryRun,
         roles: roles ?? undefined,
         reason,
       });
-      return { content: [{ type: "text", text: dryRun ? `🔍 Dry run: ${pruned} members would be pruned (${d} days inactive).` : `✅ ${pruned} members pruned (${d} days inactive).` }] };
+      return { content: [{ type: "text", text: dryRun ? `🔍 Dry run: ${pruned} members would be pruned (${days} days inactive).` : `✅ ${pruned} members pruned (${days} days inactive).` }] };
     },
   }),
 ];

--- a/src/tools/messages.ts
+++ b/src/tools/messages.ts
@@ -6,287 +6,14 @@ import {
   Message,
   MessageReaction,
 } from "discord.js";
+import { z } from "zod";
 import { discord, getTextChannel, clampInt } from "../client.js";
 import { MAX_FETCH_LIMIT, DEFAULTS } from "../constants.js";
-import { buildEmbed, EMBED_FIELD_PROPS } from "../embeds.js";
-import type { ToolModule, ToolResult } from "./types.js";
+import { buildEmbed, embedFieldsShape, embedObjectSchema } from "../embeds.js";
+import { defineModule, defineTool, snowflake } from "./define.js";
 
-/** Tool definitions for reading, sending, replying, editing, reacting, threading, embedding, deleting, pinning, and searching messages. */
-export const definitions = [
-  {
-    name: "discord_read_messages",
-    description:
-      "Read the most recent messages from a text channel or thread, oldest-to-newest. Returns a JSON array of messages (id, author, content, timestamp, attachment count, pinned flag). Use discord_search_messages to filter by keyword, or discord_fetch_pinned_messages for pinned messages only.",
-    annotations: { title: "Read messages", readOnlyHint: true, openWorldHint: true },
-    inputSchema: {
-      type: "object",
-      properties: {
-        channel_id: { type: "string", description: "ID (snowflake) of the channel or thread to read from." },
-        limit: { type: "number", description: "How many recent messages to fetch (1–100). Default 20." },
-      },
-      required: ["channel_id"],
-    },
-  },
-  {
-    name: "discord_send_message",
-    description:
-      "Send a plain-text message to a channel or thread. For rich content (title, color, fields, images) use discord_send_embed; to attach a reply reference to an existing message use discord_reply_message. Requires the bot to have the Send Messages permission. Returns the new message ID.",
-    annotations: { title: "Send message", readOnlyHint: false, destructiveHint: false, idempotentHint: false, openWorldHint: true },
-    inputSchema: {
-      type: "object",
-      properties: {
-        channel_id: { type: "string", description: "ID (snowflake) of the target channel or thread." },
-        content: { type: "string", description: "Plain-text body of the message (max 2000 characters)." },
-      },
-      required: ["channel_id", "content"],
-    },
-  },
-  {
-    name: "discord_reply_message",
-    description:
-      "Reply to a specific message, attaching a reply reference so clients show it as a threaded reply. Use discord_send_message for a standalone message with no reference. Requires the Send Messages permission. Returns the new reply's message ID.",
-    annotations: { title: "Reply to message", readOnlyHint: false, destructiveHint: false, idempotentHint: false, openWorldHint: true },
-    inputSchema: {
-      type: "object",
-      properties: {
-        channel_id: { type: "string", description: "ID (snowflake) of the channel or thread containing the message." },
-        message_id: { type: "string", description: "ID of the message to reply to." },
-        content: { type: "string", description: "Plain-text body of the reply (max 2000 characters)." },
-      },
-      required: ["channel_id", "message_id", "content"],
-    },
-  },
-  {
-    name: "discord_edit_message",
-    description:
-      "Edit the text content of a message previously sent by this bot. Discord forbids editing other users' messages, so this fails for non-bot messages. Use discord_edit_embed for embed messages. Works in text channels and threads. Returns the edited message ID.",
-    annotations: { title: "Edit message", readOnlyHint: false, destructiveHint: false, idempotentHint: true, openWorldHint: true },
-    inputSchema: {
-      type: "object",
-      properties: {
-        channel_id: { type: "string", description: "ID (snowflake) of the channel or thread containing the message." },
-        message_id: { type: "string", description: "ID of the message to edit. Must be a message authored by this bot." },
-        content: { type: "string", description: "New plain-text content that fully replaces the existing content (max 2000 characters)." },
-      },
-      required: ["channel_id", "message_id", "content"],
-    },
-  },
-  {
-    name: "discord_add_reaction",
-    description:
-      "Add a single emoji reaction to a message as the bot. Requires the Add Reactions and Read Message History permissions. Use discord_remove_reactions to undo. Idempotent: re-adding the bot's existing reaction has no effect.",
-    annotations: { title: "Add reaction", readOnlyHint: false, destructiveHint: false, idempotentHint: true, openWorldHint: true },
-    inputSchema: {
-      type: "object",
-      properties: {
-        channel_id: { type: "string", description: "ID (snowflake) of the channel or thread containing the message." },
-        message_id: { type: "string", description: "ID of the message to react to." },
-        emoji: { type: "string", description: "Unicode emoji (e.g. '👍') or a custom emoji in 'name:id' format." },
-      },
-      required: ["channel_id", "message_id", "emoji"],
-    },
-  },
-  {
-    name: "discord_create_thread",
-    description:
-      "Create a thread, either branching from an existing message (pass message_id) or as a standalone thread in a text channel (omit message_id). Standalone creation requires a parent text channel and fails if channel_id is itself a thread. Requires the Create Public Threads permission. Returns the new thread's ID.",
-    annotations: { title: "Create thread", readOnlyHint: false, destructiveHint: false, idempotentHint: false, openWorldHint: true },
-    inputSchema: {
-      type: "object",
-      properties: {
-        channel_id: { type: "string", description: "ID (snowflake) of the parent text channel. For a message-based thread, the channel containing message_id." },
-        name: { type: "string", description: "Name of the thread to create (max 100 characters)." },
-        message_id: { type: "string", description: "Optional. Message to branch the thread from. If omitted, a standalone thread is created in the channel." },
-        auto_archive_duration: { type: "number", description: "Minutes of inactivity before auto-archiving: 60, 1440, 4320, or 10080. Default 1440 (24h)." },
-      },
-      required: ["channel_id", "name"],
-    },
-  },
-  {
-    name: "discord_bulk_delete_messages",
-    description:
-      "Permanently delete multiple recent messages in one call. IRREVERSIBLE. Discord only allows bulk-deleting messages younger than 14 days; older ones are skipped. Requires the Manage Messages permission. Use discord_delete_message to remove a single specific message. Returns the number actually deleted.",
-    annotations: { title: "Bulk delete messages", readOnlyHint: false, destructiveHint: true, idempotentHint: false, openWorldHint: true },
-    inputSchema: {
-      type: "object",
-      properties: {
-        channel_id: { type: "string", description: "ID (snowflake) of the channel or thread to delete messages from." },
-        count: { type: "number", description: "Number of recent messages to delete (2–100)." },
-      },
-      required: ["channel_id", "count"],
-    },
-  },
-  {
-    name: "discord_send_embed",
-    description:
-      "Send a single rich embed (title, description, color, fields, author, footer, images, timestamp). Use discord_send_message for plain text, or discord_send_multiple_embeds to send several embeds at once. Requires the Send Messages and Embed Links permissions. Returns the new message ID.",
-    annotations: { title: "Send embed", readOnlyHint: false, destructiveHint: false, idempotentHint: false, openWorldHint: true },
-    inputSchema: {
-      type: "object",
-      properties: {
-        channel_id: { type: "string", description: "ID (snowflake) of the target channel or thread." },
-        ...EMBED_FIELD_PROPS,
-      },
-      required: ["channel_id"],
-    },
-  },
-  {
-    name: "discord_edit_embed",
-    description:
-      "Replace the embed on a message previously sent by this bot. Only this bot's messages can be edited. This is a full replace, not a merge: provided fields are applied and omitted fields are dropped from the embed. Returns a confirmation.",
-    annotations: { title: "Edit embed", readOnlyHint: false, destructiveHint: false, idempotentHint: true, openWorldHint: true },
-    inputSchema: {
-      type: "object",
-      properties: {
-        channel_id: { type: "string", description: "ID (snowflake) of the channel or thread containing the message." },
-        message_id: { type: "string", description: "ID of the message to edit. Must be a bot message that already contains an embed." },
-        ...EMBED_FIELD_PROPS,
-      },
-      required: ["channel_id", "message_id"],
-    },
-  },
-  {
-    name: "discord_send_multiple_embeds",
-    description:
-      "Send up to 10 embeds in a single message, with optional text above them. Use discord_send_embed for a single embed. Requires the Send Messages and Embed Links permissions. Returns the new message ID.",
-    annotations: { title: "Send multiple embeds", readOnlyHint: false, destructiveHint: false, idempotentHint: false, openWorldHint: true },
-    inputSchema: {
-      type: "object",
-      properties: {
-        channel_id: { type: "string", description: "ID (snowflake) of the target channel or thread." },
-        content: { type: "string", description: "Optional plain text shown above the embeds." },
-        embeds: {
-          type: "array",
-          description: "Array of embed objects to send (max 10).",
-          items: {
-            type: "object",
-            properties: { ...EMBED_FIELD_PROPS },
-          },
-        },
-      },
-      required: ["channel_id", "embeds"],
-    },
-  },
-  {
-    name: "discord_delete_message",
-    description:
-      "Permanently delete one specific message. IRREVERSIBLE. The bot can always delete its own messages; deleting another user's message requires the Manage Messages permission. Use discord_bulk_delete_messages to remove many at once. An optional reason is recorded in the audit log.",
-    annotations: { title: "Delete message", readOnlyHint: false, destructiveHint: true, idempotentHint: false, openWorldHint: true },
-    inputSchema: {
-      type: "object",
-      properties: {
-        channel_id: { type: "string", description: "ID (snowflake) of the channel or thread containing the message." },
-        message_id: { type: "string", description: "ID of the message to delete." },
-        reason: { type: "string", description: "Optional reason recorded in the server audit log." },
-      },
-      required: ["channel_id", "message_id"],
-    },
-  },
-  {
-    name: "discord_pin_message",
-    description:
-      "Pin or unpin a message in a channel, controlled by the pin flag. Requires the Pin Messages permission (a dedicated permission since early 2026, separate from Manage Messages). A channel holds at most 50 pins. Idempotent: pinning an already-pinned message (or unpinning an unpinned one) has no additional effect.",
-    annotations: { title: "Pin or unpin message", readOnlyHint: false, destructiveHint: false, idempotentHint: true, openWorldHint: true },
-    inputSchema: {
-      type: "object",
-      properties: {
-        channel_id: { type: "string", description: "ID (snowflake) of the channel or thread containing the message." },
-        message_id: { type: "string", description: "ID of the message to pin or unpin." },
-        pin: { type: "boolean", description: "true to pin the message, false to unpin it." },
-      },
-      required: ["channel_id", "message_id", "pin"],
-    },
-  },
-  {
-    name: "discord_search_messages",
-    description:
-      "Keyword search over a channel's recent messages using case-insensitive substring matching. Scans only up to the last 100 messages — it does not search full history. Returns matching messages as a JSON array. Use discord_read_messages to fetch recent messages without filtering.",
-    annotations: { title: "Search messages", readOnlyHint: true, openWorldHint: true },
-    inputSchema: {
-      type: "object",
-      properties: {
-        channel_id: { type: "string", description: "ID (snowflake) of the channel or thread to search." },
-        keyword: { type: "string", description: "Case-insensitive substring to match within message content." },
-        limit: { type: "number", description: "Max number of recent messages to scan (1–100). Default 100." },
-      },
-      required: ["channel_id", "keyword"],
-    },
-  },
-  {
-    name: "discord_crosspost_message",
-    description:
-      "Publish (crosspost) a message from an Announcement channel to every server that follows it. Only works in announcement channels on a message that has not already been published. Requires the Send Messages permission (and Manage Messages for messages authored by others). Returns a confirmation.",
-    annotations: { title: "Crosspost message", readOnlyHint: false, destructiveHint: false, idempotentHint: true, openWorldHint: true },
-    inputSchema: {
-      type: "object",
-      properties: {
-        channel_id: { type: "string", description: "ID (snowflake) of the announcement channel containing the message." },
-        message_id: { type: "string", description: "ID of the message to publish to followers." },
-      },
-      required: ["channel_id", "message_id"],
-    },
-  },
-  {
-    name: "discord_remove_reactions",
-    description:
-      "Remove reactions from a message. With no emoji: removes ALL reactions. With emoji only: removes every reaction of that emoji. With emoji and user_id: removes that one user's reaction. Removing all reactions or another user's reaction requires the Manage Messages permission. Use discord_add_reaction to add.",
-    annotations: { title: "Remove reactions", readOnlyHint: false, destructiveHint: false, idempotentHint: true, openWorldHint: true },
-    inputSchema: {
-      type: "object",
-      properties: {
-        channel_id: { type: "string", description: "ID (snowflake) of the channel or thread containing the message." },
-        message_id: { type: "string", description: "ID of the message to remove reactions from." },
-        emoji: { type: "string", description: "Unicode emoji or custom emoji 'name:id'. Omit to remove ALL reactions on the message." },
-        user_id: { type: "string", description: "Remove only this user's reaction for the given emoji. Requires emoji to be set." },
-      },
-      required: ["channel_id", "message_id"],
-    },
-  },
-  {
-    name: "discord_get_reactions",
-    description:
-      "List the users who reacted to a message with a specific emoji. Returns a JSON array of users (id, username, bot flag). Read-only.",
-    annotations: { title: "Get reactions", readOnlyHint: true, openWorldHint: true },
-    inputSchema: {
-      type: "object",
-      properties: {
-        channel_id: { type: "string", description: "ID (snowflake) of the channel or thread containing the message." },
-        message_id: { type: "string", description: "ID of the message to inspect." },
-        emoji: { type: "string", description: "Unicode emoji or custom emoji 'name:id' to list reactors for." },
-        limit: { type: "number", description: "Max users to return (1–100). Default 25." },
-      },
-      required: ["channel_id", "message_id", "emoji"],
-    },
-  },
-  {
-    name: "discord_fetch_pinned_messages",
-    description:
-      "List all pinned messages in a channel as a JSON array (id, author, content, timestamp, pinnedAt). Read-only. Use discord_pin_message to change which messages are pinned.",
-    annotations: { title: "Fetch pinned messages", readOnlyHint: true, openWorldHint: true },
-    inputSchema: {
-      type: "object",
-      properties: {
-        channel_id: { type: "string", description: "ID (snowflake) of the channel or thread to list pins from." },
-      },
-      required: ["channel_id"],
-    },
-  },
-  {
-    name: "discord_forward_message",
-    description:
-      "Forward an existing message to another channel using Discord's native forward, which preserves the original attribution. Works across text channels and threads. Use discord_send_message to compose new content instead. Requires the Send Messages permission in the target channel. Returns a confirmation.",
-    annotations: { title: "Forward message", readOnlyHint: false, destructiveHint: false, idempotentHint: false, openWorldHint: true },
-    inputSchema: {
-      type: "object",
-      properties: {
-        channel_id: { type: "string", description: "ID (snowflake) of the channel or thread containing the source message." },
-        message_id: { type: "string", description: "ID of the message to forward." },
-        target_channel_id: { type: "string", description: "ID (snowflake) of the destination channel or thread." },
-      },
-      required: ["channel_id", "message_id", "target_channel_id"],
-    },
-  },
-];
+const channelId = snowflake.describe("ID (snowflake) of the channel or thread.");
+const messageId = snowflake.describe("ID of the message.");
 
 /**
  * Looks up a reaction on a message by emoji argument.
@@ -300,16 +27,21 @@ function findReaction(msg: Message, emoji: string): MessageReaction | undefined 
   return msg.reactions.cache.get(key);
 }
 
-/**
- * Handles all message-related tools: read, send, reply, edit, react,
- * thread, bulk delete, embed, delete, pin/unpin, and keyword search.
- */
-export async function handle(name: string, args: Record<string, unknown>): Promise<ToolResult | null> {
-  switch (name) {
-    case "discord_read_messages": {
-      const channel = await getTextChannel(args.channel_id as string);
-      const limit = clampInt(args.limit, 1, MAX_FETCH_LIMIT, DEFAULTS.MESSAGES);
-      const messages = await channel.messages.fetch({ limit, cache: false });
+/** Tool definitions for reading, sending, replying, editing, reacting, threading, embedding, deleting, pinning, and searching messages. */
+const tools = [
+  defineTool({
+    name: "discord_read_messages",
+    description:
+      "Read the most recent messages from a text channel or thread, oldest-to-newest. Returns a JSON array of messages (id, author, content, timestamp, attachment count, pinned flag). Use discord_search_messages to filter by keyword, or discord_fetch_pinned_messages for pinned messages only.",
+    annotations: { title: "Read messages", readOnlyHint: true, openWorldHint: true },
+    schema: z.object({
+      channel_id: snowflake.describe("ID (snowflake) of the channel or thread to read from."),
+      limit: z.number().optional().describe("How many recent messages to fetch (1–100). Default 20."),
+    }),
+    handle: async ({ channel_id, limit }) => {
+      const channel = await getTextChannel(channel_id);
+      const max = clampInt(limit, 1, MAX_FETCH_LIMIT, DEFAULTS.MESSAGES);
+      const messages = await channel.messages.fetch({ limit: max, cache: false });
       const result = [...messages.values()]
         .sort((a, b) => a.createdTimestamp - b.createdTimestamp)
         .map((m) => ({
@@ -317,178 +49,326 @@ export async function handle(name: string, args: Record<string, unknown>): Promi
           timestamp: m.createdAt.toISOString(), attachments: m.attachments.size, pinned: m.pinned,
         }));
       return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
-    }
-
-    case "discord_send_message": {
-      const channel = await getTextChannel(args.channel_id as string);
-      const sent = await channel.send(args.content as string);
+    },
+  }),
+  defineTool({
+    name: "discord_send_message",
+    description:
+      "Send a plain-text message to a channel or thread. For rich content (title, color, fields, images) use discord_send_embed; to attach a reply reference to an existing message use discord_reply_message. Requires the bot to have the Send Messages permission. Returns the new message ID.",
+    annotations: { title: "Send message", readOnlyHint: false, destructiveHint: false, idempotentHint: false, openWorldHint: true },
+    schema: z.object({
+      channel_id: snowflake.describe("ID (snowflake) of the target channel or thread."),
+      content: z.string().describe("Plain-text body of the message (max 2000 characters)."),
+    }),
+    handle: async ({ channel_id, content }) => {
+      const channel = await getTextChannel(channel_id);
+      const sent = await channel.send(content);
       return { content: [{ type: "text", text: `✅ Message sent (id: ${sent.id}) in #${channel.name}.` }] };
-    }
-
-    case "discord_reply_message": {
-      const channel = await getTextChannel(args.channel_id as string);
-      const target = await channel.messages.fetch(args.message_id as string);
-      const sent = await target.reply(args.content as string);
-      return { content: [{ type: "text", text: `✅ Reply sent (id: ${sent.id}) to message ${args.message_id} in #${channel.name}.` }] };
-    }
-
-    case "discord_edit_message": {
-      const channel = await getTextChannel(args.channel_id as string);
-      const msg = await channel.messages.fetch(args.message_id as string);
+    },
+  }),
+  defineTool({
+    name: "discord_reply_message",
+    description:
+      "Reply to a specific message, attaching a reply reference so clients show it as a threaded reply. Use discord_send_message for a standalone message with no reference. Requires the Send Messages permission. Returns the new reply's message ID.",
+    annotations: { title: "Reply to message", readOnlyHint: false, destructiveHint: false, idempotentHint: false, openWorldHint: true },
+    schema: z.object({
+      channel_id: channelId.describe("ID (snowflake) of the channel or thread containing the message."),
+      message_id: messageId.describe("ID of the message to reply to."),
+      content: z.string().describe("Plain-text body of the reply (max 2000 characters)."),
+    }),
+    handle: async ({ channel_id, message_id, content }) => {
+      const channel = await getTextChannel(channel_id);
+      const target = await channel.messages.fetch(message_id);
+      const sent = await target.reply(content);
+      return { content: [{ type: "text", text: `✅ Reply sent (id: ${sent.id}) to message ${message_id} in #${channel.name}.` }] };
+    },
+  }),
+  defineTool({
+    name: "discord_edit_message",
+    description:
+      "Edit the text content of a message previously sent by this bot. Discord forbids editing other users' messages, so this fails for non-bot messages. Use discord_edit_embed for embed messages. Works in text channels and threads. Returns the edited message ID.",
+    annotations: { title: "Edit message", readOnlyHint: false, destructiveHint: false, idempotentHint: true, openWorldHint: true },
+    schema: z.object({
+      channel_id: channelId.describe("ID (snowflake) of the channel or thread containing the message."),
+      message_id: messageId.describe("ID of the message to edit. Must be a message authored by this bot."),
+      content: z.string().describe("New plain-text content that fully replaces the existing content (max 2000 characters)."),
+    }),
+    handle: async ({ channel_id, message_id, content }) => {
+      const channel = await getTextChannel(channel_id);
+      const msg = await channel.messages.fetch(message_id);
       if (msg.author.id !== discord.user?.id) throw new Error("Can only edit messages sent by the bot.");
-      const edited = await msg.edit(args.content as string);
+      const edited = await msg.edit(content);
       return { content: [{ type: "text", text: `✅ Message ${edited.id} edited in #${channel.name}.` }] };
-    }
-
-    case "discord_add_reaction": {
-      const channel = await getTextChannel(args.channel_id as string);
-      const msg = await channel.messages.fetch(args.message_id as string);
-      await msg.react(args.emoji as string);
-      return { content: [{ type: "text", text: `✅ Reacted with ${args.emoji} to message ${msg.id} in #${channel.name}.` }] };
-    }
-
-    case "discord_create_thread": {
-      const channel = await getTextChannel(args.channel_id as string);
-      const duration = (args.auto_archive_duration as number) ?? 1440;
-      if (args.message_id) {
-        const msg = await channel.messages.fetch(args.message_id as string);
-        const thread = await msg.startThread({
-          name: args.name as string,
-          autoArchiveDuration: duration as 60 | 1440 | 4320 | 10080,
-        });
+    },
+  }),
+  defineTool({
+    name: "discord_add_reaction",
+    description:
+      "Add a single emoji reaction to a message as the bot. Requires the Add Reactions and Read Message History permissions. Use discord_remove_reactions to undo. Idempotent: re-adding the bot's existing reaction has no effect.",
+    annotations: { title: "Add reaction", readOnlyHint: false, destructiveHint: false, idempotentHint: true, openWorldHint: true },
+    schema: z.object({
+      channel_id: channelId.describe("ID (snowflake) of the channel or thread containing the message."),
+      message_id: messageId.describe("ID of the message to react to."),
+      emoji: z.string().describe("Unicode emoji (e.g. '👍') or a custom emoji in 'name:id' format."),
+    }),
+    handle: async ({ channel_id, message_id, emoji }) => {
+      const channel = await getTextChannel(channel_id);
+      const msg = await channel.messages.fetch(message_id);
+      await msg.react(emoji);
+      return { content: [{ type: "text", text: `✅ Reacted with ${emoji} to message ${msg.id} in #${channel.name}.` }] };
+    },
+  }),
+  defineTool({
+    name: "discord_create_thread",
+    description:
+      "Create a thread, either branching from an existing message (pass message_id) or as a standalone thread in a text channel (omit message_id). Standalone creation requires a parent text channel and fails if channel_id is itself a thread. Requires the Create Public Threads permission. Returns the new thread's ID.",
+    annotations: { title: "Create thread", readOnlyHint: false, destructiveHint: false, idempotentHint: false, openWorldHint: true },
+    schema: z.object({
+      channel_id: snowflake.describe("ID (snowflake) of the parent text channel. For a message-based thread, the channel containing message_id."),
+      name: z.string().describe("Name of the thread to create (max 100 characters)."),
+      message_id: snowflake.optional().describe("Optional. Message to branch the thread from. If omitted, a standalone thread is created in the channel."),
+      auto_archive_duration: z.number().optional().describe("Minutes of inactivity before auto-archiving: 60, 1440, 4320, or 10080. Default 1440 (24h)."),
+    }),
+    handle: async ({ channel_id, name, message_id, auto_archive_duration }) => {
+      const channel = await getTextChannel(channel_id);
+      const duration = (auto_archive_duration ?? 1440) as 60 | 1440 | 4320 | 10080;
+      if (message_id) {
+        const msg = await channel.messages.fetch(message_id);
+        const thread = await msg.startThread({ name, autoArchiveDuration: duration });
         return { content: [{ type: "text", text: `✅ Thread "${thread.name}" created from message (id: ${thread.id}).` }] };
-      } else {
-        if (!(channel instanceof TextChannel)) {
-          throw new Error(`Standalone thread creation requires a parent TextChannel; ${args.channel_id} is itself a thread. Pass a message_id to start a thread from a message instead.`);
-        }
-        const thread = await channel.threads.create({
-          name: args.name as string,
-          autoArchiveDuration: duration as 60 | 1440 | 4320 | 10080,
-          type: ChannelType.PublicThread,
-        });
-        return { content: [{ type: "text", text: `✅ Thread "${thread.name}" created (id: ${thread.id}).` }] };
       }
-    }
-
-    case "discord_bulk_delete_messages": {
-      const channel = await getTextChannel(args.channel_id as string);
-      const count = clampInt(args.count, 2, 100, 2);
-      const deleted = await channel.bulkDelete(count, true);
+      if (!(channel instanceof TextChannel)) {
+        throw new Error(`Standalone thread creation requires a parent TextChannel; ${channel_id} is itself a thread. Pass a message_id to start a thread from a message instead.`);
+      }
+      const thread = await channel.threads.create({ name, autoArchiveDuration: duration, type: ChannelType.PublicThread });
+      return { content: [{ type: "text", text: `✅ Thread "${thread.name}" created (id: ${thread.id}).` }] };
+    },
+  }),
+  defineTool({
+    name: "discord_bulk_delete_messages",
+    description:
+      "Permanently delete multiple recent messages in one call. IRREVERSIBLE. Discord only allows bulk-deleting messages younger than 14 days; older ones are skipped. Requires the Manage Messages permission. Use discord_delete_message to remove a single specific message. Returns the number actually deleted.",
+    annotations: { title: "Bulk delete messages", readOnlyHint: false, destructiveHint: true, idempotentHint: false, openWorldHint: true },
+    schema: z.object({
+      channel_id: snowflake.describe("ID (snowflake) of the channel or thread to delete messages from."),
+      count: z.number().describe("Number of recent messages to delete (2–100)."),
+    }),
+    handle: async ({ channel_id, count }) => {
+      const channel = await getTextChannel(channel_id);
+      const deleted = await channel.bulkDelete(clampInt(count, 2, 100, 2), true);
       return { content: [{ type: "text", text: `✅ Deleted ${deleted.size} messages in #${channel.name}.` }] };
-    }
-
-    case "discord_send_embed": {
-      const channel = await getTextChannel(args.channel_id as string);
-      const embed = buildEmbed(args);
-      const sent = await channel.send({ embeds: [embed] });
+    },
+  }),
+  defineTool({
+    name: "discord_send_embed",
+    description:
+      "Send a single rich embed (title, description, color, fields, author, footer, images, timestamp). Use discord_send_message for plain text, or discord_send_multiple_embeds to send several embeds at once. Requires the Send Messages and Embed Links permissions. Returns the new message ID.",
+    annotations: { title: "Send embed", readOnlyHint: false, destructiveHint: false, idempotentHint: false, openWorldHint: true },
+    schema: z.object({
+      channel_id: snowflake.describe("ID (snowflake) of the target channel or thread."),
+      ...embedFieldsShape,
+    }),
+    handle: async ({ channel_id, ...embedArgs }) => {
+      const channel = await getTextChannel(channel_id);
+      const sent = await channel.send({ embeds: [buildEmbed(embedArgs)] });
       return { content: [{ type: "text", text: `✅ Embed sent (id: ${sent.id}) in #${channel.name}.` }] };
-    }
-
-    case "discord_edit_embed": {
-      const channel = await getTextChannel(args.channel_id as string);
-      const msg = await channel.messages.fetch(args.message_id as string);
+    },
+  }),
+  defineTool({
+    name: "discord_edit_embed",
+    description:
+      "Replace the embed on a message previously sent by this bot. Only this bot's messages can be edited. This is a full replace, not a merge: provided fields are applied and omitted fields are dropped from the embed. Returns a confirmation.",
+    annotations: { title: "Edit embed", readOnlyHint: false, destructiveHint: false, idempotentHint: true, openWorldHint: true },
+    schema: z.object({
+      channel_id: channelId.describe("ID (snowflake) of the channel or thread containing the message."),
+      message_id: messageId.describe("ID of the message to edit. Must be a bot message that already contains an embed."),
+      ...embedFieldsShape,
+    }),
+    handle: async ({ channel_id, message_id, ...embedArgs }) => {
+      const channel = await getTextChannel(channel_id);
+      const msg = await channel.messages.fetch(message_id);
       if (msg.author.id !== discord.user?.id) throw new Error("Can only edit embeds sent by the bot.");
-      const embed = buildEmbed(args);
-      await msg.edit({ embeds: [embed] });
-      return { content: [{ type: "text", text: `✅ Embed edited on message ${args.message_id} in #${channel.name}.` }] };
-    }
-
-    case "discord_send_multiple_embeds": {
-      const channel = await getTextChannel(args.channel_id as string);
-      const embedArgs = args.embeds as Record<string, unknown>[];
-      if (embedArgs.length > 10) throw new Error("Discord allows a maximum of 10 embeds per message.");
-      const embeds = embedArgs.map((e) => buildEmbed(e));
-      const sent = await channel.send({
-        content: (args.content as string) || undefined,
-        embeds,
-      });
-      return { content: [{ type: "text", text: `✅ ${embeds.length} embeds sent (id: ${sent.id}) in #${channel.name}.` }] };
-    }
-
-    case "discord_delete_message": {
-      const channel = await getTextChannel(args.channel_id as string);
-      const msg = await channel.messages.fetch(args.message_id as string);
+      await msg.edit({ embeds: [buildEmbed(embedArgs)] });
+      return { content: [{ type: "text", text: `✅ Embed edited on message ${message_id} in #${channel.name}.` }] };
+    },
+  }),
+  defineTool({
+    name: "discord_send_multiple_embeds",
+    description:
+      "Send up to 10 embeds in a single message, with optional text above them. Use discord_send_embed for a single embed. Requires the Send Messages and Embed Links permissions. Returns the new message ID.",
+    annotations: { title: "Send multiple embeds", readOnlyHint: false, destructiveHint: false, idempotentHint: false, openWorldHint: true },
+    schema: z.object({
+      channel_id: snowflake.describe("ID (snowflake) of the target channel or thread."),
+      content: z.string().optional().describe("Optional plain text shown above the embeds."),
+      embeds: z.array(embedObjectSchema).describe("Array of embed objects to send (max 10)."),
+    }),
+    handle: async ({ channel_id, content, embeds }) => {
+      const channel = await getTextChannel(channel_id);
+      if (embeds.length > 10) throw new Error("Discord allows a maximum of 10 embeds per message.");
+      const built = embeds.map((e) => buildEmbed(e));
+      const sent = await channel.send({ content: content || undefined, embeds: built });
+      return { content: [{ type: "text", text: `✅ ${built.length} embeds sent (id: ${sent.id}) in #${channel.name}.` }] };
+    },
+  }),
+  defineTool({
+    name: "discord_delete_message",
+    description:
+      "Permanently delete one specific message. IRREVERSIBLE. The bot can always delete its own messages; deleting another user's message requires the Manage Messages permission. Use discord_bulk_delete_messages to remove many at once. An optional reason is recorded in the audit log.",
+    annotations: { title: "Delete message", readOnlyHint: false, destructiveHint: true, idempotentHint: false, openWorldHint: true },
+    schema: z.object({
+      channel_id: channelId.describe("ID (snowflake) of the channel or thread containing the message."),
+      message_id: messageId.describe("ID of the message to delete."),
+      reason: z.string().optional().describe("Optional reason recorded in the server audit log."),
+    }),
+    handle: async ({ channel_id, message_id }) => {
+      const channel = await getTextChannel(channel_id);
+      const msg = await channel.messages.fetch(message_id);
       await msg.delete();
-      return { content: [{ type: "text", text: `✅ Message ${args.message_id} deleted.` }] };
-    }
-
-    case "discord_pin_message": {
-      const channel = await getTextChannel(args.channel_id as string);
-      const msg = await channel.messages.fetch(args.message_id as string);
-      if (args.pin) { await msg.pin(); } else { await msg.unpin(); }
-      return { content: [{ type: "text", text: `✅ Message ${args.pin ? "pinned" : "unpinned"}.` }] };
-    }
-
-    case "discord_search_messages": {
-      const channel = await getTextChannel(args.channel_id as string);
-      const limit = clampInt(args.limit, 1, MAX_FETCH_LIMIT, MAX_FETCH_LIMIT);
-      const messages = await channel.messages.fetch({ limit, cache: false });
-      const keyword = (args.keyword as string).toLowerCase();
+      return { content: [{ type: "text", text: `✅ Message ${message_id} deleted.` }] };
+    },
+  }),
+  defineTool({
+    name: "discord_pin_message",
+    description:
+      "Pin or unpin a message in a channel, controlled by the pin flag. Requires the Pin Messages permission (a dedicated permission since early 2026, separate from Manage Messages). A channel holds at most 50 pins. Idempotent: pinning an already-pinned message (or unpinning an unpinned one) has no additional effect.",
+    annotations: { title: "Pin or unpin message", readOnlyHint: false, destructiveHint: false, idempotentHint: true, openWorldHint: true },
+    schema: z.object({
+      channel_id: channelId.describe("ID (snowflake) of the channel or thread containing the message."),
+      message_id: messageId.describe("ID of the message to pin or unpin."),
+      pin: z.boolean().describe("true to pin the message, false to unpin it."),
+    }),
+    handle: async ({ channel_id, message_id, pin }) => {
+      const channel = await getTextChannel(channel_id);
+      const msg = await channel.messages.fetch(message_id);
+      if (pin) { await msg.pin(); } else { await msg.unpin(); }
+      return { content: [{ type: "text", text: `✅ Message ${pin ? "pinned" : "unpinned"}.` }] };
+    },
+  }),
+  defineTool({
+    name: "discord_search_messages",
+    description:
+      "Keyword search over a channel's recent messages using case-insensitive substring matching. Scans only up to the last 100 messages — it does not search full history. Returns matching messages as a JSON array. Use discord_read_messages to fetch recent messages without filtering.",
+    annotations: { title: "Search messages", readOnlyHint: true, openWorldHint: true },
+    schema: z.object({
+      channel_id: snowflake.describe("ID (snowflake) of the channel or thread to search."),
+      keyword: z.string().describe("Case-insensitive substring to match within message content."),
+      limit: z.number().optional().describe("Max number of recent messages to scan (1–100). Default 100."),
+    }),
+    handle: async ({ channel_id, keyword, limit }) => {
+      const channel = await getTextChannel(channel_id);
+      const max = clampInt(limit, 1, MAX_FETCH_LIMIT, MAX_FETCH_LIMIT);
+      const messages = await channel.messages.fetch({ limit: max, cache: false });
+      const needle = keyword.toLowerCase();
       const matches = [...messages.values()]
-        .filter((m) => m.content.toLowerCase().includes(keyword))
+        .filter((m) => m.content.toLowerCase().includes(needle))
         .sort((a, b) => a.createdTimestamp - b.createdTimestamp)
         .map((m) => ({ id: m.id, author: m.author.tag, content: m.content, timestamp: m.createdAt.toISOString() }));
-      return { content: [{ type: "text", text: matches.length > 0 ? JSON.stringify(matches, null, 2) : `No messages found containing "${args.keyword}" in the last ${limit} messages.` }] };
-    }
-
-    case "discord_crosspost_message": {
-      const channel = await getTextChannel(args.channel_id as string);
-      const msg = await channel.messages.fetch(args.message_id as string);
+      return { content: [{ type: "text", text: matches.length > 0 ? JSON.stringify(matches, null, 2) : `No messages found containing "${keyword}" in the last ${max} messages.` }] };
+    },
+  }),
+  defineTool({
+    name: "discord_crosspost_message",
+    description:
+      "Publish (crosspost) a message from an Announcement channel to every server that follows it. Only works in announcement channels on a message that has not already been published. Requires the Send Messages permission (and Manage Messages for messages authored by others). Returns a confirmation.",
+    annotations: { title: "Crosspost message", readOnlyHint: false, destructiveHint: false, idempotentHint: true, openWorldHint: true },
+    schema: z.object({
+      channel_id: snowflake.describe("ID (snowflake) of the announcement channel containing the message."),
+      message_id: messageId.describe("ID of the message to publish to followers."),
+    }),
+    handle: async ({ channel_id, message_id }) => {
+      const channel = await getTextChannel(channel_id);
+      const msg = await channel.messages.fetch(message_id);
       await msg.crosspost();
       return { content: [{ type: "text", text: `✅ Message ${msg.id} published to all followers of #${channel.name}.` }] };
-    }
-
-    case "discord_remove_reactions": {
-      const channel = await getTextChannel(args.channel_id as string);
-      const msg = await channel.messages.fetch(args.message_id as string);
-      if (!args.emoji) {
+    },
+  }),
+  defineTool({
+    name: "discord_remove_reactions",
+    description:
+      "Remove reactions from a message. With no emoji: removes ALL reactions. With emoji only: removes every reaction of that emoji. With emoji and user_id: removes that one user's reaction. Removing all reactions or another user's reaction requires the Manage Messages permission. Use discord_add_reaction to add.",
+    annotations: { title: "Remove reactions", readOnlyHint: false, destructiveHint: false, idempotentHint: true, openWorldHint: true },
+    schema: z.object({
+      channel_id: channelId.describe("ID (snowflake) of the channel or thread containing the message."),
+      message_id: messageId.describe("ID of the message to remove reactions from."),
+      emoji: z.string().optional().describe("Unicode emoji or custom emoji 'name:id'. Omit to remove ALL reactions on the message."),
+      user_id: snowflake.optional().describe("Remove only this user's reaction for the given emoji. Requires emoji to be set."),
+    }),
+    handle: async ({ channel_id, message_id, emoji, user_id }) => {
+      const channel = await getTextChannel(channel_id);
+      const msg = await channel.messages.fetch(message_id);
+      if (!emoji) {
         await msg.reactions.removeAll();
         return { content: [{ type: "text", text: `✅ All reactions removed from message ${msg.id}.` }] };
       }
-      const reaction = findReaction(msg, args.emoji as string);
-      if (!reaction) throw new Error(`No reaction found for emoji "${args.emoji}" on message ${msg.id}.`);
-      if (args.user_id) {
-        await reaction.users.remove(args.user_id as string);
-        return { content: [{ type: "text", text: `✅ Removed ${args.emoji} reaction from user ${args.user_id} on message ${msg.id}.` }] };
+      const reaction = findReaction(msg, emoji);
+      if (!reaction) throw new Error(`No reaction found for emoji "${emoji}" on message ${msg.id}.`);
+      if (user_id) {
+        await reaction.users.remove(user_id);
+        return { content: [{ type: "text", text: `✅ Removed ${emoji} reaction from user ${user_id} on message ${msg.id}.` }] };
       }
       await reaction.remove();
-      return { content: [{ type: "text", text: `✅ All ${args.emoji} reactions removed from message ${msg.id}.` }] };
-    }
-
-    case "discord_get_reactions": {
-      const channel = await getTextChannel(args.channel_id as string);
-      const msg = await channel.messages.fetch(args.message_id as string);
-      const reaction = findReaction(msg, args.emoji as string);
-      if (!reaction) throw new Error(`No reaction found for emoji "${args.emoji}" on message ${msg.id}.`);
-      const limit = clampInt(args.limit, 1, MAX_FETCH_LIMIT, DEFAULTS.LIMIT);
-      const users = await reaction.users.fetch({ limit });
+      return { content: [{ type: "text", text: `✅ All ${emoji} reactions removed from message ${msg.id}.` }] };
+    },
+  }),
+  defineTool({
+    name: "discord_get_reactions",
+    description:
+      "List the users who reacted to a message with a specific emoji. Returns a JSON array of users (id, username, bot flag). Read-only.",
+    annotations: { title: "Get reactions", readOnlyHint: true, openWorldHint: true },
+    schema: z.object({
+      channel_id: channelId.describe("ID (snowflake) of the channel or thread containing the message."),
+      message_id: messageId.describe("ID of the message to inspect."),
+      emoji: z.string().describe("Unicode emoji or custom emoji 'name:id' to list reactors for."),
+      limit: z.number().optional().describe("Max users to return (1–100). Default 25."),
+    }),
+    handle: async ({ channel_id, message_id, emoji, limit }) => {
+      const channel = await getTextChannel(channel_id);
+      const msg = await channel.messages.fetch(message_id);
+      const reaction = findReaction(msg, emoji);
+      if (!reaction) throw new Error(`No reaction found for emoji "${emoji}" on message ${msg.id}.`);
+      const users = await reaction.users.fetch({ limit: clampInt(limit, 1, MAX_FETCH_LIMIT, DEFAULTS.LIMIT) });
       const result = [...users.values()].map((u) => ({ id: u.id, username: u.username, bot: u.bot }));
       return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
-    }
-
-    case "discord_fetch_pinned_messages": {
-      const channel = await getTextChannel(args.channel_id as string);
+    },
+  }),
+  defineTool({
+    name: "discord_fetch_pinned_messages",
+    description:
+      "List all pinned messages in a channel as a JSON array (id, author, content, timestamp, pinnedAt). Read-only. Use discord_pin_message to change which messages are pinned.",
+    annotations: { title: "Fetch pinned messages", readOnlyHint: true, openWorldHint: true },
+    schema: z.object({
+      channel_id: snowflake.describe("ID (snowflake) of the channel or thread to list pins from."),
+    }),
+    handle: async ({ channel_id }) => {
+      const channel = await getTextChannel(channel_id);
       const pinned = await channel.messages.fetchPins();
       const result = pinned.items.map(({ message: m, pinnedAt }) => ({
         id: m.id, author: m.author.tag, content: m.content,
         timestamp: m.createdAt.toISOString(), pinnedAt: pinnedAt.toISOString(),
       }));
       return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
-    }
-
-    case "discord_forward_message": {
-      const channel = await getTextChannel(args.channel_id as string);
-      const msg = await channel.messages.fetch(args.message_id as string);
-      const targetChannel = await getTextChannel(args.target_channel_id as string);
+    },
+  }),
+  defineTool({
+    name: "discord_forward_message",
+    description:
+      "Forward an existing message to another channel using Discord's native forward, which preserves the original attribution. Works across text channels and threads. Use discord_send_message to compose new content instead. Requires the Send Messages permission in the target channel. Returns a confirmation.",
+    annotations: { title: "Forward message", readOnlyHint: false, destructiveHint: false, idempotentHint: false, openWorldHint: true },
+    schema: z.object({
+      channel_id: channelId.describe("ID (snowflake) of the channel or thread containing the source message."),
+      message_id: messageId.describe("ID of the message to forward."),
+      target_channel_id: snowflake.describe("ID (snowflake) of the destination channel or thread."),
+    }),
+    handle: async ({ channel_id, message_id, target_channel_id }) => {
+      const channel = await getTextChannel(channel_id);
+      const msg = await channel.messages.fetch(message_id);
+      const targetChannel = await getTextChannel(target_channel_id);
       // ThreadChannel<boolean> is the abstract base for PublicThreadChannel / PrivateThreadChannel;
       // any runtime instance is one of them, but the type narrowing can't be expressed without a cast.
       await msg.forward(targetChannel as TextChannel | PublicThreadChannel<boolean> | PrivateThreadChannel);
       return { content: [{ type: "text", text: `✅ Message ${msg.id} forwarded to #${targetChannel.name}.` }] };
-    }
+    },
+  }),
+];
 
-    default:
-      return null;
-  }
-}
-
-export default { definitions, handle } satisfies ToolModule;
+export default defineModule(tools);

--- a/src/tools/messages.ts
+++ b/src/tools/messages.ts
@@ -7,10 +7,10 @@ import {
   MessageReaction,
 } from "discord.js";
 import { z } from "zod";
-import { discord, getTextChannel, clampInt } from "../client.js";
+import { discord, getTextChannel } from "../client.js";
 import { MAX_FETCH_LIMIT, DEFAULTS } from "../constants.js";
 import { buildEmbed, embedFieldsShape, embedObjectSchema } from "../embeds.js";
-import { defineModule, defineTool, snowflake } from "./define.js";
+import { defineModule, defineTool, snowflake, intIn } from "./define.js";
 
 const channelId = snowflake.describe("ID (snowflake) of the channel or thread.");
 const messageId = snowflake.describe("ID of the message.");
@@ -36,12 +36,11 @@ const tools = [
     annotations: { title: "Read messages", readOnlyHint: true, openWorldHint: true },
     schema: z.object({
       channel_id: snowflake.describe("ID (snowflake) of the channel or thread to read from."),
-      limit: z.number().optional().describe("How many recent messages to fetch (1–100). Default 20."),
+      limit: intIn(1, MAX_FETCH_LIMIT).default(DEFAULTS.MESSAGES).describe("How many recent messages to fetch (1–100). Default 20."),
     }),
     handle: async ({ channel_id, limit }) => {
       const channel = await getTextChannel(channel_id);
-      const max = clampInt(limit, 1, MAX_FETCH_LIMIT, DEFAULTS.MESSAGES);
-      const messages = await channel.messages.fetch({ limit: max, cache: false });
+      const messages = await channel.messages.fetch({ limit, cache: false });
       const result = [...messages.values()]
         .sort((a, b) => a.createdTimestamp - b.createdTimestamp)
         .map((m) => ({
@@ -127,11 +126,14 @@ const tools = [
       channel_id: snowflake.describe("ID (snowflake) of the parent text channel. For a message-based thread, the channel containing message_id."),
       name: z.string().describe("Name of the thread to create (max 100 characters)."),
       message_id: snowflake.optional().describe("Optional. Message to branch the thread from. If omitted, a standalone thread is created in the channel."),
-      auto_archive_duration: z.number().optional().describe("Minutes of inactivity before auto-archiving: 60, 1440, 4320, or 10080. Default 1440 (24h)."),
+      auto_archive_duration: z
+        .union([z.literal(60), z.literal(1440), z.literal(4320), z.literal(10080)])
+        .default(1440)
+        .describe("Minutes of inactivity before auto-archiving: 60, 1440, 4320, or 10080. Default 1440 (24h)."),
     }),
     handle: async ({ channel_id, name, message_id, auto_archive_duration }) => {
       const channel = await getTextChannel(channel_id);
-      const duration = (auto_archive_duration ?? 1440) as 60 | 1440 | 4320 | 10080;
+      const duration = auto_archive_duration;
       if (message_id) {
         const msg = await channel.messages.fetch(message_id);
         const thread = await msg.startThread({ name, autoArchiveDuration: duration });
@@ -151,11 +153,11 @@ const tools = [
     annotations: { title: "Bulk delete messages", readOnlyHint: false, destructiveHint: true, idempotentHint: false, openWorldHint: true },
     schema: z.object({
       channel_id: snowflake.describe("ID (snowflake) of the channel or thread to delete messages from."),
-      count: z.number().describe("Number of recent messages to delete (2–100)."),
+      count: intIn(2, MAX_FETCH_LIMIT).describe("Number of recent messages to delete (2–100)."),
     }),
     handle: async ({ channel_id, count }) => {
       const channel = await getTextChannel(channel_id);
-      const deleted = await channel.bulkDelete(clampInt(count, 2, 100, 2), true);
+      const deleted = await channel.bulkDelete(count, true);
       return { content: [{ type: "text", text: `✅ Deleted ${deleted.size} messages in #${channel.name}.` }] };
     },
   }),
@@ -252,18 +254,17 @@ const tools = [
     schema: z.object({
       channel_id: snowflake.describe("ID (snowflake) of the channel or thread to search."),
       keyword: z.string().describe("Case-insensitive substring to match within message content."),
-      limit: z.number().optional().describe("Max number of recent messages to scan (1–100). Default 100."),
+      limit: intIn(1, MAX_FETCH_LIMIT).default(MAX_FETCH_LIMIT).describe("Max number of recent messages to scan (1–100). Default 100."),
     }),
     handle: async ({ channel_id, keyword, limit }) => {
       const channel = await getTextChannel(channel_id);
-      const max = clampInt(limit, 1, MAX_FETCH_LIMIT, MAX_FETCH_LIMIT);
-      const messages = await channel.messages.fetch({ limit: max, cache: false });
+      const messages = await channel.messages.fetch({ limit, cache: false });
       const needle = keyword.toLowerCase();
       const matches = [...messages.values()]
         .filter((m) => m.content.toLowerCase().includes(needle))
         .sort((a, b) => a.createdTimestamp - b.createdTimestamp)
         .map((m) => ({ id: m.id, author: m.author.tag, content: m.content, timestamp: m.createdAt.toISOString() }));
-      return { content: [{ type: "text", text: matches.length > 0 ? JSON.stringify(matches, null, 2) : `No messages found containing "${keyword}" in the last ${max} messages.` }] };
+      return { content: [{ type: "text", text: matches.length > 0 ? JSON.stringify(matches, null, 2) : `No messages found containing "${keyword}" in the last ${limit} messages.` }] };
     },
   }),
   defineTool({
@@ -319,14 +320,14 @@ const tools = [
       channel_id: channelId.describe("ID (snowflake) of the channel or thread containing the message."),
       message_id: messageId.describe("ID of the message to inspect."),
       emoji: z.string().describe("Unicode emoji or custom emoji 'name:id' to list reactors for."),
-      limit: z.number().optional().describe("Max users to return (1–100). Default 25."),
+      limit: intIn(1, MAX_FETCH_LIMIT).default(DEFAULTS.LIMIT).describe("Max users to return (1–100). Default 25."),
     }),
     handle: async ({ channel_id, message_id, emoji, limit }) => {
       const channel = await getTextChannel(channel_id);
       const msg = await channel.messages.fetch(message_id);
       const reaction = findReaction(msg, emoji);
       if (!reaction) throw new Error(`No reaction found for emoji "${emoji}" on message ${msg.id}.`);
-      const users = await reaction.users.fetch({ limit: clampInt(limit, 1, MAX_FETCH_LIMIT, DEFAULTS.LIMIT) });
+      const users = await reaction.users.fetch({ limit });
       const result = [...users.values()].map((u) => ({ id: u.id, username: u.username, bot: u.bot }));
       return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
     },

--- a/src/tools/moderation.ts
+++ b/src/tools/moderation.ts
@@ -1,36 +1,24 @@
-import { discord, validateId, clampInt } from "../client.js";
-import type { ToolModule, ToolResult } from "./types.js";
+import { z } from "zod";
+import { discord, clampInt } from "../client.js";
+import { defineTool, defineModule, guildId } from "./define.js";
 
 /** Tool definitions for server moderation (audit log). */
-export const definitions = [
-  {
+const tools = [
+  defineTool({
     name: "discord_get_audit_log",
     description:
       "Fetch the server's audit log — a record of administrative actions (bans, kicks, role/channel changes, etc.) with who performed them and when. Requires the View Audit Log permission. Returns a JSON array (id, action, executor, target, reason, timestamp). Read-only.",
     annotations: { title: "Get audit log", readOnlyHint: true, openWorldHint: true },
-    inputSchema: {
-      type: "object",
-      properties: {
-        guild_id: { type: "string", description: "Discord server (guild) ID (snowflake)." },
-        limit: { type: "number", description: "How many recent entries to fetch (1–100). Default 25." },
-        action_type: { type: "number", description: "Optional Discord AuditLogEvent numeric ID to filter by (e.g. 22 = MemberBanAdd). Omit for all action types." },
-      },
-      required: ["guild_id"],
-    },
-  },
-];
-
-/**
- * Handles moderation tools: fetches the guild audit log
- * with optional filtering by action type.
- */
-export async function handle(name: string, args: Record<string, unknown>): Promise<ToolResult | null> {
-  switch (name) {
-    case "discord_get_audit_log": {
-      const guild = await discord.guilds.fetch(validateId(args.guild_id, "guild_id"));
+    schema: z.object({
+      guild_id: guildId,
+      limit: z.number().optional().describe("How many recent entries to fetch (1–100). Default 25."),
+      action_type: z.number().optional().describe("Optional Discord AuditLogEvent numeric ID to filter by (e.g. 22 = MemberBanAdd). Omit for all action types."),
+    }),
+    handle: async ({ guild_id, limit, action_type }) => {
+      const guild = await discord.guilds.fetch(guild_id);
       const logs = await guild.fetchAuditLogs({
-        limit: clampInt(args.limit, 1, 100, 25),
-        type: args.action_type as number | undefined,
+        limit: clampInt(limit, 1, 100, 25),
+        type: action_type as number | undefined,
       });
       const result = logs.entries.map((entry) => ({
         id: entry.id, action: entry.action,
@@ -38,11 +26,8 @@ export async function handle(name: string, args: Record<string, unknown>): Promi
         reason: entry.reason, createdAt: entry.createdAt.toISOString(),
       }));
       return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
-    }
+    },
+  }),
+];
 
-    default:
-      return null;
-  }
-}
-
-export default { definitions, handle } satisfies ToolModule;
+export default defineModule(tools);

--- a/src/tools/moderation.ts
+++ b/src/tools/moderation.ts
@@ -1,6 +1,6 @@
 import { z } from "zod";
-import { discord, clampInt } from "../client.js";
-import { defineTool, defineModule, guildId } from "./define.js";
+import { discord } from "../client.js";
+import { defineTool, defineModule, guildId, intIn } from "./define.js";
 
 /** Tool definitions for server moderation (audit log). */
 const tools = [
@@ -11,13 +11,13 @@ const tools = [
     annotations: { title: "Get audit log", readOnlyHint: true, openWorldHint: true },
     schema: z.object({
       guild_id: guildId,
-      limit: z.number().optional().describe("How many recent entries to fetch (1–100). Default 25."),
-      action_type: z.number().optional().describe("Optional Discord AuditLogEvent numeric ID to filter by (e.g. 22 = MemberBanAdd). Omit for all action types."),
+      limit: intIn(1, 100).default(25).describe("How many recent entries to fetch (1–100). Default 25."),
+      action_type: z.int().optional().describe("Optional Discord AuditLogEvent numeric ID to filter by (e.g. 22 = MemberBanAdd). Omit for all action types."),
     }),
     handle: async ({ guild_id, limit, action_type }) => {
       const guild = await discord.guilds.fetch(guild_id);
       const logs = await guild.fetchAuditLogs({
-        limit: clampInt(limit, 1, 100, 25),
+        limit,
         type: action_type as number | undefined,
       });
       const result = logs.entries.map((entry) => ({

--- a/src/tools/permissions.ts
+++ b/src/tools/permissions.ts
@@ -1,114 +1,32 @@
 import { PermissionOverwriteOptions, GuildChannel } from "discord.js";
-import { discord, getGuildChannel, serializePermissions, validateId } from "../client.js";
-import type { ToolModule, ToolResult } from "./types.js";
-
-/** Tool definitions for viewing and managing per-channel permission overwrites. */
-export const definitions = [
-  {
-    name: "discord_get_channel_permissions",
-    description:
-      "List every permission overwrite on a channel, per role and per member, with the allowed and denied permission flags for each. Read-only. Use discord_audit_permissions for a server-wide report across all channels.",
-    annotations: { title: "Get channel permissions", readOnlyHint: true, openWorldHint: true },
-    inputSchema: {
-      type: "object",
-      properties: { channel_id: { type: "string", description: "ID (snowflake) of the channel to inspect." } },
-      required: ["channel_id"],
-    },
-  },
-  {
-    name: "discord_set_role_permission",
-    description:
-      "Add or update a per-channel permission overwrite for a role, allowing and/or denying specific permissions. Merges with the role's existing overwrite (does not reset it). Requires the Manage Roles permission. Use discord_set_member_permission to target a single member instead.",
-    annotations: { title: "Set role channel permission", readOnlyHint: false, destructiveHint: false, idempotentHint: true, openWorldHint: true },
-    inputSchema: {
-      type: "object",
-      properties: {
-        channel_id: { type: "string", description: "ID (snowflake) of the channel to set the overwrite on." },
-        role_id: { type: "string", description: "ID (snowflake) of the role to grant/deny permissions for." },
-        allow: { type: "array", items: { type: "string" }, description: "Permission flag names to allow, e.g. ['SendMessages','ViewChannel']. Uses Discord PermissionsBitField flag names." },
-        deny: { type: "array", items: { type: "string" }, description: "Permission flag names to deny, e.g. ['SendMessages']." },
-        reason: { type: "string", description: "Optional reason recorded in the server audit log." },
-      },
-      required: ["channel_id", "role_id"],
-    },
-  },
-  {
-    name: "discord_set_member_permission",
-    description:
-      "Add or update a per-channel permission overwrite for a single member, allowing and/or denying specific permissions. Merges with the member's existing overwrite. Requires the Manage Roles permission. Use discord_set_role_permission to target a whole role instead.",
-    annotations: { title: "Set member channel permission", readOnlyHint: false, destructiveHint: false, idempotentHint: true, openWorldHint: true },
-    inputSchema: {
-      type: "object",
-      properties: {
-        channel_id: { type: "string", description: "ID (snowflake) of the channel to set the overwrite on." },
-        user_id: { type: "string", description: "ID (snowflake) of the member to grant/deny permissions for." },
-        allow: { type: "array", items: { type: "string" }, description: "Permission flag names to allow, e.g. ['ViewChannel']. Uses Discord PermissionsBitField flag names." },
-        deny: { type: "array", items: { type: "string" }, description: "Permission flag names to deny." },
-        reason: { type: "string", description: "Optional reason recorded in the server audit log." },
-      },
-      required: ["channel_id", "user_id"],
-    },
-  },
-  {
-    name: "discord_reset_channel_permissions",
-    description:
-      "Remove ALL permission overwrites on a channel, resetting it to inherit from its category/server defaults. IRREVERSIBLE — the cleared overwrites cannot be recovered. Requires the Manage Roles permission.",
-    annotations: { title: "Reset channel permissions", readOnlyHint: false, destructiveHint: true, idempotentHint: true, openWorldHint: true },
-    inputSchema: {
-      type: "object",
-      properties: {
-        channel_id: { type: "string", description: "ID (snowflake) of the channel whose overwrites will be cleared." },
-        reason: { type: "string", description: "Optional reason recorded in the server audit log." },
-      },
-      required: ["channel_id"],
-    },
-  },
-  {
-    name: "discord_copy_permissions",
-    description:
-      "Replace the target channel's permission overwrites with a copy of the source channel's. The target's existing overwrites are overwritten. Requires the Manage Roles permission. Returns a confirmation.",
-    annotations: { title: "Copy channel permissions", readOnlyHint: false, destructiveHint: false, idempotentHint: true, openWorldHint: true },
-    inputSchema: {
-      type: "object",
-      properties: {
-        source_channel_id: { type: "string", description: "ID (snowflake) of the channel to copy overwrites from." },
-        target_channel_id: { type: "string", description: "ID (snowflake) of the channel whose overwrites will be replaced." },
-        reason: { type: "string", description: "Optional reason recorded in the server audit log." },
-      },
-      required: ["source_channel_id", "target_channel_id"],
-    },
-  },
-  {
-    name: "discord_audit_permissions",
-    description:
-      "Generate a server-wide permission report: for every channel that has overwrites, lists each role/member and their allowed/denied permissions (entity names resolved). Read-only. Returns a JSON array. Use discord_get_channel_permissions for a single channel.",
-    annotations: { title: "Audit permissions", readOnlyHint: true, openWorldHint: true },
-    inputSchema: {
-      type: "object",
-      properties: { guild_id: { type: "string", description: "Discord server (guild) ID (snowflake) to audit." } },
-      required: ["guild_id"],
-    },
-  },
-];
+import { z } from "zod";
+import { discord, getGuildChannel, serializePermissions } from "../client.js";
+import { defineTool, defineModule, snowflake, guildId } from "./define.js";
 
 /**
  * Parses a permission array from tool arguments.
  * Accepts an array directly or a JSON-encoded string.
  */
-function parsePermArray(value: unknown): string[] {
+function parsePermArray(value: string[] | string | undefined): string[] {
   if (Array.isArray(value)) return value;
   if (typeof value === "string") return JSON.parse(value);
   return [];
 }
 
-/**
- * Handles permission tools: view overwrites, set per-role/per-member permissions,
- * reset to inherited, copy between channels, and full guild audit.
- */
-export async function handle(name: string, args: Record<string, unknown>): Promise<ToolResult | null> {
-  switch (name) {
-    case "discord_get_channel_permissions": {
-      const channel = await getGuildChannel(args.channel_id as string);
+const permFlags = z.union([z.array(z.string()), z.string()]).optional();
+
+/** Tool definitions for viewing and managing per-channel permission overwrites. */
+const tools = [
+  defineTool({
+    name: "discord_get_channel_permissions",
+    description:
+      "List every permission overwrite on a channel, per role and per member, with the allowed and denied permission flags for each. Read-only. Use discord_audit_permissions for a server-wide report across all channels.",
+    annotations: { title: "Get channel permissions", readOnlyHint: true, openWorldHint: true },
+    schema: z.object({
+      channel_id: snowflake.describe("ID (snowflake) of the channel to inspect."),
+    }),
+    handle: async ({ channel_id }) => {
+      const channel = await getGuildChannel(channel_id);
       const overwrites = channel.permissionOverwrites.cache.map((ow) => ({
         id: ow.id,
         type: ow.type === 0 ? "role" : "member",
@@ -116,44 +34,95 @@ export async function handle(name: string, args: Record<string, unknown>): Promi
         deny: serializePermissions(ow.deny),
       }));
       return { content: [{ type: "text", text: JSON.stringify(overwrites, null, 2) }] };
-    }
-
-    case "discord_set_role_permission": {
-      const channel = await getGuildChannel(args.channel_id as string);
+    },
+  }),
+  defineTool({
+    name: "discord_set_role_permission",
+    description:
+      "Add or update a per-channel permission overwrite for a role, allowing and/or denying specific permissions. Merges with the role's existing overwrite (does not reset it). Requires the Manage Roles permission. Use discord_set_member_permission to target a single member instead.",
+    annotations: { title: "Set role channel permission", readOnlyHint: false, destructiveHint: false, idempotentHint: true, openWorldHint: true },
+    schema: z.object({
+      channel_id: snowflake.describe("ID (snowflake) of the channel to set the overwrite on."),
+      role_id: snowflake.describe("ID (snowflake) of the role to grant/deny permissions for."),
+      allow: permFlags.describe("Permission flag names to allow, e.g. ['SendMessages','ViewChannel']. Uses Discord PermissionsBitField flag names."),
+      deny: permFlags.describe("Permission flag names to deny, e.g. ['SendMessages']."),
+      reason: z.string().optional().describe("Optional reason recorded in the server audit log."),
+    }),
+    handle: async ({ channel_id, role_id, allow, deny, reason }) => {
+      const channel = await getGuildChannel(channel_id);
       const options: PermissionOverwriteOptions = {};
-      parsePermArray(args.allow).forEach((p) => { (options as Record<string, boolean>)[p] = true; });
-      parsePermArray(args.deny).forEach((p) => { (options as Record<string, boolean>)[p] = false; });
-      await channel.permissionOverwrites.edit(args.role_id as string, options, { reason: args.reason as string | undefined });
-      return { content: [{ type: "text", text: `✅ Permissions updated for role ${args.role_id} on #${channel.name}.` }] };
-    }
-
-    case "discord_set_member_permission": {
-      const channel = await getGuildChannel(args.channel_id as string);
+      parsePermArray(allow).forEach((p) => { (options as Record<string, boolean>)[p] = true; });
+      parsePermArray(deny).forEach((p) => { (options as Record<string, boolean>)[p] = false; });
+      await channel.permissionOverwrites.edit(role_id, options, { reason });
+      return { content: [{ type: "text", text: `✅ Permissions updated for role ${role_id} on #${channel.name}.` }] };
+    },
+  }),
+  defineTool({
+    name: "discord_set_member_permission",
+    description:
+      "Add or update a per-channel permission overwrite for a single member, allowing and/or denying specific permissions. Merges with the member's existing overwrite. Requires the Manage Roles permission. Use discord_set_role_permission to target a whole role instead.",
+    annotations: { title: "Set member channel permission", readOnlyHint: false, destructiveHint: false, idempotentHint: true, openWorldHint: true },
+    schema: z.object({
+      channel_id: snowflake.describe("ID (snowflake) of the channel to set the overwrite on."),
+      user_id: snowflake.describe("ID (snowflake) of the member to grant/deny permissions for."),
+      allow: permFlags.describe("Permission flag names to allow, e.g. ['ViewChannel']. Uses Discord PermissionsBitField flag names."),
+      deny: permFlags.describe("Permission flag names to deny."),
+      reason: z.string().optional().describe("Optional reason recorded in the server audit log."),
+    }),
+    handle: async ({ channel_id, user_id, allow, deny, reason }) => {
+      const channel = await getGuildChannel(channel_id);
       const options: PermissionOverwriteOptions = {};
-      parsePermArray(args.allow).forEach((p) => { (options as Record<string, boolean>)[p] = true; });
-      parsePermArray(args.deny).forEach((p) => { (options as Record<string, boolean>)[p] = false; });
-      await channel.permissionOverwrites.edit(args.user_id as string, options, { reason: args.reason as string | undefined });
-      return { content: [{ type: "text", text: `✅ Permissions updated for member ${args.user_id} on #${channel.name}.` }] };
-    }
-
-    case "discord_reset_channel_permissions": {
-      const channel = await getGuildChannel(args.channel_id as string);
-      await channel.permissionOverwrites.set([], args.reason as string | undefined);
+      parsePermArray(allow).forEach((p) => { (options as Record<string, boolean>)[p] = true; });
+      parsePermArray(deny).forEach((p) => { (options as Record<string, boolean>)[p] = false; });
+      await channel.permissionOverwrites.edit(user_id, options, { reason });
+      return { content: [{ type: "text", text: `✅ Permissions updated for member ${user_id} on #${channel.name}.` }] };
+    },
+  }),
+  defineTool({
+    name: "discord_reset_channel_permissions",
+    description:
+      "Remove ALL permission overwrites on a channel, resetting it to inherit from its category/server defaults. IRREVERSIBLE — the cleared overwrites cannot be recovered. Requires the Manage Roles permission.",
+    annotations: { title: "Reset channel permissions", readOnlyHint: false, destructiveHint: true, idempotentHint: true, openWorldHint: true },
+    schema: z.object({
+      channel_id: snowflake.describe("ID (snowflake) of the channel whose overwrites will be cleared."),
+      reason: z.string().optional().describe("Optional reason recorded in the server audit log."),
+    }),
+    handle: async ({ channel_id, reason }) => {
+      const channel = await getGuildChannel(channel_id);
+      await channel.permissionOverwrites.set([], reason);
       return { content: [{ type: "text", text: `✅ All permission overwrites cleared on #${channel.name}.` }] };
-    }
-
-    case "discord_copy_permissions": {
-      const source = await getGuildChannel(args.source_channel_id as string);
-      const target = await getGuildChannel(args.target_channel_id as string);
+    },
+  }),
+  defineTool({
+    name: "discord_copy_permissions",
+    description:
+      "Replace the target channel's permission overwrites with a copy of the source channel's. The target's existing overwrites are overwritten. Requires the Manage Roles permission. Returns a confirmation.",
+    annotations: { title: "Copy channel permissions", readOnlyHint: false, destructiveHint: false, idempotentHint: true, openWorldHint: true },
+    schema: z.object({
+      source_channel_id: snowflake.describe("ID (snowflake) of the channel to copy overwrites from."),
+      target_channel_id: snowflake.describe("ID (snowflake) of the channel whose overwrites will be replaced."),
+      reason: z.string().optional().describe("Optional reason recorded in the server audit log."),
+    }),
+    handle: async ({ source_channel_id, target_channel_id, reason }) => {
+      const source = await getGuildChannel(source_channel_id);
+      const target = await getGuildChannel(target_channel_id);
       const overwrites = source.permissionOverwrites.cache.map((ow) => ({
         id: ow.id, type: ow.type, allow: ow.allow, deny: ow.deny,
       }));
-      await target.permissionOverwrites.set(overwrites, args.reason as string | undefined);
+      await target.permissionOverwrites.set(overwrites, reason);
       return { content: [{ type: "text", text: `✅ Permissions copied from #${source.name} to #${target.name}.` }] };
-    }
-
-    case "discord_audit_permissions": {
-      const guild = await discord.guilds.fetch(validateId(args.guild_id, "guild_id"));
+    },
+  }),
+  defineTool({
+    name: "discord_audit_permissions",
+    description:
+      "Generate a server-wide permission report: for every channel that has overwrites, lists each role/member and their allowed/denied permissions (entity names resolved). Read-only. Returns a JSON array. Use discord_get_channel_permissions for a single channel.",
+    annotations: { title: "Audit permissions", readOnlyHint: true, openWorldHint: true },
+    schema: z.object({
+      guild_id: guildId,
+    }),
+    handle: async ({ guild_id }) => {
+      const guild = await discord.guilds.fetch(guild_id);
       await guild.channels.fetch();
       await guild.roles.fetch();
       const memberIdsNeeded = new Set<string>();
@@ -180,11 +149,8 @@ export async function handle(name: string, args: Record<string, unknown>): Promi
           if (overwrites.length > 0) report.push({ channel: gch.name, channelId: gch.id, overwrites });
         });
       return { content: [{ type: "text", text: JSON.stringify(report, null, 2) }] };
-    }
+    },
+  }),
+];
 
-    default:
-      return null;
-  }
-}
-
-export default { definitions, handle } satisfies ToolModule;
+export default defineModule(tools);

--- a/src/tools/roles.ts
+++ b/src/tools/roles.ts
@@ -193,7 +193,7 @@ const tools = [
     schema: z.object({
       guild_id: guildId,
       role_id: snowflake.describe("ID (snowflake) of the role to reposition."),
-      position: z.number().describe("New hierarchy position (0 = lowest, just above @everyone). Higher numbers rank higher."),
+      position: z.int().min(0).describe("New hierarchy position (0 = lowest, just above @everyone). Higher numbers rank higher."),
     }),
     handle: async ({ guild_id, role_id, position }) => {
       const guild = await discord.guilds.fetch(guild_id);

--- a/src/tools/roles.ts
+++ b/src/tools/roles.ts
@@ -1,156 +1,15 @@
 import { ColorResolvable, Role, Guild } from "discord.js";
-import { discord, serializePermissions, deserializePermissions, validateId } from "../client.js";
-import type { ToolModule, ToolResult } from "./types.js";
+import { z } from "zod";
+import { discord, serializePermissions, deserializePermissions } from "../client.js";
+import { defineTool, defineModule, snowflake, guildId } from "./define.js";
 
-/** Tool definitions for creating, editing, deleting, and assigning roles. */
-export const definitions = [
-  {
-    name: "discord_list_roles",
-    description:
-      "List all roles in a server (excluding @everyone), highest-first, with color, position, member count, and permissions. Read-only. Returns a JSON array. Use discord_get_role_members to see who holds a given role.",
-    annotations: { title: "List roles", readOnlyHint: true, openWorldHint: true },
-    inputSchema: {
-      type: "object",
-      properties: { guild_id: { type: "string", description: "Discord server (guild) ID (snowflake)." } },
-      required: ["guild_id"],
-    },
-  },
-  {
-    name: "discord_create_role",
-    description:
-      "Create a new role in a server. Requires the Manage Roles permission; the new role is placed below the bot's highest role. Use discord_add_role to then assign it to members. Returns the new role's name and ID.",
-    annotations: { title: "Create role", readOnlyHint: false, destructiveHint: false, idempotentHint: false, openWorldHint: true },
-    inputSchema: {
-      type: "object",
-      properties: {
-        guild_id: { type: "string", description: "Discord server (guild) ID (snowflake)." },
-        name: { type: "string", description: "Name of the new role (max 100 characters)." },
-        color: { type: "string", description: "Role color as a hex string, e.g. '#FF5733'." },
-        hoist: { type: "boolean", description: "If true, display members with this role separately in the member list." },
-        mentionable: { type: "boolean", description: "If true, anyone can @mention this role." },
-        permissions: { type: "array", items: { type: "string" }, description: "Server-wide permission flag names to grant, e.g. ['SendMessages','ViewChannel']. Uses Discord PermissionsBitField flag names." },
-      },
-      required: ["guild_id", "name"],
-    },
-  },
-  {
-    name: "discord_edit_role",
-    description:
-      "Update an existing role's name, color, permissions, hoist, or mentionable flag. Only provided fields change; passing permissions REPLACES the role's full permission set. Requires the Manage Roles permission, and the role must be below the bot's highest role.",
-    annotations: { title: "Edit role", readOnlyHint: false, destructiveHint: false, idempotentHint: true, openWorldHint: true },
-    inputSchema: {
-      type: "object",
-      properties: {
-        guild_id: { type: "string", description: "Discord server (guild) ID (snowflake)." },
-        role_id: { type: "string", description: "ID (snowflake) of the role to edit." },
-        name: { type: "string", description: "New role name (max 100 characters)." },
-        color: { type: "string", description: "New role color as a hex string, e.g. '#FF5733'." },
-        hoist: { type: "boolean", description: "If true, display members with this role separately in the member list." },
-        mentionable: { type: "boolean", description: "If true, anyone can @mention this role." },
-        permissions: { type: "array", items: { type: "string" }, description: "Permission flag names. Providing this REPLACES the role's entire permission set. Uses Discord PermissionsBitField flag names." },
-      },
-      required: ["guild_id", "role_id"],
-    },
-  },
-  {
-    name: "discord_delete_role",
-    description:
-      "Permanently delete a role from the server; it is automatically removed from every member who held it. IRREVERSIBLE. Requires the Manage Roles permission, and the role must be below the bot's highest role.",
-    annotations: { title: "Delete role", readOnlyHint: false, destructiveHint: true, idempotentHint: false, openWorldHint: true },
-    inputSchema: {
-      type: "object",
-      properties: {
-        guild_id: { type: "string", description: "Discord server (guild) ID (snowflake)." },
-        role_id: { type: "string", description: "ID (snowflake) of the role to delete." },
-        reason: { type: "string", description: "Optional reason recorded in the server audit log." },
-      },
-      required: ["guild_id", "role_id"],
-    },
-  },
-  {
-    name: "discord_add_role",
-    description:
-      "Assign an existing role to a member. Requires the Manage Roles permission, and the role must be below the bot's highest role. Idempotent: assigning a role the member already has has no effect. Use discord_remove_role to undo.",
-    annotations: { title: "Add role to member", readOnlyHint: false, destructiveHint: false, idempotentHint: true, openWorldHint: true },
-    inputSchema: {
-      type: "object",
-      properties: {
-        guild_id: { type: "string", description: "Discord server (guild) ID (snowflake)." },
-        user_id: { type: "string", description: "Discord user ID (snowflake) of the member to give the role to." },
-        role_id: { type: "string", description: "ID (snowflake) of the role to assign." },
-        reason: { type: "string", description: "Optional reason recorded in the server audit log." },
-      },
-      required: ["guild_id", "user_id", "role_id"],
-    },
-  },
-  {
-    name: "discord_remove_role",
-    description:
-      "Remove a role from a member. Requires the Manage Roles permission, and the role must be below the bot's highest role. Idempotent: removing a role the member doesn't have has no effect. Reverses discord_add_role.",
-    annotations: { title: "Remove role from member", readOnlyHint: false, destructiveHint: false, idempotentHint: true, openWorldHint: true },
-    inputSchema: {
-      type: "object",
-      properties: {
-        guild_id: { type: "string", description: "Discord server (guild) ID (snowflake)." },
-        user_id: { type: "string", description: "Discord user ID (snowflake) of the member to remove the role from." },
-        role_id: { type: "string", description: "ID (snowflake) of the role to remove." },
-        reason: { type: "string", description: "Optional reason recorded in the server audit log." },
-      },
-      required: ["guild_id", "user_id", "role_id"],
-    },
-  },
-  {
-    name: "discord_get_role_members",
-    description:
-      "List every member who currently holds a specific role. Returns a JSON array (id, username, nickname). Read-only. Use discord_list_roles to discover role IDs first.",
-    annotations: { title: "Get role members", readOnlyHint: true, openWorldHint: true },
-    inputSchema: {
-      type: "object",
-      properties: {
-        guild_id: { type: "string", description: "Discord server (guild) ID (snowflake)." },
-        role_id: { type: "string", description: "ID (snowflake) of the role to list holders of." },
-      },
-      required: ["guild_id", "role_id"],
-    },
-  },
-  {
-    name: "discord_set_role_position",
-    description:
-      "Move a role up or down in the server's role hierarchy, which determines permission precedence and member-list ordering. Higher position = higher in the list. Requires the Manage Roles permission, and the target position must be below the bot's highest role.",
-    annotations: { title: "Set role position", readOnlyHint: false, destructiveHint: false, idempotentHint: true, openWorldHint: true },
-    inputSchema: {
-      type: "object",
-      properties: {
-        guild_id: { type: "string", description: "Discord server (guild) ID (snowflake)." },
-        role_id: { type: "string", description: "ID (snowflake) of the role to reposition." },
-        position: { type: "number", description: "New hierarchy position (0 = lowest, just above @everyone). Higher numbers rank higher." },
-      },
-      required: ["guild_id", "role_id", "position"],
-    },
-  },
-  {
-    name: "discord_set_role_icon",
-    description:
-      "Set or clear a role's icon — either a custom image or a unicode emoji. Requires the server to be Boost Level 2+ (the ROLE_ICONS feature) and the Manage Roles permission. Pass null to either field to remove that icon. Returns a confirmation.",
-    annotations: { title: "Set role icon", readOnlyHint: false, destructiveHint: false, idempotentHint: true, openWorldHint: true },
-    inputSchema: {
-      type: "object",
-      properties: {
-        guild_id: { type: "string", description: "Discord server (guild) ID (snowflake)." },
-        role_id: { type: "string", description: "ID (snowflake) of the role to set the icon on." },
-        icon: { type: "string", description: "Image URL for the role icon, or null to remove it." },
-        unicode_emoji: { type: "string", description: "Unicode emoji to use as the role icon, or null to remove it." },
-      },
-      required: ["guild_id", "role_id"],
-    },
-  },
-];
+const roleId = snowflake.describe("ID (snowflake) of the role to edit.");
 
 /**
  * Parses a permission array from tool arguments.
  * Accepts an array, a JSON string, or returns undefined if absent.
  */
-function parsePerms(raw: unknown): string[] | undefined {
+function parsePerms(raw: string[] | string | undefined): string[] | undefined {
   if (Array.isArray(raw)) return raw;
   if (typeof raw === "string") return JSON.parse(raw);
   return undefined;
@@ -160,21 +19,24 @@ function parsePerms(raw: unknown): string[] | undefined {
  * Validates a role_id argument, fetches the role, and guarantees it exists.
  * @throws {Error} If the id is not a valid snowflake or the role is not found.
  */
-async function fetchRole(guild: Guild, rawId: unknown): Promise<Role> {
-  const id = validateId(rawId, "role_id");
-  const role = await guild.roles.fetch(id);
-  if (!role) throw new Error(`Role ${id} not found in this server.`);
+async function fetchRole(guild: Guild, rawId: string): Promise<Role> {
+  const role = await guild.roles.fetch(rawId);
+  if (!role) throw new Error(`Role ${rawId} not found in this server.`);
   return role;
 }
 
-/**
- * Handles role tools: list all roles, CRUD operations,
- * assign/remove from members, and list members by role.
- */
-export async function handle(name: string, args: Record<string, unknown>): Promise<ToolResult | null> {
-  switch (name) {
-    case "discord_list_roles": {
-      const guild = await discord.guilds.fetch(validateId(args.guild_id, "guild_id"));
+/** Tool definitions for creating, editing, deleting, and assigning roles. */
+const tools = [
+  defineTool({
+    name: "discord_list_roles",
+    description:
+      "List all roles in a server (excluding @everyone), highest-first, with color, position, member count, and permissions. Read-only. Returns a JSON array. Use discord_get_role_members to see who holds a given role.",
+    annotations: { title: "List roles", readOnlyHint: true, openWorldHint: true },
+    schema: z.object({
+      guild_id: guildId,
+    }),
+    handle: async ({ guild_id }) => {
+      const guild = await discord.guilds.fetch(guild_id);
       const roles = await guild.roles.fetch();
       const result = [...roles.values()]
         .filter((r) => r.name !== "@everyone")
@@ -185,59 +47,127 @@ export async function handle(name: string, args: Record<string, unknown>): Promi
           hoist: r.hoist, mentionable: r.mentionable,
         }));
       return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
-    }
-
-    case "discord_create_role": {
-      const guild = await discord.guilds.fetch(validateId(args.guild_id, "guild_id"));
-      const perms = parsePerms(args.permissions);
+    },
+  }),
+  defineTool({
+    name: "discord_create_role",
+    description:
+      "Create a new role in a server. Requires the Manage Roles permission; the new role is placed below the bot's highest role. Use discord_add_role to then assign it to members. Returns the new role's name and ID.",
+    annotations: { title: "Create role", readOnlyHint: false, destructiveHint: false, idempotentHint: false, openWorldHint: true },
+    schema: z.object({
+      guild_id: guildId,
+      name: z.string().describe("Name of the new role (max 100 characters)."),
+      color: z.string().optional().describe("Role color as a hex string, e.g. '#FF5733'."),
+      hoist: z.boolean().optional().describe("If true, display members with this role separately in the member list."),
+      mentionable: z.boolean().optional().describe("If true, anyone can @mention this role."),
+      permissions: z.union([z.array(z.string()), z.string()]).optional().describe("Server-wide permission flag names to grant, e.g. ['SendMessages','ViewChannel']. Uses Discord PermissionsBitField flag names."),
+    }),
+    handle: async ({ guild_id, name, color, hoist, mentionable, permissions }) => {
+      const guild = await discord.guilds.fetch(guild_id);
+      const perms = parsePerms(permissions);
       const role = await guild.roles.create({
-        name: args.name as string,
-        color: args.color as ColorResolvable | undefined,
-        hoist: args.hoist as boolean | undefined,
-        mentionable: args.mentionable as boolean | undefined,
+        name,
+        color: color as ColorResolvable | undefined,
+        hoist,
+        mentionable,
         permissions: perms ? deserializePermissions(perms) : undefined,
       });
       return { content: [{ type: "text", text: `✅ Role "${role.name}" created (id: ${role.id}).` }] };
-    }
-
-    case "discord_edit_role": {
-      const guild = await discord.guilds.fetch(validateId(args.guild_id, "guild_id"));
-      const role = await fetchRole(guild, args.role_id);
-      const perms = parsePerms(args.permissions);
+    },
+  }),
+  defineTool({
+    name: "discord_edit_role",
+    description:
+      "Update an existing role's name, color, permissions, hoist, or mentionable flag. Only provided fields change; passing permissions REPLACES the role's full permission set. Requires the Manage Roles permission, and the role must be below the bot's highest role.",
+    annotations: { title: "Edit role", readOnlyHint: false, destructiveHint: false, idempotentHint: true, openWorldHint: true },
+    schema: z.object({
+      guild_id: guildId,
+      role_id: roleId,
+      name: z.string().optional().describe("New role name (max 100 characters)."),
+      color: z.string().optional().describe("New role color as a hex string, e.g. '#FF5733'."),
+      hoist: z.boolean().optional().describe("If true, display members with this role separately in the member list."),
+      mentionable: z.boolean().optional().describe("If true, anyone can @mention this role."),
+      permissions: z.union([z.array(z.string()), z.string()]).optional().describe("Permission flag names. Providing this REPLACES the role's entire permission set. Uses Discord PermissionsBitField flag names."),
+    }),
+    handle: async ({ guild_id, role_id, name, color, hoist, mentionable, permissions }) => {
+      const guild = await discord.guilds.fetch(guild_id);
+      const role = await fetchRole(guild, role_id);
+      const perms = parsePerms(permissions);
       await role.edit({
-        name: args.name as string | undefined,
-        color: args.color as ColorResolvable | undefined,
-        hoist: args.hoist as boolean | undefined,
-        mentionable: args.mentionable as boolean | undefined,
+        name,
+        color: color as ColorResolvable | undefined,
+        hoist,
+        mentionable,
         permissions: perms ? deserializePermissions(perms) : undefined,
       });
       return { content: [{ type: "text", text: `✅ Role "${role.name}" updated.` }] };
-    }
-
-    case "discord_delete_role": {
-      const guild = await discord.guilds.fetch(validateId(args.guild_id, "guild_id"));
-      const role = await fetchRole(guild, args.role_id);
-      await role.delete(args.reason as string | undefined);
+    },
+  }),
+  defineTool({
+    name: "discord_delete_role",
+    description:
+      "Permanently delete a role from the server; it is automatically removed from every member who held it. IRREVERSIBLE. Requires the Manage Roles permission, and the role must be below the bot's highest role.",
+    annotations: { title: "Delete role", readOnlyHint: false, destructiveHint: true, idempotentHint: false, openWorldHint: true },
+    schema: z.object({
+      guild_id: guildId,
+      role_id: snowflake.describe("ID (snowflake) of the role to delete."),
+      reason: z.string().optional().describe("Optional reason recorded in the server audit log."),
+    }),
+    handle: async ({ guild_id, role_id, reason }) => {
+      const guild = await discord.guilds.fetch(guild_id);
+      const role = await fetchRole(guild, role_id);
+      await role.delete(reason);
       return { content: [{ type: "text", text: `✅ Role "${role.name}" deleted.` }] };
-    }
-
-    case "discord_add_role": {
-      const guild = await discord.guilds.fetch(validateId(args.guild_id, "guild_id"));
-      const member = await guild.members.fetch(validateId(args.user_id, "user_id"));
-      await member.roles.add(validateId(args.role_id, "role_id"), args.reason as string | undefined);
+    },
+  }),
+  defineTool({
+    name: "discord_add_role",
+    description:
+      "Assign an existing role to a member. Requires the Manage Roles permission, and the role must be below the bot's highest role. Idempotent: assigning a role the member already has has no effect. Use discord_remove_role to undo.",
+    annotations: { title: "Add role to member", readOnlyHint: false, destructiveHint: false, idempotentHint: true, openWorldHint: true },
+    schema: z.object({
+      guild_id: guildId,
+      user_id: snowflake.describe("Discord user ID (snowflake) of the member to give the role to."),
+      role_id: snowflake.describe("ID (snowflake) of the role to assign."),
+      reason: z.string().optional().describe("Optional reason recorded in the server audit log."),
+    }),
+    handle: async ({ guild_id, user_id, role_id, reason }) => {
+      const guild = await discord.guilds.fetch(guild_id);
+      const member = await guild.members.fetch(user_id);
+      await member.roles.add(role_id, reason);
       return { content: [{ type: "text", text: `✅ Role added to ${member.user.tag}.` }] };
-    }
-
-    case "discord_remove_role": {
-      const guild = await discord.guilds.fetch(validateId(args.guild_id, "guild_id"));
-      const member = await guild.members.fetch(validateId(args.user_id, "user_id"));
-      await member.roles.remove(validateId(args.role_id, "role_id"), args.reason as string | undefined);
+    },
+  }),
+  defineTool({
+    name: "discord_remove_role",
+    description:
+      "Remove a role from a member. Requires the Manage Roles permission, and the role must be below the bot's highest role. Idempotent: removing a role the member doesn't have has no effect. Reverses discord_add_role.",
+    annotations: { title: "Remove role from member", readOnlyHint: false, destructiveHint: false, idempotentHint: true, openWorldHint: true },
+    schema: z.object({
+      guild_id: guildId,
+      user_id: snowflake.describe("Discord user ID (snowflake) of the member to remove the role from."),
+      role_id: snowflake.describe("ID (snowflake) of the role to remove."),
+      reason: z.string().optional().describe("Optional reason recorded in the server audit log."),
+    }),
+    handle: async ({ guild_id, user_id, role_id, reason }) => {
+      const guild = await discord.guilds.fetch(guild_id);
+      const member = await guild.members.fetch(user_id);
+      await member.roles.remove(role_id, reason);
       return { content: [{ type: "text", text: `✅ Role removed from ${member.user.tag}.` }] };
-    }
-
-    case "discord_get_role_members": {
-      const guild = await discord.guilds.fetch(validateId(args.guild_id, "guild_id"));
-      const role = await fetchRole(guild, args.role_id);
+    },
+  }),
+  defineTool({
+    name: "discord_get_role_members",
+    description:
+      "List every member who currently holds a specific role. Returns a JSON array (id, username, nickname). Read-only. Use discord_list_roles to discover role IDs first.",
+    annotations: { title: "Get role members", readOnlyHint: true, openWorldHint: true },
+    schema: z.object({
+      guild_id: guildId,
+      role_id: snowflake.describe("ID (snowflake) of the role to list holders of."),
+    }),
+    handle: async ({ guild_id, role_id }) => {
+      const guild = await discord.guilds.fetch(guild_id);
+      const role = await fetchRole(guild, role_id);
       // No "members of a role" endpoint exists, so populate the cache then filter (1000/page max).
       const MAX_PAGES = 20;
       let after: string | undefined;
@@ -253,30 +183,48 @@ export async function handle(name: string, args: Record<string, unknown>): Promi
         truncated,
         note: truncated ? `Only the first ${MAX_PAGES * 1000} members were scanned; results may be incomplete on very large servers.` : undefined,
       }, null, 2) }] };
-    }
-
-    case "discord_set_role_position": {
-      const guild = await discord.guilds.fetch(validateId(args.guild_id, "guild_id"));
-      const role = await fetchRole(guild, args.role_id);
-      await role.setPosition(args.position as number);
-      return { content: [{ type: "text", text: `✅ Role "${role.name}" moved to position ${args.position}.` }] };
-    }
-
-    case "discord_set_role_icon": {
-      const guild = await discord.guilds.fetch(validateId(args.guild_id, "guild_id"));
-      const role = await fetchRole(guild, args.role_id);
-      if (args.icon !== undefined) {
-        await role.setIcon(args.icon === "null" || args.icon === null ? null : args.icon as string);
+    },
+  }),
+  defineTool({
+    name: "discord_set_role_position",
+    description:
+      "Move a role up or down in the server's role hierarchy, which determines permission precedence and member-list ordering. Higher position = higher in the list. Requires the Manage Roles permission, and the target position must be below the bot's highest role.",
+    annotations: { title: "Set role position", readOnlyHint: false, destructiveHint: false, idempotentHint: true, openWorldHint: true },
+    schema: z.object({
+      guild_id: guildId,
+      role_id: snowflake.describe("ID (snowflake) of the role to reposition."),
+      position: z.number().describe("New hierarchy position (0 = lowest, just above @everyone). Higher numbers rank higher."),
+    }),
+    handle: async ({ guild_id, role_id, position }) => {
+      const guild = await discord.guilds.fetch(guild_id);
+      const role = await fetchRole(guild, role_id);
+      await role.setPosition(position);
+      return { content: [{ type: "text", text: `✅ Role "${role.name}" moved to position ${position}.` }] };
+    },
+  }),
+  defineTool({
+    name: "discord_set_role_icon",
+    description:
+      "Set or clear a role's icon — either a custom image or a unicode emoji. Requires the server to be Boost Level 2+ (the ROLE_ICONS feature) and the Manage Roles permission. Pass null to either field to remove that icon. Returns a confirmation.",
+    annotations: { title: "Set role icon", readOnlyHint: false, destructiveHint: false, idempotentHint: true, openWorldHint: true },
+    schema: z.object({
+      guild_id: guildId,
+      role_id: snowflake.describe("ID (snowflake) of the role to set the icon on."),
+      icon: z.string().nullable().optional().describe("Image URL for the role icon, or null to remove it."),
+      unicode_emoji: z.string().nullable().optional().describe("Unicode emoji to use as the role icon, or null to remove it."),
+    }),
+    handle: async ({ guild_id, role_id, icon, unicode_emoji }) => {
+      const guild = await discord.guilds.fetch(guild_id);
+      const role = await fetchRole(guild, role_id);
+      if (icon !== undefined) {
+        await role.setIcon(icon === "null" || icon === null ? null : icon);
       }
-      if (args.unicode_emoji !== undefined) {
-        await role.setUnicodeEmoji(args.unicode_emoji === "null" || args.unicode_emoji === null ? null : args.unicode_emoji as string);
+      if (unicode_emoji !== undefined) {
+        await role.setUnicodeEmoji(unicode_emoji === "null" || unicode_emoji === null ? null : unicode_emoji);
       }
       return { content: [{ type: "text", text: `✅ Role "${role.name}" icon updated.` }] };
-    }
+    },
+  }),
+];
 
-    default:
-      return null;
-  }
-}
-
-export default { definitions, handle } satisfies ToolModule;
+export default defineModule(tools);

--- a/src/tools/scheduledEvents.ts
+++ b/src/tools/scheduledEvents.ts
@@ -1,8 +1,8 @@
 import { GuildScheduledEventEntityType, GuildScheduledEventPrivacyLevel, GuildScheduledEventStatus, type GuildScheduledEventCreateOptions, type GuildScheduledEventEditOptions } from "discord.js";
 import { z } from "zod";
-import { discord, clampInt } from "../client.js";
+import { discord } from "../client.js";
 import { MAX_FETCH_LIMIT, DEFAULTS } from "../constants.js";
-import { defineTool, defineModule, snowflake, guildId } from "./define.js";
+import { defineTool, defineModule, snowflake, guildId, intIn } from "./define.js";
 
 // ─── Helpers ────────────────────────────────────────────────────────────────────
 
@@ -200,20 +200,19 @@ const tools = [
     schema: z.object({
       guild_id: guildId,
       event_id: snowflake.describe("ID (snowflake) of the scheduled event."),
-      limit: z.number().optional().describe("Max subscribers per page (1–100). Default 25."),
+      limit: intIn(1, MAX_FETCH_LIMIT).default(DEFAULTS.LIMIT).describe("Max subscribers per page (1–100). Default 25."),
       after: snowflake.optional().describe("Pagination cursor: a user ID (snowflake). Pass the previous response's nextCursor to fetch the next page."),
     }),
     handle: async ({ guild_id, event_id, limit, after }) => {
       const guild = await discord.guilds.fetch(guild_id);
       const event = await guild.scheduledEvents.fetch(event_id);
-      const resolvedLimit = clampInt(limit, 1, MAX_FETCH_LIMIT, DEFAULTS.LIMIT);
-      const subscribers = await event.fetchSubscribers({ limit: resolvedLimit, after });
+      const subscribers = await event.fetchSubscribers({ limit, after });
       const list = [...subscribers.values()].map((sub) => ({
         user_id: sub.user.id,
         username: sub.user.username,
         avatar: sub.user.displayAvatarURL(),
       }));
-      const nextCursor = subscribers.size === resolvedLimit ? subscribers.lastKey() ?? null : null;
+      const nextCursor = subscribers.size === limit ? subscribers.lastKey() ?? null : null;
       return { content: [{ type: "text", text: JSON.stringify({ subscribers: list, nextCursor }, null, 2) }] };
     },
   }),
@@ -226,16 +225,16 @@ const tools = [
       guild_id: guildId,
       event_id: snowflake.describe("ID (snowflake) of the scheduled event to link the invite to."),
       channel_id: snowflake.optional().describe("Channel (snowflake) the invite points to. Defaults to the server's first text channel if omitted."),
-      max_age: z.number().optional().describe("Invite lifetime in seconds; 0 means it never expires. Default 86400 (24h)."),
-      max_uses: z.number().optional().describe("Maximum number of uses; 0 means unlimited. Default 0."),
+      max_age: intIn(0, 604800).default(86400).describe("Invite lifetime in seconds, 0–604800 (7 days); 0 means it never expires. Default 86400 (24h)."),
+      max_uses: intIn(0, 100).default(0).describe("Maximum number of uses, 0–100; 0 means unlimited. Default 0."),
     }),
     handle: async ({ guild_id, event_id, channel_id, max_age, max_uses }) => {
       const guild = await discord.guilds.fetch(guild_id);
       const event = await guild.scheduledEvents.fetch(event_id);
       const url = await event.createInviteURL({
         channel: channel_id,
-        maxAge: max_age ?? 86400,
-        maxUses: max_uses ?? 0,
+        maxAge: max_age,
+        maxUses: max_uses,
       });
       return { content: [{ type: "text", text: `✅ Event invite created: ${url}` }] };
     },

--- a/src/tools/scheduledEvents.ts
+++ b/src/tools/scheduledEvents.ts
@@ -1,148 +1,8 @@
 import { GuildScheduledEventEntityType, GuildScheduledEventPrivacyLevel, GuildScheduledEventStatus, type GuildScheduledEventCreateOptions, type GuildScheduledEventEditOptions } from "discord.js";
-import { discord, validateId, clampInt } from "../client.js";
+import { z } from "zod";
+import { discord, clampInt } from "../client.js";
 import { MAX_FETCH_LIMIT, DEFAULTS } from "../constants.js";
-import type { ToolModule, ToolResult } from "./types.js";
-
-/** Tool definitions for managing guild scheduled events. */
-export const definitions = [
-  {
-    name: "discord_list_scheduled_events",
-    description:
-      "List all scheduled events in a server (id, name, status, type, time, location, interested count). Read-only. Use discord_get_scheduled_event for one event's full details.",
-    annotations: { title: "List scheduled events", readOnlyHint: true, openWorldHint: true },
-    inputSchema: {
-      type: "object",
-      properties: {
-        guild_id: { type: "string", description: "Discord server (guild) ID (snowflake)." },
-      },
-      required: ["guild_id"],
-    },
-  },
-  {
-    name: "discord_get_scheduled_event",
-    description:
-      "Get full details for one scheduled event: name, description, status, type, channel/location, start/end times, creator, and interested-user count. Read-only. Returns a JSON object.",
-    annotations: { title: "Get scheduled event", readOnlyHint: true, openWorldHint: true },
-    inputSchema: {
-      type: "object",
-      properties: {
-        guild_id: { type: "string", description: "Discord server (guild) ID (snowflake)." },
-        event_id: { type: "string", description: "ID (snowflake) of the scheduled event." },
-      },
-      required: ["guild_id", "event_id"],
-    },
-  },
-  {
-    name: "discord_create_scheduled_event",
-    description:
-      "Create a scheduled event. For 'VOICE'/'STAGE_INSTANCE' events provide channel_id; for 'EXTERNAL' events provide location AND scheduled_end_time. Requires the Manage Events permission. Returns the new event's name and ID.",
-    annotations: { title: "Create scheduled event", readOnlyHint: false, destructiveHint: false, idempotentHint: false, openWorldHint: true },
-    inputSchema: {
-      type: "object",
-      properties: {
-        guild_id: { type: "string", description: "Discord server (guild) ID (snowflake)." },
-        name: { type: "string", description: "Event name (max 100 characters)." },
-        description: { type: "string", description: "Optional event description (max 1000 characters)." },
-        entity_type: {
-          type: "string",
-          enum: ["VOICE", "STAGE_INSTANCE", "EXTERNAL"],
-          description: "Where the event happens: 'VOICE' or 'STAGE_INSTANCE' (needs channel_id), or 'EXTERNAL' (needs location + scheduled_end_time).",
-        },
-        scheduled_start_time: {
-          type: "string",
-          description: "Event start as an ISO 8601 datetime, e.g. '2026-06-01T20:00:00Z'. Must be in the future.",
-        },
-        scheduled_end_time: {
-          type: "string",
-          description: "Event end as an ISO 8601 datetime. Required for EXTERNAL events.",
-        },
-        channel_id: {
-          type: "string",
-          description: "Voice or stage channel ID (snowflake). Required for VOICE/STAGE_INSTANCE events.",
-        },
-        location: {
-          type: "string",
-          description: "Free-text location (e.g. a URL or place). Required for EXTERNAL events.",
-        },
-        image: { type: "string", description: "Optional cover image URL." },
-      },
-      required: ["guild_id", "name", "entity_type", "scheduled_start_time"],
-    },
-  },
-  {
-    name: "discord_edit_scheduled_event",
-    description:
-      "Update a scheduled event; only provided fields change. Use the status field to start ('ACTIVE'), end ('COMPLETED'), or cancel ('CANCELED') an event — note Discord only allows certain status transitions. Requires the Manage Events permission.",
-    annotations: { title: "Edit scheduled event", readOnlyHint: false, destructiveHint: false, idempotentHint: true, openWorldHint: true },
-    inputSchema: {
-      type: "object",
-      properties: {
-        guild_id: { type: "string", description: "Discord server (guild) ID (snowflake)." },
-        event_id: { type: "string", description: "ID (snowflake) of the event to edit." },
-        name: { type: "string", description: "New event name (max 100 characters)." },
-        description: { type: "string", description: "New event description (max 1000 characters)." },
-        scheduled_start_time: { type: "string", description: "New start time as an ISO 8601 datetime." },
-        scheduled_end_time: { type: "string", description: "New end time as an ISO 8601 datetime." },
-        channel_id: { type: "string", description: "New voice/stage channel ID (snowflake) for VOICE/STAGE_INSTANCE events." },
-        location: { type: "string", description: "New free-text location for EXTERNAL events." },
-        image: { type: "string", description: "New cover image URL." },
-        status: {
-          type: "string",
-          enum: ["SCHEDULED", "ACTIVE", "COMPLETED", "CANCELED"],
-          description: "Change event status. Allowed transitions only: SCHEDULED→ACTIVE→COMPLETED, or SCHEDULED→CANCELED.",
-        },
-      },
-      required: ["guild_id", "event_id"],
-    },
-  },
-  {
-    name: "discord_delete_scheduled_event",
-    description:
-      "Permanently delete a scheduled event. IRREVERSIBLE. To cancel an event while keeping a record, use discord_edit_scheduled_event with status:'CANCELED' instead. Requires the Manage Events permission.",
-    annotations: { title: "Delete scheduled event", readOnlyHint: false, destructiveHint: true, idempotentHint: false, openWorldHint: true },
-    inputSchema: {
-      type: "object",
-      properties: {
-        guild_id: { type: "string", description: "Discord server (guild) ID (snowflake)." },
-        event_id: { type: "string", description: "ID (snowflake) of the event to delete." },
-      },
-      required: ["guild_id", "event_id"],
-    },
-  },
-  {
-    name: "discord_get_event_subscribers",
-    description:
-      "List the users who marked themselves 'Interested' in a scheduled event. Returns { subscribers: [...], nextCursor }. A page holds up to 100 users; if nextCursor is non-null, pass it back as `after` to fetch the next page. Read-only.",
-    annotations: { title: "Get event subscribers", readOnlyHint: true, openWorldHint: true },
-    inputSchema: {
-      type: "object",
-      properties: {
-        guild_id: { type: "string", description: "Discord server (guild) ID (snowflake)." },
-        event_id: { type: "string", description: "ID (snowflake) of the scheduled event." },
-        limit: { type: "number", description: "Max subscribers per page (1–100). Default 25." },
-        after: { type: "string", description: "Pagination cursor: a user ID (snowflake). Pass the previous response's nextCursor to fetch the next page." },
-      },
-      required: ["guild_id", "event_id"],
-    },
-  },
-  {
-    name: "discord_create_event_invite",
-    description:
-      "Create a shareable invite URL that points to a scheduled event, so recipients land on the event when joining. Requires the Create Instant Invite permission. Returns the invite URL.",
-    annotations: { title: "Create event invite", readOnlyHint: false, destructiveHint: false, idempotentHint: false, openWorldHint: true },
-    inputSchema: {
-      type: "object",
-      properties: {
-        guild_id: { type: "string", description: "Discord server (guild) ID (snowflake)." },
-        event_id: { type: "string", description: "ID (snowflake) of the scheduled event to link the invite to." },
-        channel_id: { type: "string", description: "Channel (snowflake) the invite points to. Defaults to the server's first text channel if omitted." },
-        max_age: { type: "number", description: "Invite lifetime in seconds; 0 means it never expires. Default 86400 (24h)." },
-        max_uses: { type: "number", description: "Maximum number of uses; 0 means unlimited. Default 0." },
-      },
-      required: ["guild_id", "event_id"],
-    },
-  },
-];
+import { defineTool, defineModule, snowflake, guildId } from "./define.js";
 
 // ─── Helpers ────────────────────────────────────────────────────────────────────
 
@@ -189,136 +49,197 @@ function serializeEvent(event: import("discord.js").GuildScheduledEvent) {
   };
 }
 
-// ─── Handler ────────────────────────────────────────────────────────────────────
+// ─── Tools ──────────────────────────────────────────────────────────────────────
 
-export async function handle(
-  name: string,
-  args: Record<string, unknown>,
-): Promise<ToolResult | null> {
-  switch (name) {
-    case "discord_list_scheduled_events": {
-      const guildId = validateId(args.guild_id, "guild_id");
-      const guild = await discord.guilds.fetch(guildId);
+/** Tool definitions for managing guild scheduled events. */
+const tools = [
+  defineTool({
+    name: "discord_list_scheduled_events",
+    description:
+      "List all scheduled events in a server (id, name, status, type, time, location, interested count). Read-only. Use discord_get_scheduled_event for one event's full details.",
+    annotations: { title: "List scheduled events", readOnlyHint: true, openWorldHint: true },
+    schema: z.object({
+      guild_id: guildId,
+    }),
+    handle: async ({ guild_id }) => {
+      const guild = await discord.guilds.fetch(guild_id);
       const events = await guild.scheduledEvents.fetch();
       const list = [...events.values()].map(serializeEvent);
       return { content: [{ type: "text", text: JSON.stringify(list, null, 2) }] };
-    }
-
-    case "discord_get_scheduled_event": {
-      const guildId = validateId(args.guild_id, "guild_id");
-      const eventId = validateId(args.event_id, "event_id");
-      const guild = await discord.guilds.fetch(guildId);
-      const event = await guild.scheduledEvents.fetch(eventId);
+    },
+  }),
+  defineTool({
+    name: "discord_get_scheduled_event",
+    description:
+      "Get full details for one scheduled event: name, description, status, type, channel/location, start/end times, creator, and interested-user count. Read-only. Returns a JSON object.",
+    annotations: { title: "Get scheduled event", readOnlyHint: true, openWorldHint: true },
+    schema: z.object({
+      guild_id: guildId,
+      event_id: snowflake.describe("ID (snowflake) of the scheduled event."),
+    }),
+    handle: async ({ guild_id, event_id }) => {
+      const guild = await discord.guilds.fetch(guild_id);
+      const event = await guild.scheduledEvents.fetch(event_id);
       return { content: [{ type: "text", text: JSON.stringify(serializeEvent(event), null, 2) }] };
-    }
+    },
+  }),
+  defineTool({
+    name: "discord_create_scheduled_event",
+    description:
+      "Create a scheduled event. For 'VOICE'/'STAGE_INSTANCE' events provide channel_id; for 'EXTERNAL' events provide location AND scheduled_end_time. Requires the Manage Events permission. Returns the new event's name and ID.",
+    annotations: { title: "Create scheduled event", readOnlyHint: false, destructiveHint: false, idempotentHint: false, openWorldHint: true },
+    schema: z.object({
+      guild_id: guildId,
+      name: z.string().describe("Event name (max 100 characters)."),
+      description: z.string().optional().describe("Optional event description (max 1000 characters)."),
+      entity_type: z.enum(["VOICE", "STAGE_INSTANCE", "EXTERNAL"]).describe("Where the event happens: 'VOICE' or 'STAGE_INSTANCE' (needs channel_id), or 'EXTERNAL' (needs location + scheduled_end_time)."),
+      scheduled_start_time: z.string().describe("Event start as an ISO 8601 datetime, e.g. '2026-06-01T20:00:00Z'. Must be in the future."),
+      scheduled_end_time: z.string().optional().describe("Event end as an ISO 8601 datetime. Required for EXTERNAL events."),
+      channel_id: snowflake.optional().describe("Voice or stage channel ID (snowflake). Required for VOICE/STAGE_INSTANCE events."),
+      location: z.string().optional().describe("Free-text location (e.g. a URL or place). Required for EXTERNAL events."),
+      image: z.string().optional().describe("Optional cover image URL."),
+    }),
+    handle: async ({ guild_id, name, description, entity_type, scheduled_start_time, scheduled_end_time, channel_id, location, image }) => {
+      const guild = await discord.guilds.fetch(guild_id);
 
-    case "discord_create_scheduled_event": {
-      const guildId = validateId(args.guild_id, "guild_id");
-      const guild = await discord.guilds.fetch(guildId);
+      const entityType = ENTITY_TYPE_MAP[entity_type];
+      if (!entityType) throw new Error(`Invalid entity_type: "${entity_type}". Must be VOICE, STAGE_INSTANCE, or EXTERNAL.`);
 
-      const entityTypeStr = String(args.entity_type).toUpperCase();
-      const entityType = ENTITY_TYPE_MAP[entityTypeStr];
-      if (!entityType) throw new Error(`Invalid entity_type: "${args.entity_type}". Must be VOICE, STAGE_INSTANCE, or EXTERNAL.`);
-
-      if ((entityType === GuildScheduledEventEntityType.Voice || entityType === GuildScheduledEventEntityType.StageInstance) && !args.channel_id) {
+      if ((entityType === GuildScheduledEventEntityType.Voice || entityType === GuildScheduledEventEntityType.StageInstance) && !channel_id) {
         throw new Error("channel_id is required for VOICE or STAGE_INSTANCE events.");
       }
-      if (entityType === GuildScheduledEventEntityType.External && !args.location) {
+      if (entityType === GuildScheduledEventEntityType.External && !location) {
         throw new Error("location is required for EXTERNAL events.");
       }
-      if (entityType === GuildScheduledEventEntityType.External && !args.scheduled_end_time) {
+      if (entityType === GuildScheduledEventEntityType.External && !scheduled_end_time) {
         throw new Error("scheduled_end_time is required for EXTERNAL events.");
       }
 
       const options: Record<string, unknown> = {
-        name: String(args.name),
-        scheduledStartTime: String(args.scheduled_start_time),
+        name,
+        scheduledStartTime: scheduled_start_time,
         entityType,
         privacyLevel: GuildScheduledEventPrivacyLevel.GuildOnly,
       };
-      if (args.description) options.description = String(args.description);
-      if (args.scheduled_end_time) options.scheduledEndTime = String(args.scheduled_end_time);
-      if (args.channel_id) options.channel = validateId(args.channel_id, "channel_id");
-      if (args.location) options.entityMetadata = { location: String(args.location) };
-      if (args.image) options.image = String(args.image);
+      if (description) options.description = description;
+      if (scheduled_end_time) options.scheduledEndTime = scheduled_end_time;
+      if (channel_id) options.channel = channel_id;
+      if (location) options.entityMetadata = { location };
+      if (image) options.image = image;
 
       const event = await guild.scheduledEvents.create(options as unknown as GuildScheduledEventCreateOptions);
       return {
         content: [{ type: "text", text: `✅ Scheduled event "${event.name}" created (id: ${event.id}).` }],
       };
-    }
-
-    case "discord_edit_scheduled_event": {
-      const guildId = validateId(args.guild_id, "guild_id");
-      const eventId = validateId(args.event_id, "event_id");
-      const guild = await discord.guilds.fetch(guildId);
-      const event = await guild.scheduledEvents.fetch(eventId);
+    },
+  }),
+  defineTool({
+    name: "discord_edit_scheduled_event",
+    description:
+      "Update a scheduled event; only provided fields change. Use the status field to start ('ACTIVE'), end ('COMPLETED'), or cancel ('CANCELED') an event — note Discord only allows certain status transitions. Requires the Manage Events permission.",
+    annotations: { title: "Edit scheduled event", readOnlyHint: false, destructiveHint: false, idempotentHint: true, openWorldHint: true },
+    schema: z.object({
+      guild_id: guildId,
+      event_id: snowflake.describe("ID (snowflake) of the event to edit."),
+      name: z.string().optional().describe("New event name (max 100 characters)."),
+      description: z.string().optional().describe("New event description (max 1000 characters)."),
+      scheduled_start_time: z.string().optional().describe("New start time as an ISO 8601 datetime."),
+      scheduled_end_time: z.string().optional().describe("New end time as an ISO 8601 datetime."),
+      channel_id: snowflake.optional().describe("New voice/stage channel ID (snowflake) for VOICE/STAGE_INSTANCE events."),
+      location: z.string().optional().describe("New free-text location for EXTERNAL events."),
+      image: z.string().optional().describe("New cover image URL."),
+      status: z.enum(["SCHEDULED", "ACTIVE", "COMPLETED", "CANCELED"]).optional().describe("Change event status. Allowed transitions only: SCHEDULED→ACTIVE→COMPLETED, or SCHEDULED→CANCELED."),
+    }),
+    handle: async ({ guild_id, event_id, name, description, scheduled_start_time, scheduled_end_time, channel_id, location, image, status }) => {
+      const guild = await discord.guilds.fetch(guild_id);
+      const event = await guild.scheduledEvents.fetch(event_id);
 
       const options: Record<string, unknown> = {};
-      if (args.name) options.name = String(args.name);
-      if (args.description !== undefined) options.description = String(args.description);
-      if (args.scheduled_start_time) options.scheduledStartTime = String(args.scheduled_start_time);
-      if (args.scheduled_end_time) options.scheduledEndTime = String(args.scheduled_end_time);
-      if (args.channel_id) options.channel = validateId(args.channel_id, "channel_id");
-      if (args.location) options.entityMetadata = { location: String(args.location) };
-      if (args.image) options.image = String(args.image);
-      if (args.status) {
-        const statusStr = String(args.status).toUpperCase();
-        const status = STATUS_MAP[statusStr];
-        if (!status) throw new Error(`Invalid status: "${args.status}". Must be SCHEDULED, ACTIVE, COMPLETED, or CANCELED.`);
-        options.status = status;
+      if (name) options.name = name;
+      if (description !== undefined) options.description = description;
+      if (scheduled_start_time) options.scheduledStartTime = scheduled_start_time;
+      if (scheduled_end_time) options.scheduledEndTime = scheduled_end_time;
+      if (channel_id) options.channel = channel_id;
+      if (location) options.entityMetadata = { location };
+      if (image) options.image = image;
+      if (status) {
+        const statusVal = STATUS_MAP[status];
+        if (!statusVal) throw new Error(`Invalid status: "${status}". Must be SCHEDULED, ACTIVE, COMPLETED, or CANCELED.`);
+        options.status = statusVal;
       }
 
       const updated = await event.edit(options as unknown as GuildScheduledEventEditOptions<any, any>);
       return {
         content: [{ type: "text", text: `✅ Scheduled event "${updated.name}" updated (id: ${updated.id}).` }],
       };
-    }
-
-    case "discord_delete_scheduled_event": {
-      const guildId = validateId(args.guild_id, "guild_id");
-      const eventId = validateId(args.event_id, "event_id");
-      const guild = await discord.guilds.fetch(guildId);
-      const event = await guild.scheduledEvents.fetch(eventId);
+    },
+  }),
+  defineTool({
+    name: "discord_delete_scheduled_event",
+    description:
+      "Permanently delete a scheduled event. IRREVERSIBLE. To cancel an event while keeping a record, use discord_edit_scheduled_event with status:'CANCELED' instead. Requires the Manage Events permission.",
+    annotations: { title: "Delete scheduled event", readOnlyHint: false, destructiveHint: true, idempotentHint: false, openWorldHint: true },
+    schema: z.object({
+      guild_id: guildId,
+      event_id: snowflake.describe("ID (snowflake) of the event to delete."),
+    }),
+    handle: async ({ guild_id, event_id }) => {
+      const guild = await discord.guilds.fetch(guild_id);
+      const event = await guild.scheduledEvents.fetch(event_id);
       await event.delete();
       return {
-        content: [{ type: "text", text: `✅ Scheduled event "${event.name}" deleted (id: ${eventId}).` }],
+        content: [{ type: "text", text: `✅ Scheduled event "${event.name}" deleted (id: ${event_id}).` }],
       };
-    }
-
-    case "discord_get_event_subscribers": {
-      const guildId = validateId(args.guild_id, "guild_id");
-      const eventId = validateId(args.event_id, "event_id");
-      const guild = await discord.guilds.fetch(guildId);
-      const event = await guild.scheduledEvents.fetch(eventId);
-      const limit = clampInt(args.limit, 1, MAX_FETCH_LIMIT, DEFAULTS.LIMIT);
-      const after = args.after !== undefined ? validateId(args.after, "after") : undefined;
-      const subscribers = await event.fetchSubscribers({ limit, after });
+    },
+  }),
+  defineTool({
+    name: "discord_get_event_subscribers",
+    description:
+      "List the users who marked themselves 'Interested' in a scheduled event. Returns { subscribers: [...], nextCursor }. A page holds up to 100 users; if nextCursor is non-null, pass it back as `after` to fetch the next page. Read-only.",
+    annotations: { title: "Get event subscribers", readOnlyHint: true, openWorldHint: true },
+    schema: z.object({
+      guild_id: guildId,
+      event_id: snowflake.describe("ID (snowflake) of the scheduled event."),
+      limit: z.number().optional().describe("Max subscribers per page (1–100). Default 25."),
+      after: snowflake.optional().describe("Pagination cursor: a user ID (snowflake). Pass the previous response's nextCursor to fetch the next page."),
+    }),
+    handle: async ({ guild_id, event_id, limit, after }) => {
+      const guild = await discord.guilds.fetch(guild_id);
+      const event = await guild.scheduledEvents.fetch(event_id);
+      const resolvedLimit = clampInt(limit, 1, MAX_FETCH_LIMIT, DEFAULTS.LIMIT);
+      const subscribers = await event.fetchSubscribers({ limit: resolvedLimit, after });
       const list = [...subscribers.values()].map((sub) => ({
         user_id: sub.user.id,
         username: sub.user.username,
         avatar: sub.user.displayAvatarURL(),
       }));
-      const nextCursor = subscribers.size === limit ? subscribers.lastKey() ?? null : null;
+      const nextCursor = subscribers.size === resolvedLimit ? subscribers.lastKey() ?? null : null;
       return { content: [{ type: "text", text: JSON.stringify({ subscribers: list, nextCursor }, null, 2) }] };
-    }
-
-    case "discord_create_event_invite": {
-      const guildId = validateId(args.guild_id, "guild_id");
-      const eventId = validateId(args.event_id, "event_id");
-      const guild = await discord.guilds.fetch(guildId);
-      const event = await guild.scheduledEvents.fetch(eventId);
+    },
+  }),
+  defineTool({
+    name: "discord_create_event_invite",
+    description:
+      "Create a shareable invite URL that points to a scheduled event, so recipients land on the event when joining. Requires the Create Instant Invite permission. Returns the invite URL.",
+    annotations: { title: "Create event invite", readOnlyHint: false, destructiveHint: false, idempotentHint: false, openWorldHint: true },
+    schema: z.object({
+      guild_id: guildId,
+      event_id: snowflake.describe("ID (snowflake) of the scheduled event to link the invite to."),
+      channel_id: snowflake.optional().describe("Channel (snowflake) the invite points to. Defaults to the server's first text channel if omitted."),
+      max_age: z.number().optional().describe("Invite lifetime in seconds; 0 means it never expires. Default 86400 (24h)."),
+      max_uses: z.number().optional().describe("Maximum number of uses; 0 means unlimited. Default 0."),
+    }),
+    handle: async ({ guild_id, event_id, channel_id, max_age, max_uses }) => {
+      const guild = await discord.guilds.fetch(guild_id);
+      const event = await guild.scheduledEvents.fetch(event_id);
       const url = await event.createInviteURL({
-        channel: args.channel_id ? validateId(args.channel_id, "channel_id") : undefined,
-        maxAge: Number(args.max_age ?? 86400),
-        maxUses: Number(args.max_uses ?? 0),
+        channel: channel_id,
+        maxAge: max_age ?? 86400,
+        maxUses: max_uses ?? 0,
       });
       return { content: [{ type: "text", text: `✅ Event invite created: ${url}` }] };
-    }
+    },
+  }),
+];
 
-    default:
-      return null;
-  }
-}
-
-export default { definitions, handle } satisfies ToolModule;
+export default defineModule(tools);

--- a/src/tools/screening.ts
+++ b/src/tools/screening.ts
@@ -1,81 +1,54 @@
-import { discord, validateId } from "../client.js";
-import type { ToolModule, ToolResult } from "./types.js";
+import { z } from "zod";
+import { discord } from "../client.js";
+import { defineTool, defineModule, guildId } from "./define.js";
 
 /** Tool definitions for reading and updating the guild membership screening form. */
-export const definitions = [
-  {
+const tools = [
+  defineTool({
     name: "discord_get_membership_screening",
     description:
       "Fetch the server's membership screening form — the rules/questions new members must accept before gaining access. Requires the server to have the Community feature enabled. Read-only. Returns the raw form as JSON (including its version, needed by the update tool).",
     annotations: { title: "Get membership screening", readOnlyHint: true, openWorldHint: true },
-    inputSchema: {
-      type: "object",
-      properties: { guild_id: { type: "string", description: "Discord server (guild) ID (snowflake)." } },
-      required: ["guild_id"],
+    schema: z.object({
+      guild_id: guildId,
+    }),
+    handle: async ({ guild_id }) => {
+      const data = await discord.rest.get(`/guilds/${guild_id}/member-verification`);
+      return { content: [{ type: "text", text: JSON.stringify(data, null, 2) }] };
     },
-  },
-  {
+  }),
+  defineTool({
     name: "discord_update_membership_screening",
     description:
       "Update the server's membership screening form: set the welcome description and the rules new members must agree to. Only provided fields change. Requires the Community feature and the Manage Server permission. Returns the updated form.",
     annotations: { title: "Update membership screening", readOnlyHint: false, destructiveHint: false, idempotentHint: true, openWorldHint: true },
-    inputSchema: {
-      type: "object",
-      properties: {
-        guild_id: { type: "string", description: "Discord server (guild) ID (snowflake)." },
-        description: { type: "string", description: "Welcome message shown at the top of the screening form." },
-        form_fields: {
-          type: "array",
-          description: "Rules/agreement blocks new members must accept. Replaces the existing fields when provided.",
-          items: {
-            type: "object",
-            properties: {
-              label: { type: "string", description: "Title of this rules block." },
-              values: { type: "array", items: { type: "string" }, description: "Individual rule lines shown under the label." },
-              required: { type: "boolean", description: "Whether the member must agree to this block. Default true." },
-            },
-            required: ["label", "values"],
-          },
-        },
-      },
-      required: ["guild_id"],
-    },
-  },
-];
-
-/**
- * Handles membership screening tools: fetch the current verification form
- * and update it with new descriptions/rules via the Discord REST API.
- */
-export async function handle(name: string, args: Record<string, unknown>): Promise<ToolResult | null> {
-  switch (name) {
-    case "discord_get_membership_screening": {
-      const guildId = validateId(args.guild_id, "guild_id");
-      const data = await discord.rest.get(`/guilds/${guildId}/member-verification`);
-      return { content: [{ type: "text", text: JSON.stringify(data, null, 2) }] };
-    }
-
-    case "discord_update_membership_screening": {
-      const guildId = validateId(args.guild_id, "guild_id");
-      const current = await discord.rest.get(`/guilds/${guildId}/member-verification`) as Record<string, unknown>;
+    schema: z.object({
+      guild_id: guildId,
+      description: z.string().optional().describe("Welcome message shown at the top of the screening form."),
+      form_fields: z.array(
+        z.object({
+          label: z.string().describe("Title of this rules block."),
+          values: z.array(z.string()).describe("Individual rule lines shown under the label."),
+          required: z.boolean().optional().describe("Whether the member must agree to this block. Default true."),
+        })
+      ).optional().describe("Rules/agreement blocks new members must accept. Replaces the existing fields when provided."),
+    }),
+    handle: async ({ guild_id, description, form_fields }) => {
+      const current = await discord.rest.get(`/guilds/${guild_id}/member-verification`) as Record<string, unknown>;
       const body: Record<string, unknown> = { version: current.version };
-      if (args.description !== undefined) body.description = args.description as string;
-      if (args.form_fields !== undefined) {
-        const fields = args.form_fields as { label: string; values: string[]; required?: boolean }[];
-        body.form_fields = fields.map((f) => ({
+      if (description !== undefined) body.description = description;
+      if (form_fields !== undefined) {
+        body.form_fields = form_fields.map((f) => ({
           field_type: "TERMS",
           label: f.label,
           values: f.values,
           required: f.required ?? true,
         }));
       }
-      const updated = await discord.rest.patch(`/guilds/${guildId}/member-verification`, { body });
+      const updated = await discord.rest.patch(`/guilds/${guild_id}/member-verification`, { body });
       return { content: [{ type: "text", text: `✅ Membership screening updated.\n${JSON.stringify(updated, null, 2)}` }] };
-    }
+    },
+  }),
+];
 
-    default:
-      return null;
-  }
-}
-
-export default { definitions, handle } satisfies ToolModule;
+export default defineModule(tools);

--- a/src/tools/stats.ts
+++ b/src/tools/stats.ts
@@ -1,30 +1,20 @@
 import { ChannelType } from "discord.js";
-import { discord, validateId } from "../client.js";
-import type { ToolModule, ToolResult } from "./types.js";
+import { z } from "zod";
+import { discord } from "../client.js";
+import { defineModule, defineTool, guildId } from "./define.js";
 
 /** Tool definitions for server statistics (members, channels, boosts). */
-export const definitions = [
-  {
+const tools = [
+  defineTool({
     name: "discord_get_server_stats",
     description:
       "Get a snapshot of server metrics: total members (humans vs cached bots), channel breakdown (text/voice/category), role count, boost tier and count, and creation date. Read-only. Returns a JSON object. Note: the bot count reflects only members currently in cache.",
     annotations: { title: "Get server stats", readOnlyHint: true, openWorldHint: true },
-    inputSchema: {
-      type: "object",
-      properties: { guild_id: { type: "string", description: "Discord server (guild) ID (snowflake)." } },
-      required: ["guild_id"],
-    },
-  },
-];
-
-/**
- * Handles stats tools: returns a snapshot of server metrics
- * including member counts, channel breakdown, and boost info.
- */
-export async function handle(name: string, args: Record<string, unknown>): Promise<ToolResult | null> {
-  switch (name) {
-    case "discord_get_server_stats": {
-      const guild = await (await discord.guilds.fetch(validateId(args.guild_id, "guild_id"))).fetch();
+    schema: z.object({
+      guild_id: guildId,
+    }),
+    handle: async ({ guild_id }) => {
+      const guild = await (await discord.guilds.fetch(guild_id)).fetch();
       await guild.channels.fetch();
       const cachedBots = guild.members.cache.filter((m) => m.user.bot).size;
       return {
@@ -44,11 +34,8 @@ export async function handle(name: string, args: Record<string, unknown>): Promi
           }, null, 2),
         }],
       };
-    }
+    },
+  }),
+];
 
-    default:
-      return null;
-  }
-}
-
-export default { definitions, handle } satisfies ToolModule;
+export default defineModule(tools);

--- a/src/tools/webhooks.ts
+++ b/src/tools/webhooks.ts
@@ -1,201 +1,62 @@
 import { WebhookClient } from "discord.js";
-import { discord, validateId } from "../client.js";
-import { buildEmbed } from "../embeds.js";
-import type { ToolModule, ToolResult } from "./types.js";
+import { z } from "zod";
+import { discord } from "../client.js";
+import { buildEmbed, embedObjectSchema } from "../embeds.js";
+import { defineTool, defineModule, snowflake, guildId } from "./define.js";
 
-/** Embed input-schema fragment for webhook messages (shared by send/edit webhook-message tools). */
-const WEBHOOK_EMBED_PROPS = {
-  type: "array",
-  description: "Up to 10 embed objects to attach to the webhook message.",
-  items: {
-    type: "object",
-    properties: {
-      title: { type: "string", description: "Embed title shown in bold at the top." },
-      url: { type: "string", description: "URL that makes the title clickable." },
-      description: { type: "string", description: "Main body text of the embed (supports Markdown)." },
-      color: { type: "string", description: "Side-bar color as a hex string, e.g. '#5865F2'." },
-      fields: {
-        type: "array",
-        description: "Up to 25 name/value field blocks.",
-        items: {
-          type: "object",
-          properties: {
-            name: { type: "string", description: "Field heading." },
-            value: { type: "string", description: "Field body text." },
-            inline: { type: "boolean", description: "If true, render side-by-side with adjacent inline fields." },
-          },
-          required: ["name", "value"],
-        },
-      },
-      footer: { type: "string", description: "Footer text shown at the bottom of the embed." },
-      image_url: { type: "string", description: "Large image shown below the embed body." },
-      thumbnail_url: { type: "string", description: "Small image shown in the top-right corner." },
-      timestamp: { type: "boolean", description: "If true, stamp the embed with the current time." },
-    },
-  },
-} as const;
+const webhookId = snowflake.describe("ID (snowflake) of the webhook.");
+const webhookToken = z.string().describe("Secret token of the webhook.");
+const messageId = snowflake.describe("ID of the webhook message.");
 
 /** Tool definitions for creating, sending via, editing, deleting, and listing webhooks. */
-export const definitions = [
-  {
+const tools = [
+  defineTool({
     name: "discord_create_webhook",
     description:
       "Create a webhook on a channel and return its ID and token. SECURITY: the returned token grants anyone the ability to post as this webhook without authentication — treat it as a secret. Requires the Manage Webhooks permission. Use the returned id+token with discord_send_webhook_message.",
     annotations: { title: "Create webhook", readOnlyHint: false, destructiveHint: false, idempotentHint: false, openWorldHint: true },
-    inputSchema: {
-      type: "object",
-      properties: {
-        channel_id: { type: "string", description: "ID (snowflake) of the channel to attach the webhook to." },
-        name: { type: "string", description: "Display name for the webhook (max 80 characters)." },
-        avatar: { type: "string", description: "Optional avatar image URL for the webhook." },
-      },
-      required: ["channel_id", "name"],
-    },
-  },
-  {
-    name: "discord_send_webhook_message",
-    description:
-      "Send a message through a webhook using its ID and token (no bot permissions needed — the token authorizes the send). Supports per-message username/avatar overrides and up to 10 embeds. At least one of content or embeds is required. Returns the new message ID.",
-    annotations: { title: "Send webhook message", readOnlyHint: false, destructiveHint: false, idempotentHint: false, openWorldHint: true },
-    inputSchema: {
-      type: "object",
-      properties: {
-        webhook_id: { type: "string", description: "ID (snowflake) of the webhook to send through." },
-        webhook_token: { type: "string", description: "Secret token of the webhook (from discord_create_webhook or discord_list_webhooks)." },
-        content: { type: "string", description: "Plain-text body of the message (max 2000 characters). Optional if embeds are provided." },
-        username: { type: "string", description: "Override the webhook's default display name for this message." },
-        avatar_url: { type: "string", description: "Override the webhook's default avatar for this message." },
-        embeds: WEBHOOK_EMBED_PROPS,
-      },
-      required: ["webhook_id", "webhook_token"],
-    },
-  },
-  {
-    name: "discord_edit_webhook",
-    description:
-      "Update a webhook's name, avatar, or the channel it posts to. Only provided fields change. Requires the Manage Webhooks permission. Returns a confirmation.",
-    annotations: { title: "Edit webhook", readOnlyHint: false, destructiveHint: false, idempotentHint: true, openWorldHint: true },
-    inputSchema: {
-      type: "object",
-      properties: {
-        webhook_id: { type: "string", description: "ID (snowflake) of the webhook to edit." },
-        name: { type: "string", description: "New display name for the webhook (max 80 characters)." },
-        avatar: { type: "string", description: "New avatar image URL for the webhook." },
-        channel_id: { type: "string", description: "ID (snowflake) of a channel to move the webhook to." },
-      },
-      required: ["webhook_id"],
-    },
-  },
-  {
-    name: "discord_delete_webhook",
-    description:
-      "Permanently delete a webhook by its ID, invalidating its token. IRREVERSIBLE — any integrations using the old token will stop working. Requires the Manage Webhooks permission.",
-    annotations: { title: "Delete webhook", readOnlyHint: false, destructiveHint: true, idempotentHint: false, openWorldHint: true },
-    inputSchema: {
-      type: "object",
-      properties: {
-        webhook_id: { type: "string", description: "ID (snowflake) of the webhook to delete." },
-      },
-      required: ["webhook_id"],
-    },
-  },
-  {
-    name: "discord_list_webhooks",
-    description:
-      "List the webhooks in a single channel or across a whole server (id, name, channel, token when visible, creator). Provide exactly one of channel_id or guild_id. Requires the Manage Webhooks permission. Read-only.",
-    annotations: { title: "List webhooks", readOnlyHint: true, openWorldHint: true },
-    inputSchema: {
-      type: "object",
-      properties: {
-        channel_id: { type: "string", description: "ID (snowflake) of a channel to list webhooks for. Mutually exclusive with guild_id." },
-        guild_id: { type: "string", description: "Discord server (guild) ID (snowflake) to list all webhooks for. Mutually exclusive with channel_id." },
-      },
-    },
-  },
-  {
-    name: "discord_edit_webhook_message",
-    description:
-      "Edit a message previously sent through a webhook, using the webhook's ID and token. Replaces the provided fields. Requires the original webhook token. Returns a confirmation.",
-    annotations: { title: "Edit webhook message", readOnlyHint: false, destructiveHint: false, idempotentHint: true, openWorldHint: true },
-    inputSchema: {
-      type: "object",
-      properties: {
-        webhook_id: { type: "string", description: "ID (snowflake) of the webhook that sent the message." },
-        webhook_token: { type: "string", description: "Secret token of the webhook." },
-        message_id: { type: "string", description: "ID of the webhook message to edit." },
-        content: { type: "string", description: "New plain-text content for the message (max 2000 characters)." },
-        embeds: WEBHOOK_EMBED_PROPS,
-      },
-      required: ["webhook_id", "webhook_token", "message_id"],
-    },
-  },
-  {
-    name: "discord_delete_webhook_message",
-    description:
-      "Permanently delete a message that was sent through a webhook, using the webhook's ID and token. IRREVERSIBLE. Requires the original webhook token.",
-    annotations: { title: "Delete webhook message", readOnlyHint: false, destructiveHint: true, idempotentHint: false, openWorldHint: true },
-    inputSchema: {
-      type: "object",
-      properties: {
-        webhook_id: { type: "string", description: "ID (snowflake) of the webhook that sent the message." },
-        webhook_token: { type: "string", description: "Secret token of the webhook." },
-        message_id: { type: "string", description: "ID of the webhook message to delete." },
-      },
-      required: ["webhook_id", "webhook_token", "message_id"],
-    },
-  },
-  {
-    name: "discord_fetch_webhook_message",
-    description:
-      "Fetch a single message sent through a webhook (id, content, embed count, timestamp), using the webhook's ID and token. Read-only. Requires the original webhook token.",
-    annotations: { title: "Fetch webhook message", readOnlyHint: true, openWorldHint: true },
-    inputSchema: {
-      type: "object",
-      properties: {
-        webhook_id: { type: "string", description: "ID (snowflake) of the webhook that sent the message." },
-        webhook_token: { type: "string", description: "Secret token of the webhook." },
-        message_id: { type: "string", description: "ID of the webhook message to fetch." },
-      },
-      required: ["webhook_id", "webhook_token", "message_id"],
-    },
-  },
-];
-
-/**
- * Handles webhook tools: create, send message via webhook,
- * edit, delete, and list webhooks.
- */
-export async function handle(name: string, args: Record<string, unknown>): Promise<ToolResult | null> {
-  switch (name) {
-    case "discord_create_webhook": {
-      const channel = await discord.channels.fetch(validateId(args.channel_id, "channel_id"));
+    schema: z.object({
+      channel_id: snowflake.describe("ID (snowflake) of the channel to attach the webhook to."),
+      name: z.string().describe("Display name for the webhook (max 80 characters)."),
+      avatar: z.string().optional().describe("Optional avatar image URL for the webhook."),
+    }),
+    handle: async ({ channel_id, name, avatar }) => {
+      const channel = await discord.channels.fetch(channel_id);
       if (!channel || !("createWebhook" in channel)) throw new Error("Channel does not support webhooks.");
-      const webhook = await (channel as any).createWebhook({
-        name: args.name as string,
-        avatar: (args.avatar as string | undefined) ?? undefined,
-      });
+      const webhook = await (channel as any).createWebhook({ name, avatar: avatar ?? undefined });
       return {
         content: [{
           type: "text",
           text: `✅ Webhook "${webhook.name}" created (id: ${webhook.id}, token: ${webhook.token}).`,
         }],
       };
-    }
+    },
+  }),
 
-    case "discord_send_webhook_message": {
-      const webhookId = validateId(args.webhook_id, "webhook_id");
-      const token = args.webhook_token as string;
-      if (!token) throw new Error("webhook_token is required.");
-      const client = new WebhookClient({ id: webhookId, token });
+  defineTool({
+    name: "discord_send_webhook_message",
+    description:
+      "Send a message through a webhook using its ID and token (no bot permissions needed — the token authorizes the send). Supports per-message username/avatar overrides and up to 10 embeds. At least one of content or embeds is required. Returns the new message ID.",
+    annotations: { title: "Send webhook message", readOnlyHint: false, destructiveHint: false, idempotentHint: false, openWorldHint: true },
+    schema: z.object({
+      webhook_id: webhookId.describe("ID (snowflake) of the webhook to send through."),
+      webhook_token: webhookToken.describe("Secret token of the webhook (from discord_create_webhook or discord_list_webhooks)."),
+      content: z.string().optional().describe("Plain-text body of the message (max 2000 characters). Optional if embeds are provided."),
+      username: z.string().optional().describe("Override the webhook's default display name for this message."),
+      avatar_url: z.string().optional().describe("Override the webhook's default avatar for this message."),
+      embeds: z.array(embedObjectSchema).optional().describe("Up to 10 embed objects to attach to the webhook message."),
+    }),
+    handle: async ({ webhook_id, webhook_token, content, username, avatar_url, embeds }) => {
+      if (!webhook_token) throw new Error("webhook_token is required.");
+      const client = new WebhookClient({ id: webhook_id, token: webhook_token });
       try {
         const sendOptions: Record<string, unknown> = {};
-        if (args.content) sendOptions.content = args.content as string;
-        if (args.username) sendOptions.username = args.username as string;
-        if (args.avatar_url) sendOptions.avatarURL = args.avatar_url as string;
-        if (args.embeds) {
-          const embedArgs = args.embeds as Record<string, unknown>[];
-          if (embedArgs.length > 10) throw new Error("Discord allows a maximum of 10 embeds per message.");
-          sendOptions.embeds = embedArgs.map((e) => buildEmbed(e));
+        if (content) sendOptions.content = content;
+        if (username) sendOptions.username = username;
+        if (avatar_url) sendOptions.avatarURL = avatar_url;
+        if (embeds) {
+          if (embeds.length > 10) throw new Error("Discord allows a maximum of 10 embeds per message.");
+          sendOptions.embeds = embeds.map((e) => buildEmbed(e));
         }
         if (!sendOptions.content && !sendOptions.embeds) {
           throw new Error("At least one of content or embeds is required.");
@@ -205,30 +66,59 @@ export async function handle(name: string, args: Record<string, unknown>): Promi
       } finally {
         client.destroy();
       }
-    }
+    },
+  }),
 
-    case "discord_edit_webhook": {
-      const webhookId = validateId(args.webhook_id, "webhook_id");
-      const webhook = await discord.fetchWebhook(webhookId);
+  defineTool({
+    name: "discord_edit_webhook",
+    description:
+      "Update a webhook's name, avatar, or the channel it posts to. Only provided fields change. Requires the Manage Webhooks permission. Returns a confirmation.",
+    annotations: { title: "Edit webhook", readOnlyHint: false, destructiveHint: false, idempotentHint: true, openWorldHint: true },
+    schema: z.object({
+      webhook_id: webhookId.describe("ID (snowflake) of the webhook to edit."),
+      name: z.string().optional().describe("New display name for the webhook (max 80 characters)."),
+      avatar: z.string().optional().describe("New avatar image URL for the webhook."),
+      channel_id: snowflake.optional().describe("ID (snowflake) of a channel to move the webhook to."),
+    }),
+    handle: async ({ webhook_id, name, avatar, channel_id }) => {
+      const webhook = await discord.fetchWebhook(webhook_id);
       const editOptions: Record<string, unknown> = {};
-      if (args.name !== undefined) editOptions.name = args.name as string;
-      if (args.avatar !== undefined) editOptions.avatar = args.avatar as string;
-      if (args.channel_id !== undefined) editOptions.channel = validateId(args.channel_id, "channel_id");
+      if (name !== undefined) editOptions.name = name;
+      if (avatar !== undefined) editOptions.avatar = avatar;
+      if (channel_id !== undefined) editOptions.channel = channel_id;
       await webhook.edit(editOptions);
       return { content: [{ type: "text", text: `✅ Webhook "${webhook.name}" (id: ${webhook.id}) updated.` }] };
-    }
+    },
+  }),
 
-    case "discord_delete_webhook": {
-      const webhookId = validateId(args.webhook_id, "webhook_id");
-      const webhook = await discord.fetchWebhook(webhookId);
+  defineTool({
+    name: "discord_delete_webhook",
+    description:
+      "Permanently delete a webhook by its ID, invalidating its token. IRREVERSIBLE — any integrations using the old token will stop working. Requires the Manage Webhooks permission.",
+    annotations: { title: "Delete webhook", readOnlyHint: false, destructiveHint: true, idempotentHint: false, openWorldHint: true },
+    schema: z.object({
+      webhook_id: webhookId.describe("ID (snowflake) of the webhook to delete."),
+    }),
+    handle: async ({ webhook_id }) => {
+      const webhook = await discord.fetchWebhook(webhook_id);
       const webhookName = webhook.name;
       await webhook.delete();
-      return { content: [{ type: "text", text: `✅ Webhook "${webhookName}" (id: ${webhookId}) deleted.` }] };
-    }
+      return { content: [{ type: "text", text: `✅ Webhook "${webhookName}" (id: ${webhook_id}) deleted.` }] };
+    },
+  }),
 
-    case "discord_list_webhooks": {
-      if (args.channel_id) {
-        const channel = await discord.channels.fetch(validateId(args.channel_id, "channel_id"));
+  defineTool({
+    name: "discord_list_webhooks",
+    description:
+      "List the webhooks in a single channel or across a whole server (id, name, channel, token when visible, creator). Provide exactly one of channel_id or guild_id. Requires the Manage Webhooks permission. Read-only.",
+    annotations: { title: "List webhooks", readOnlyHint: true, openWorldHint: true },
+    schema: z.object({
+      channel_id: snowflake.optional().describe("ID (snowflake) of a channel to list webhooks for. Mutually exclusive with guild_id."),
+      guild_id: guildId.optional().describe("Discord server (guild) ID (snowflake) to list all webhooks for. Mutually exclusive with channel_id."),
+    }),
+    handle: async ({ channel_id, guild_id }) => {
+      if (channel_id) {
+        const channel = await discord.channels.fetch(channel_id);
         if (!channel || !("fetchWebhooks" in channel)) throw new Error("Channel does not support webhooks.");
         const webhooks = await (channel as any).fetchWebhooks();
         const result = [...webhooks.values()].map((w: any) => ({
@@ -239,8 +129,8 @@ export async function handle(name: string, args: Record<string, unknown>): Promi
           creator: w.owner?.tag ?? null,
         }));
         return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
-      } else if (args.guild_id) {
-        const guild = await discord.guilds.fetch(validateId(args.guild_id, "guild_id"));
+      } else if (guild_id) {
+        const guild = await discord.guilds.fetch(guild_id);
         const webhooks = await guild.fetchWebhooks();
         const result = [...webhooks.values()].map((w) => ({
           id: w.id,
@@ -253,47 +143,73 @@ export async function handle(name: string, args: Record<string, unknown>): Promi
       } else {
         throw new Error("Either channel_id or guild_id is required.");
       }
-    }
+    },
+  }),
 
-    case "discord_edit_webhook_message": {
-      const webhookId = validateId(args.webhook_id, "webhook_id");
-      const token = args.webhook_token as string;
-      if (!token) throw new Error("webhook_token is required.");
-      const client = new WebhookClient({ id: webhookId, token });
+  defineTool({
+    name: "discord_edit_webhook_message",
+    description:
+      "Edit a message previously sent through a webhook, using the webhook's ID and token. Replaces the provided fields. Requires the original webhook token. Returns a confirmation.",
+    annotations: { title: "Edit webhook message", readOnlyHint: false, destructiveHint: false, idempotentHint: true, openWorldHint: true },
+    schema: z.object({
+      webhook_id: webhookId.describe("ID (snowflake) of the webhook that sent the message."),
+      webhook_token: webhookToken.describe("Secret token of the webhook."),
+      message_id: messageId.describe("ID of the webhook message to edit."),
+      content: z.string().optional().describe("New plain-text content for the message (max 2000 characters)."),
+      embeds: z.array(embedObjectSchema).optional().describe("Up to 10 embed objects to attach to the webhook message."),
+    }),
+    handle: async ({ webhook_id, webhook_token, message_id, content, embeds }) => {
+      if (!webhook_token) throw new Error("webhook_token is required.");
+      const client = new WebhookClient({ id: webhook_id, token: webhook_token });
       try {
         const editOptions: Record<string, unknown> = {};
-        if (args.content !== undefined) editOptions.content = args.content as string;
-        if (args.embeds) {
-          const embedArgs = args.embeds as Record<string, unknown>[];
-          editOptions.embeds = embedArgs.map((e) => buildEmbed(e));
-        }
-        await client.editMessage(args.message_id as string, editOptions);
-        return { content: [{ type: "text", text: `✅ Webhook message ${args.message_id} edited.` }] };
+        if (content !== undefined) editOptions.content = content;
+        if (embeds) editOptions.embeds = embeds.map((e) => buildEmbed(e));
+        await client.editMessage(message_id, editOptions);
+        return { content: [{ type: "text", text: `✅ Webhook message ${message_id} edited.` }] };
       } finally {
         client.destroy();
       }
-    }
+    },
+  }),
 
-    case "discord_delete_webhook_message": {
-      const webhookId = validateId(args.webhook_id, "webhook_id");
-      const token = args.webhook_token as string;
-      if (!token) throw new Error("webhook_token is required.");
-      const client = new WebhookClient({ id: webhookId, token });
+  defineTool({
+    name: "discord_delete_webhook_message",
+    description:
+      "Permanently delete a message that was sent through a webhook, using the webhook's ID and token. IRREVERSIBLE. Requires the original webhook token.",
+    annotations: { title: "Delete webhook message", readOnlyHint: false, destructiveHint: true, idempotentHint: false, openWorldHint: true },
+    schema: z.object({
+      webhook_id: webhookId.describe("ID (snowflake) of the webhook that sent the message."),
+      webhook_token: webhookToken.describe("Secret token of the webhook."),
+      message_id: messageId.describe("ID of the webhook message to delete."),
+    }),
+    handle: async ({ webhook_id, webhook_token, message_id }) => {
+      if (!webhook_token) throw new Error("webhook_token is required.");
+      const client = new WebhookClient({ id: webhook_id, token: webhook_token });
       try {
-        await client.deleteMessage(args.message_id as string);
-        return { content: [{ type: "text", text: `✅ Webhook message ${args.message_id} deleted.` }] };
+        await client.deleteMessage(message_id);
+        return { content: [{ type: "text", text: `✅ Webhook message ${message_id} deleted.` }] };
       } finally {
         client.destroy();
       }
-    }
+    },
+  }),
 
-    case "discord_fetch_webhook_message": {
-      const webhookId = validateId(args.webhook_id, "webhook_id");
-      const token = args.webhook_token as string;
-      if (!token) throw new Error("webhook_token is required.");
-      const client = new WebhookClient({ id: webhookId, token });
+  defineTool({
+    name: "discord_fetch_webhook_message",
+    description:
+      "Fetch a single message sent through a webhook (id, content, embed count, timestamp), using the webhook's ID and token. Read-only. Requires the original webhook token.",
+    annotations: { title: "Fetch webhook message", readOnlyHint: true, openWorldHint: true },
+    schema: z.object({
+      webhook_id: webhookId.describe("ID (snowflake) of the webhook that sent the message."),
+      webhook_token: webhookToken.describe("Secret token of the webhook."),
+      message_id: messageId.describe("ID of the webhook message to fetch."),
+    }),
+    handle: async ({ webhook_id, webhook_token, message_id }) => {
+      if (!webhook_token) throw new Error("webhook_token is required.");
+      const client = new WebhookClient({ id: webhook_id, token: webhook_token });
       try {
-        const msg = await client.fetchMessage(args.message_id as string);
+        const msg = await client.fetchMessage(message_id);
         return { content: [{ type: "text", text: JSON.stringify({
           id: msg.id, content: msg.content, embeds: msg.embeds.length,
           timestamp: msg.timestamp,
@@ -301,11 +217,8 @@ export async function handle(name: string, args: Record<string, unknown>): Promi
       } finally {
         client.destroy();
       }
-    }
+    },
+  }),
+];
 
-    default:
-      return null;
-  }
-}
-
-export default { definitions, handle } satisfies ToolModule;
+export default defineModule(tools);

--- a/test/define.test.ts
+++ b/test/define.test.ts
@@ -38,3 +38,19 @@ test("handle rejects invalid args before reaching the Discord API", async () => 
 test("handle returns null for a tool it does not own", async () => {
   assert.equal(await messages.handle("discord_not_a_messages_tool", {}), null);
 });
+
+test("bounded integer fields advertise integer + min/max + default in the inputSchema", () => {
+  const read = messages.definitions.find((d) => d.name === "discord_read_messages");
+  const limit = (read!.inputSchema as { properties: Record<string, Record<string, unknown>> }).properties.limit;
+  assert.equal(limit.type, "integer");
+  assert.equal(limit.minimum, 1);
+  assert.equal(limit.maximum, 100);
+  assert.equal(limit.default, 20);
+});
+
+test("handle rejects out-of-range and non-integer numbers before reaching the Discord API", async () => {
+  // Valid channel_id, but the bound/integer check on limit fails synchronously with no network call.
+  await assert.rejects(() => messages.handle("discord_read_messages", { channel_id: VALID_ID, limit: 500 }), ZodError);
+  await assert.rejects(() => messages.handle("discord_read_messages", { channel_id: VALID_ID, limit: 0 }), ZodError);
+  await assert.rejects(() => messages.handle("discord_read_messages", { channel_id: VALID_ID, limit: 3.7 }), ZodError);
+});

--- a/test/define.test.ts
+++ b/test/define.test.ts
@@ -1,0 +1,40 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { ZodError } from "zod";
+import { snowflake } from "../src/tools/define.js";
+import messages from "../src/tools/messages.js";
+
+const VALID_ID = "123456789012345678";
+
+test("snowflake accepts a valid ID and rejects malformed ones", () => {
+  assert.equal(snowflake.parse(VALID_ID), VALID_ID);
+  assert.throws(() => snowflake.parse("123"), ZodError);
+  assert.throws(() => snowflake.parse("not-an-id"), ZodError);
+  assert.throws(() => snowflake.parse(42), ZodError);
+});
+
+test("derived inputSchema is a bare object schema with no $schema key", () => {
+  const read = messages.definitions.find((d) => d.name === "discord_read_messages");
+  assert.ok(read, "discord_read_messages should be defined");
+  const schema = read.inputSchema as Record<string, unknown>;
+  assert.equal(schema.type, "object");
+  assert.ok(!("$schema" in schema), "$schema must be stripped from inputSchema");
+  const props = schema.properties as Record<string, unknown>;
+  assert.ok(props.channel_id && props.limit, "properties should be derived from the zod schema");
+  assert.deepEqual(schema.required, ["channel_id"]);
+});
+
+test("field descriptions propagate from .describe() into the inputSchema", () => {
+  const send = messages.definitions.find((d) => d.name === "discord_send_message");
+  const props = (send!.inputSchema as { properties: Record<string, { description?: string }> }).properties;
+  assert.match(props.content.description ?? "", /Plain-text body/);
+});
+
+test("handle rejects invalid args before reaching the Discord API", async () => {
+  // A malformed channel_id fails zod validation synchronously, with no network call.
+  await assert.rejects(() => messages.handle("discord_read_messages", { channel_id: "bad" }), ZodError);
+});
+
+test("handle returns null for a tool it does not own", async () => {
+  assert.equal(await messages.handle("discord_not_a_messages_tool", {}), null);
+});

--- a/test/helpers.test.ts
+++ b/test/helpers.test.ts
@@ -3,8 +3,6 @@ import assert from "node:assert/strict";
 import { PermissionsBitField } from "discord.js";
 import {
   validateId,
-  clampInt,
-  validateInt,
   serializePermissions,
   deserializePermissions,
 } from "../src/client.js";
@@ -18,22 +16,6 @@ test("validateId rejects non-snowflakes", () => {
   assert.throws(() => validateId("", "id"));
   assert.throws(() => validateId("123", "id"));
   assert.throws(() => validateId(undefined, "id"));
-});
-
-test("clampInt clamps, truncates, and falls back on non-numbers", () => {
-  assert.equal(clampInt("abc", 1, 100, 20), 20);
-  assert.equal(clampInt(undefined, 1, 100, 20), 20);
-  assert.equal(clampInt(9999, 1, 100, 20), 100);
-  assert.equal(clampInt(0, 1, 100, 20), 1);
-  assert.equal(clampInt(5.7, 1, 100, 20), 5);
-});
-
-test("validateInt enforces an integer range", () => {
-  assert.equal(validateInt(30, 0, 40320, "duration"), 30);
-  assert.equal(validateInt(0, 0, 40320, "duration"), 0);
-  assert.throws(() => validateInt("abc", 0, 40320, "duration"));
-  assert.throws(() => validateInt(50000, 0, 40320, "duration"));
-  assert.throws(() => validateInt(-1, 0, 40320, "duration"));
 });
 
 test("serialize/deserialize permissions round-trips", () => {


### PR DESCRIPTION
Foundation of the 2.0 release: zod becomes the single source of truth for tool I/O, and numeric inputs are now validated by the schema itself.

## What
- Each tool declares one zod schema; the MCP `inputSchema` is derived from it via `z.toJSONSchema({io:"input"})` and incoming args are validated with `schema.parse()` before dispatch (commits `e9bf408`, `8a3ec68`).
- All 24 numeric fields move from bare `z.number()` to `z.int().min().max()` via a shared `intIn()` helper, with `.default()` where applicable. `clampInt`/`validateInt` removed. `auto_archive_duration` is now a literal union (commit `0ec0684`).

## Breaking change (why this is 2.0)
Out-of-range or non-integer numeric arguments are now **rejected** with a `ZodError` ("Invalid arguments — <field>: ...") instead of being silently clamped. For example `limit:500` previously clamped to 100; it now errors. The derived `inputSchema` now advertises `integer` + `minimum`/`maximum`/`default`, so the contract is machine-readable.

## Verification
- build + lint (0 errors) + tests (13/13, including new bounds-rejection tests) green.
- Live-tested against the running MCP server: happy path, default application, over-max/under-min/non-integer/literal-union rejection across read and mutating tools.