### PR TITLE
fix(tools): correct destructiveHint on data-overwriting tools

### DIFF
--- a/src/tools/forums.ts
+++ b/src/tools/forums.ts
@@ -211,7 +211,7 @@ const tools = [
     name: "discord_set_forum_tags",
     description:
       "Replace the full set of available tags on a forum channel with the provided list. This overwrites existing tags, so include every tag you want to keep. Requires the Manage Channels permission. Returns a confirmation.",
-    annotations: { title: "Set forum tags", readOnlyHint: false, destructiveHint: false, idempotentHint: true, openWorldHint: true },
+    annotations: { title: "Set forum tags", readOnlyHint: false, destructiveHint: true, idempotentHint: true, openWorldHint: true },
     schema: z.object({
       forum_channel_id: snowflake.describe("ID (snowflake) of the forum channel to set tags on."),
       tags: z.array(z.object({

--- a/src/tools/messages.ts
+++ b/src/tools/messages.ts
@@ -287,7 +287,7 @@ const tools = [
     name: "discord_remove_reactions",
     description:
       "Remove reactions from a message. With no emoji: removes ALL reactions. With emoji only: removes every reaction of that emoji. With emoji and user_id: removes that one user's reaction. Removing all reactions or another user's reaction requires the Manage Messages permission. Use discord_add_reaction to add.",
-    annotations: { title: "Remove reactions", readOnlyHint: false, destructiveHint: false, idempotentHint: true, openWorldHint: true },
+    annotations: { title: "Remove reactions", readOnlyHint: false, destructiveHint: true, idempotentHint: true, openWorldHint: true },
     schema: z.object({
       channel_id: channelId.describe("ID (snowflake) of the channel or thread containing the message."),
       message_id: messageId.describe("ID of the message to remove reactions from."),

--- a/src/tools/permissions.ts
+++ b/src/tools/permissions.ts
@@ -97,7 +97,7 @@ const tools = [
     name: "discord_copy_permissions",
     description:
       "Replace the target channel's permission overwrites with a copy of the source channel's. The target's existing overwrites are overwritten. Requires the Manage Roles permission. Returns a confirmation.",
-    annotations: { title: "Copy channel permissions", readOnlyHint: false, destructiveHint: false, idempotentHint: true, openWorldHint: true },
+    annotations: { title: "Copy channel permissions", readOnlyHint: false, destructiveHint: true, idempotentHint: true, openWorldHint: true },
     schema: z.object({
       source_channel_id: snowflake.describe("ID (snowflake) of the channel to copy overwrites from."),
       target_channel_id: snowflake.describe("ID (snowflake) of the channel whose overwrites will be replaced."),


### PR DESCRIPTION
Audit finding #4 (tool annotations), expanded to an exhaustive review of annotation correctness across all 97 tools.

Three tools irreversibly remove or overwrite existing state but were annotated `destructiveHint:false`:
- `discord_remove_reactions` — `reactions.removeAll()` / `reaction.remove()` delete existing reaction data.
- `discord_copy_permissions` — `permissionOverwrites.set()` replaces the target's entire overwrite set.
- `discord_set_forum_tags` — `setAvailableTags()` replaces the whole tag collection.

All three now set `destructiveHint:true`, matching the MCP annotation semantics (destructive = removes/overwrites existing data) and the already-correct `delete_*`/ban/kick/prune/reset tools.

The wider audit confirmed every other tool's `readOnlyHint`/`destructiveHint`/`idempotentHint` is already correct: over-flags on conventional in-place edits and on `remove_role`/`unban`/`crosspost` idempotency were reviewed and rejected.

build + lint (0 errors) + tests (13/13) green.