### PR TITLE
fix(tools): remove as-any casts (Findings #5, #34)

### DIFF
--- a/src/tools/invites.ts
+++ b/src/tools/invites.ts
@@ -71,7 +71,7 @@ const tools = [
       if (!channel || !("createInvite" in channel)) {
         throw new Error(`Channel ${channel_id} does not support invites.`);
       }
-      const invite = await (channel as any).createInvite({
+      const invite = await channel.createInvite({
         maxAge: max_age,
         maxUses: max_uses,
         unique: unique ?? false,
@@ -114,7 +114,7 @@ const tools = [
       if (!channel || !("fetchInvites" in channel)) {
         throw new Error(`Channel ${channel_id} does not support invites.`);
       }
-      const invites = await (channel as any).fetchInvites();
+      const invites = await channel.fetchInvites();
       const list = [...invites.values()].map(serializeInvite);
       return { content: [{ type: "text", text: JSON.stringify(list, null, 2) }] };
     },

--- a/src/tools/scheduledEvents.ts
+++ b/src/tools/scheduledEvents.ts
@@ -168,7 +168,14 @@ const tools = [
         options.status = statusVal;
       }
 
-      const updated = await event.edit(options as unknown as GuildScheduledEventEditOptions<any, any>);
+      const updated = await event.edit(
+        options as unknown as GuildScheduledEventEditOptions<
+          GuildScheduledEventStatus,
+          | GuildScheduledEventStatus.Active
+          | GuildScheduledEventStatus.Completed
+          | GuildScheduledEventStatus.Canceled
+        >,
+      );
       return {
         content: [{ type: "text", text: `✅ Scheduled event "${updated.name}" updated (id: ${updated.id}).` }],
       };

--- a/src/tools/webhooks.ts
+++ b/src/tools/webhooks.ts
@@ -23,7 +23,7 @@ const tools = [
     handle: async ({ channel_id, name, avatar }) => {
       const channel = await discord.channels.fetch(channel_id);
       if (!channel || !("createWebhook" in channel)) throw new Error("Channel does not support webhooks.");
-      const webhook = await (channel as any).createWebhook({ name, avatar: avatar ?? undefined });
+      const webhook = await channel.createWebhook({ name, avatar: avatar ?? undefined });
       return {
         content: [{
           type: "text",
@@ -120,13 +120,13 @@ const tools = [
       if (channel_id) {
         const channel = await discord.channels.fetch(channel_id);
         if (!channel || !("fetchWebhooks" in channel)) throw new Error("Channel does not support webhooks.");
-        const webhooks = await (channel as any).fetchWebhooks();
-        const result = [...webhooks.values()].map((w: any) => ({
+        const webhooks = await channel.fetchWebhooks();
+        const result = [...webhooks.values()].map((w) => ({
           id: w.id,
           name: w.name,
           channel_id: w.channelId,
           token: w.token ?? null,
-          creator: w.owner?.tag ?? null,
+          creator: w.owner && "tag" in w.owner ? w.owner.tag : (w.owner?.username ?? null),
         }));
         return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
       } else if (guild_id) {


### PR DESCRIPTION
Audit findings #5 (invite typing) and #34 (the eslint `no-explicit-any` warnings), addressed exhaustively across the codebase.

## Changes
- `invites.ts` (74, 117): drop `(channel as any)` on `createInvite`/`fetchInvites` — the `'createInvite' in channel` / `'fetchInvites' in channel` guards already narrow the type, so the cast is unnecessary.
- `webhooks.ts` (26, 123, 124): drop `(channel as any)` on `createWebhook`/`fetchWebhooks` and the `(w: any)` map. Removing the cast surfaced a **latent bug**: the channel branch read `w.owner?.tag`, but `Webhook.owner` can be an `APIUser` (raw object, no `.tag`) — it now uses the same `"tag" in owner ? owner.tag : owner.username` guard the guild branch already had.
- `scheduledEvents.ts` (171): replace the `<any, any>` generics on `GuildScheduledEventEditOptions` with the precise type the API requires (`<GuildScheduledEventStatus, Active | Completed | Canceled>`).

## Result
eslint is now **warning-free** (was 7 `no-explicit-any` warnings). build + tests (13/13) green.

The remaining `as` casts in the codebase (`as ColorResolvable`, `as ForumChannel`, the discovery position sorts, the permission-overwrite key writes) were audited and confirmed safe/necessary — proposed "fixes" for them did not type-check against discord.js v14 and were rejected.