### PR TITLE
feat(tools): outputSchema + structuredContent on read tools (Finding #3)

### DIFF
--- a/src/tools/define.ts
+++ b/src/tools/define.ts
@@ -29,6 +29,26 @@ function toInputSchema(schema: z.ZodType): Record<string, unknown> {
 }
 
 /**
+ * Converts a zod schema into the JSON Schema MCP advertises as a tool's `outputSchema`.
+ * `io: "output"` emits the post-parse view; the `$schema` key is stripped (bare object
+ * schema). MCP requires an object root, so the schema must be a `z.object({...})`.
+ */
+function toOutputSchema(schema: z.ZodType): Record<string, unknown> {
+  const json = z.toJSONSchema(schema, { io: "output" }) as Record<string, unknown>;
+  delete json.$schema;
+  return json;
+}
+
+/**
+ * Builds a dual-output result: a human-readable JSON text block plus the same data
+ * as machine-readable `structuredContent`. Pass an object (wrap arrays as
+ * `{ items: [...] }`) so it conforms to the tool's object-root `outputSchema`.
+ */
+export function structured(data: Record<string, unknown>): ToolResult {
+  return { content: [{ type: "text", text: JSON.stringify(data, null, 2) }], structuredContent: data };
+}
+
+/**
  * A registered tool: its public metadata plus a `run` that validates raw args
  * with its zod schema before handing typed values to the handler.
  */
@@ -37,6 +57,7 @@ interface RegisteredTool {
   description: string;
   annotations?: ToolAnnotations;
   inputSchema: Record<string, unknown>;
+  outputSchema?: Record<string, unknown>;
   run(args: Record<string, unknown>): Promise<ToolResult>;
 }
 
@@ -44,20 +65,39 @@ interface RegisteredTool {
  * Declares one tool from a single source of truth: the zod `schema` derives the
  * client-facing `inputSchema` and validates incoming args, so `handle` receives
  * values already typed and checked — no `as` casts, no schema/handler drift.
+ * An optional `outputSchema` (a `z.object`) derives the advertised `outputSchema`
+ * and checks the handler's `structuredContent` against it on the way out. The check
+ * is non-fatal: a conforming result is normalised (unknown keys dropped), a
+ * non-conforming one is left untouched and a warning is logged — so a schema bug
+ * never turns a working tool into a runtime error, while drift stays visible in dev.
  */
 export function defineTool<S extends z.ZodType>(tool: {
   name: string;
   description: string;
   annotations?: ToolAnnotations;
   schema: S;
+  outputSchema?: z.ZodType;
   handle(args: z.infer<S>): Promise<ToolResult>;
 }): RegisteredTool {
+  const { outputSchema } = tool;
   return {
     name: tool.name,
     description: tool.description,
     annotations: tool.annotations,
     inputSchema: toInputSchema(tool.schema),
-    run: (args) => tool.handle(tool.schema.parse(args)),
+    outputSchema: outputSchema ? toOutputSchema(outputSchema) : undefined,
+    run: async (args) => {
+      const result = await tool.handle(tool.schema.parse(args));
+      if (outputSchema && result.structuredContent !== undefined) {
+        const parsed = outputSchema.safeParse(result.structuredContent);
+        if (parsed.success) {
+          result.structuredContent = parsed.data as Record<string, unknown>;
+        } else {
+          console.error(`[${tool.name}] structuredContent does not match outputSchema:`, parsed.error.issues);
+        }
+      }
+      return result;
+    },
   };
 }
 
@@ -73,6 +113,7 @@ export function defineModule(tools: RegisteredTool[]): ToolModule {
     description: t.description,
     annotations: t.annotations,
     inputSchema: t.inputSchema,
+    ...(t.outputSchema ? { outputSchema: t.outputSchema } : {}),
   }));
 
   async function handle(name: string, args: Record<string, unknown>): Promise<ToolResult | null> {

--- a/src/tools/define.ts
+++ b/src/tools/define.ts
@@ -45,7 +45,10 @@ function toOutputSchema(schema: z.ZodType): Record<string, unknown> {
  * `{ items: [...] }`) so it conforms to the tool's object-root `outputSchema`.
  */
 export function structured(data: Record<string, unknown>): ToolResult {
-  return { content: [{ type: "text", text: JSON.stringify(data, null, 2) }], structuredContent: data };
+  return {
+    content: [{ type: "text", text: JSON.stringify(data, null, 2) }],
+    structuredContent: data,
+  };
 }
 
 /**
@@ -67,9 +70,10 @@ interface RegisteredTool {
  * values already typed and checked — no `as` casts, no schema/handler drift.
  * An optional `outputSchema` (a `z.object`) derives the advertised `outputSchema`
  * and checks the handler's `structuredContent` against it on the way out. The check
- * is non-fatal: a conforming result is normalised (unknown keys dropped), a
- * non-conforming one is left untouched and a warning is logged — so a schema bug
- * never turns a working tool into a runtime error, while drift stays visible in dev.
+ * is non-fatal here, but conformance is a spec MUST and SDK clients reject
+ * non-conforming results — so a logged drift warning is a release blocker, not noise.
+ * A conforming result is normalised (unknown keys dropped) and its text block
+ * regenerated so both representations stay identical.
  */
 export function defineTool<S extends z.ZodType>(tool: {
   name: string;
@@ -92,8 +96,12 @@ export function defineTool<S extends z.ZodType>(tool: {
         const parsed = outputSchema.safeParse(result.structuredContent);
         if (parsed.success) {
           result.structuredContent = parsed.data as Record<string, unknown>;
+          result.content = [{ type: "text", text: JSON.stringify(parsed.data, null, 2) }];
         } else {
-          console.error(`[${tool.name}] structuredContent does not match outputSchema:`, parsed.error.issues);
+          console.error(
+            `[${tool.name}] structuredContent does not match outputSchema:`,
+            parsed.error.issues,
+          );
         }
       }
       return result;

--- a/src/tools/discovery.ts
+++ b/src/tools/discovery.ts
@@ -1,7 +1,20 @@
 import { ChannelType, CategoryChannel, GuildChannel } from "discord.js";
 import { z } from "zod";
 import { discord } from "../client.js";
-import { defineTool, defineModule, guildId } from "./define.js";
+import { defineTool, defineModule, guildId, structured } from "./define.js";
+
+const guildSummary = z.object({
+  id: z.string(),
+  name: z.string(),
+  memberCount: z.number(),
+  icon: z.string().nullable(),
+});
+
+const channelSummary = z.object({
+  id: z.string(),
+  name: z.string(),
+  type: z.string(),
+});
 
 /** Tool definitions for server/guild discovery and channel navigation. */
 const tools = [
@@ -11,11 +24,12 @@ const tools = [
       "List every Discord server (guild) the bot is a member of (id, name, member count, icon). Takes no arguments. Read-only. Start here to discover the guild_id needed by most other tools.",
     annotations: { title: "List servers", readOnlyHint: true, openWorldHint: true },
     schema: z.object({}),
+    outputSchema: z.object({ guilds: z.array(guildSummary) }),
     handle: async () => {
       const guilds = discord.guilds.cache.map((g) => ({
         id: g.id, name: g.name, memberCount: g.memberCount, icon: g.iconURL(),
       }));
-      return { content: [{ type: "text", text: JSON.stringify(guilds, null, 2) }] };
+      return structured({ guilds });
     },
   }),
   defineTool({
@@ -26,18 +40,26 @@ const tools = [
     schema: z.object({
       guild_id: guildId,
     }),
+    outputSchema: z.object({
+      id: z.string(),
+      name: z.string(),
+      description: z.string().nullable(),
+      memberCount: z.number(),
+      channelCount: z.number(),
+      roleCount: z.number(),
+      boostLevel: z.number(),
+      boostCount: z.number().nullable(),
+      createdAt: z.string(),
+      owner: z.string(),
+    }),
     handle: async ({ guild_id }) => {
       const guild = await (await discord.guilds.fetch(guild_id)).fetch();
-      return {
-        content: [{
-          type: "text", text: JSON.stringify({
-            id: guild.id, name: guild.name, description: guild.description,
-            memberCount: guild.memberCount, channelCount: guild.channels.cache.size,
-            roleCount: guild.roles.cache.size, boostLevel: guild.premiumTier,
-            boostCount: guild.premiumSubscriptionCount, createdAt: guild.createdAt, owner: guild.ownerId,
-          }, null, 2),
-        }],
-      };
+      return structured({
+        id: guild.id, name: guild.name, description: guild.description,
+        memberCount: guild.memberCount, channelCount: guild.channels.cache.size,
+        roleCount: guild.roles.cache.size, boostLevel: guild.premiumTier,
+        boostCount: guild.premiumSubscriptionCount, createdAt: guild.createdAt.toISOString(), owner: guild.ownerId,
+      });
     },
   }),
   defineTool({
@@ -48,6 +70,7 @@ const tools = [
     schema: z.object({
       guild_id: guildId,
     }),
+    outputSchema: z.object({}).catchall(z.array(channelSummary)),
     handle: async ({ guild_id }) => {
       const guild = await discord.guilds.fetch(guild_id);
       await guild.channels.fetch();
@@ -68,7 +91,7 @@ const tools = [
           result[parentName].push(entry);
         });
 
-      return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
+      return structured(result);
     },
   }),
   defineTool({
@@ -80,6 +103,7 @@ const tools = [
       guild_id: guildId,
       name: z.string().describe("Case-insensitive substring to match against channel names."),
     }),
+    outputSchema: z.object({ matches: z.array(channelSummary) }),
     handle: async ({ guild_id, name }) => {
       const guild = await discord.guilds.fetch(guild_id);
       await guild.channels.fetch();
@@ -87,7 +111,7 @@ const tools = [
       const matches = guild.channels.cache
         .filter((c) => c.name.toLowerCase().includes(keyword))
         .map((c) => ({ id: c.id, name: c.name, type: ChannelType[c.type] }));
-      return { content: [{ type: "text", text: JSON.stringify(matches, null, 2) }] };
+      return structured({ matches });
     },
   }),
 ];

--- a/src/tools/dm.ts
+++ b/src/tools/dm.ts
@@ -1,7 +1,7 @@
 import { z } from "zod";
 import { discord } from "../client.js";
 import { buildEmbed, embedFieldsShape } from "../embeds.js";
-import { defineTool, defineModule, snowflake, intIn } from "./define.js";
+import { defineTool, defineModule, snowflake, intIn, structured } from "./define.js";
 
 const userId = snowflake.describe("Discord user ID (snowflake) of the DM recipient.");
 const messageId = snowflake.describe("ID of the target message within the DM conversation.");
@@ -111,6 +111,17 @@ const tools = [
       user_id: userId,
       limit: intIn(1, 100).default(20).describe("How many recent messages to fetch (1–100). Default 20."),
     }),
+    outputSchema: z.object({
+      messages: z.array(
+        z.object({
+          id: z.string(),
+          author: z.string(),
+          content: z.string(),
+          embeds: z.number(),
+          timestamp: z.string(),
+        }),
+      ),
+    }),
     handle: async ({ user_id, limit }) => {
       const user = await discord.users.fetch(user_id);
       const dm = await user.createDM();
@@ -124,7 +135,7 @@ const tools = [
           embeds: m.embeds.length,
           timestamp: m.createdAt.toISOString(),
         }));
-      return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
+      return structured({ messages: result });
     },
   }),
   defineTool({

--- a/src/tools/forums.ts
+++ b/src/tools/forums.ts
@@ -1,9 +1,20 @@
 import { ChannelType, ForumChannel, ThreadChannel } from "discord.js";
 import { z } from "zod";
 import { discord } from "../client.js";
-import { defineTool, defineModule, snowflake, guildId, intIn } from "./define.js";
+import { defineTool, defineModule, snowflake, guildId, intIn, structured } from "./define.js";
 
 const threadId = snowflake.describe("ID (snowflake) of the forum post (thread).");
+
+/** Shape of a forum post (thread) summary, shared by the post getter and thread lister. */
+const threadSummary = z.object({
+  id: z.string(),
+  name: z.string(),
+  archived: z.boolean().nullable(),
+  locked: z.boolean().nullable(),
+  messageCount: z.number().nullable(),
+  appliedTags: z.array(z.string()),
+  createdAt: z.string().nullable(),
+});
 
 /**
  * Fetches a channel by ID and guarantees it is a forum channel.
@@ -35,6 +46,14 @@ const tools = [
     schema: z.object({
       guild_id: guildId,
     }),
+    outputSchema: z.object({
+      channels: z.array(z.object({
+        id: z.string(),
+        name: z.string(),
+        topic: z.string().nullable(),
+        parentId: z.string().nullable(),
+      })),
+    }),
     handle: async ({ guild_id }) => {
       const guild = await discord.guilds.fetch(guild_id);
       const channels = await guild.channels.fetch();
@@ -46,7 +65,7 @@ const tools = [
           topic: (c as ForumChannel).topic,
           parentId: c!.parentId,
         }));
-      return { content: [{ type: "text", text: JSON.stringify(forums, null, 2) }] };
+      return structured({ channels: forums });
     },
   }),
   defineTool({
@@ -101,6 +120,14 @@ const tools = [
       thread_id: threadId.describe("ID (snowflake) of the forum post (thread)."),
       limit: intIn(1, 100).default(20).describe("How many recent messages to include (1–100). Default 20."),
     }),
+    outputSchema: threadSummary.extend({
+      messages: z.array(z.object({
+        id: z.string(),
+        author: z.string(),
+        content: z.string(),
+        timestamp: z.string(),
+      })),
+    }),
     handle: async ({ thread_id, limit }) => {
       const thread = await getThreadChannel(thread_id);
       const messages = await thread.messages.fetch({ limit });
@@ -111,7 +138,7 @@ const tools = [
         locked: thread.locked,
         messageCount: thread.messageCount,
         appliedTags: thread.appliedTags,
-        createdAt: thread.createdAt?.toISOString(),
+        createdAt: thread.createdAt?.toISOString() ?? null,
         messages: [...messages.values()]
           .sort((a, b) => a.createdTimestamp - b.createdTimestamp)
           .map((m) => ({
@@ -121,7 +148,7 @@ const tools = [
             timestamp: m.createdAt.toISOString(),
           })),
       };
-      return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
+      return structured(result);
     },
   }),
   defineTool({
@@ -133,6 +160,11 @@ const tools = [
       forum_channel_id: snowflake.describe("ID (snowflake) of the forum channel to list posts from."),
       limit: intIn(1, 100).default(100).describe("Max archived posts per page (1–100). Default 100."),
       before: z.string().optional().describe("Pagination cursor: an ISO timestamp. Pass the previous response's nextBefore to fetch older archived posts. When set, active posts are omitted."),
+    }),
+    outputSchema: z.object({
+      threads: z.array(threadSummary),
+      hasMore: z.boolean(),
+      nextBefore: z.string().nullable(),
     }),
     handle: async ({ forum_channel_id, limit, before }) => {
       const forum = await getForumChannel(forum_channel_id);
@@ -151,11 +183,11 @@ const tools = [
         locked: t.locked,
         messageCount: t.messageCount,
         appliedTags: t.appliedTags,
-        createdAt: t.createdAt?.toISOString(),
+        createdAt: t.createdAt?.toISOString() ?? null,
       }));
       const lastArchived = archived.threads.last();
       const nextBefore = archived.hasMore ? lastArchived?.archivedAt?.toISOString() ?? null : null;
-      return { content: [{ type: "text", text: JSON.stringify({ threads, hasMore: archived.hasMore, nextBefore }, null, 2) }] };
+      return structured({ threads, hasMore: archived.hasMore, nextBefore });
     },
   }),
   defineTool({
@@ -196,6 +228,14 @@ const tools = [
     schema: z.object({
       forum_channel_id: snowflake.describe("ID (snowflake) of the forum channel to read tags from."),
     }),
+    outputSchema: z.object({
+      tags: z.array(z.object({
+        id: z.string(),
+        name: z.string(),
+        emoji: z.string().nullable(),
+        moderated: z.boolean(),
+      })),
+    }),
     handle: async ({ forum_channel_id }) => {
       const forum = await getForumChannel(forum_channel_id);
       const tags = forum.availableTags.map((t) => ({
@@ -204,7 +244,7 @@ const tools = [
         emoji: t.emoji?.name ?? null,
         moderated: t.moderated,
       }));
-      return { content: [{ type: "text", text: JSON.stringify(tags, null, 2) }] };
+      return structured({ tags });
     },
   }),
   defineTool({

--- a/src/tools/invites.ts
+++ b/src/tools/invites.ts
@@ -1,8 +1,27 @@
 import { z } from "zod";
 import { discord } from "../client.js";
-import { defineTool, defineModule, snowflake, guildId, intIn } from "./define.js";
+import { defineTool, defineModule, snowflake, guildId, intIn, structured } from "./define.js";
 
 // ─── Helpers ────────────────────────────────────────────────────────────────────
+
+const inviteSummary = z.object({
+  code: z.string(),
+  url: z.string(),
+  channel_id: z.string().nullable(),
+  channel_name: z.string().nullable(),
+  inviter: z
+    .object({
+      id: z.string(),
+      username: z.string(),
+    })
+    .nullable(),
+  uses: z.number(),
+  max_uses: z.number(),
+  max_age: z.number(),
+  temporary: z.boolean(),
+  created_at: z.string().nullable(),
+  expires_at: z.string().nullable(),
+});
 
 function serializeInvite(invite: import("discord.js").Invite) {
   return {
@@ -32,11 +51,14 @@ const tools = [
     schema: z.object({
       guild_id: guildId,
     }),
+    outputSchema: z.object({
+      invites: z.array(inviteSummary),
+    }),
     handle: async ({ guild_id }) => {
       const guild = await discord.guilds.fetch(guild_id);
       const invites = await guild.invites.fetch();
       const list = [...invites.values()].map(serializeInvite);
-      return { content: [{ type: "text", text: JSON.stringify(list, null, 2) }] };
+      return structured({ invites: list });
     },
   }),
   defineTool({
@@ -47,11 +69,12 @@ const tools = [
     schema: z.object({
       invite_code: z.string().describe("The invite code, e.g. 'abc123'. A full discord.gg/abc123 URL is also accepted and stripped."),
     }),
+    outputSchema: inviteSummary,
     handle: async ({ invite_code }) => {
       const code = invite_code.replace(/^(https?:\/\/)?(discord\.gg\/)?/, "");
       if (!code) throw new Error("invite_code is required.");
       const invite = await discord.fetchInvite(code);
-      return { content: [{ type: "text", text: JSON.stringify(serializeInvite(invite), null, 2) }] };
+      return structured(serializeInvite(invite));
     },
   }),
   defineTool({
@@ -109,6 +132,9 @@ const tools = [
     schema: z.object({
       channel_id: snowflake.describe("ID (snowflake) of the channel to list invites for."),
     }),
+    outputSchema: z.object({
+      invites: z.array(inviteSummary),
+    }),
     handle: async ({ channel_id }) => {
       const channel = await discord.channels.fetch(channel_id);
       if (!channel || !("fetchInvites" in channel)) {
@@ -116,7 +142,7 @@ const tools = [
       }
       const invites = await channel.fetchInvites();
       const list = [...invites.values()].map(serializeInvite);
-      return { content: [{ type: "text", text: JSON.stringify(list, null, 2) }] };
+      return structured({ invites: list });
     },
   }),
 ];

--- a/src/tools/members.ts
+++ b/src/tools/members.ts
@@ -2,7 +2,16 @@ import { GuildMember } from "discord.js";
 import { z } from "zod";
 import { discord, serializePermissions } from "../client.js";
 import { MAX_FETCH_LIMIT, DEFAULTS } from "../constants.js";
-import { defineTool, defineModule, snowflake, guildId, intIn } from "./define.js";
+import { defineTool, defineModule, snowflake, guildId, intIn, structured } from "./define.js";
+
+const roleRef = z.object({ id: z.string(), name: z.string() });
+const memberSummary = z.object({
+  id: z.string(),
+  username: z.string(),
+  nickname: z.string().nullable(),
+  roles: z.array(roleRef),
+  joinedAt: z.string().nullable(),
+});
 
 /** Tool definitions for listing, inspecting, and moderating guild members. */
 const tools = [
@@ -16,16 +25,17 @@ const tools = [
       limit: intIn(1, DEFAULTS.MEMBERS_MAX).default(DEFAULTS.MEMBERS).describe("How many members per page (1–1000). Default 50."),
       after: snowflake.optional().describe("Pagination cursor: a user ID (snowflake). Pass the previous response's nextCursor to fetch the next page."),
     }),
+    outputSchema: z.object({ members: z.array(memberSummary), nextCursor: z.string().nullable() }),
     handle: async ({ guild_id, limit, after }) => {
       const guild = await discord.guilds.fetch(guild_id);
       const members = await guild.members.list({ limit, after });
       const result = [...members.values()].map((m: GuildMember) => ({
         id: m.id, username: m.user.tag, nickname: m.nickname,
         roles: m.roles.cache.filter((r) => r.name !== "@everyone").map((r) => ({ id: r.id, name: r.name })),
-        joinedAt: m.joinedAt?.toISOString(),
+        joinedAt: m.joinedAt?.toISOString() ?? null,
       }));
       const nextCursor = members.size === limit ? members.lastKey() ?? null : null;
-      return { content: [{ type: "text", text: JSON.stringify({ members: result, nextCursor }, null, 2) }] };
+      return structured({ members: result, nextCursor });
     },
   }),
   defineTool({
@@ -37,20 +47,27 @@ const tools = [
       guild_id: guildId,
       user_id: snowflake.describe("Discord user ID (snowflake) of the member."),
     }),
+    outputSchema: z.object({
+      id: z.string(),
+      username: z.string(),
+      nickname: z.string().nullable(),
+      roles: z.array(roleRef),
+      permissions: z.array(z.string()),
+      joinedAt: z.string().nullable(),
+      createdAt: z.string(),
+      bot: z.boolean(),
+      timedOutUntil: z.string().nullable(),
+    }),
     handle: async ({ guild_id, user_id }) => {
       const guild = await discord.guilds.fetch(guild_id);
       const member = await guild.members.fetch(user_id);
-      return {
-        content: [{
-          type: "text", text: JSON.stringify({
-            id: member.id, username: member.user.tag, nickname: member.nickname,
-            roles: member.roles.cache.filter((r) => r.name !== "@everyone").map((r) => ({ id: r.id, name: r.name })),
-            permissions: serializePermissions(member.permissions),
-            joinedAt: member.joinedAt?.toISOString(), createdAt: member.user.createdAt.toISOString(),
-            bot: member.user.bot, timedOutUntil: member.communicationDisabledUntil?.toISOString() ?? null,
-          }, null, 2),
-        }],
-      };
+      return structured({
+        id: member.id, username: member.user.tag, nickname: member.nickname,
+        roles: member.roles.cache.filter((r) => r.name !== "@everyone").map((r) => ({ id: r.id, name: r.name })),
+        permissions: serializePermissions(member.permissions),
+        joinedAt: member.joinedAt?.toISOString() ?? null, createdAt: member.user.createdAt.toISOString(),
+        bot: member.user.bot, timedOutUntil: member.communicationDisabledUntil?.toISOString() ?? null,
+      });
     },
   }),
   defineTool({
@@ -140,6 +157,14 @@ const tools = [
       query: z.string().describe("Prefix to match against usernames and nicknames."),
       limit: intIn(1, MAX_FETCH_LIMIT).default(DEFAULTS.LIMIT).describe("Max members to return (1–100). Default 25."),
     }),
+    outputSchema: z.object({
+      members: z.array(z.object({
+        id: z.string(),
+        username: z.string(),
+        nickname: z.string().nullable(),
+        roles: z.array(roleRef),
+      })),
+    }),
     handle: async ({ guild_id, query, limit }) => {
       const guild = await discord.guilds.fetch(guild_id);
       const members = await guild.members.search({ query, limit });
@@ -147,7 +172,7 @@ const tools = [
         id: m.id, username: m.user.tag, nickname: m.nickname,
         roles: m.roles.cache.filter((r) => r.name !== "@everyone").map((r) => ({ id: r.id, name: r.name })),
       }));
-      return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
+      return structured({ members: result });
     },
   }),
   defineTool({
@@ -179,6 +204,14 @@ const tools = [
       limit: intIn(1, DEFAULTS.MEMBERS_MAX).default(DEFAULTS.MEMBERS_MAX).describe("Max bans per page (1–1000). Default 1000."),
       after: snowflake.optional().describe("Pagination cursor: a user ID (snowflake). Pass the previous response's nextCursor to fetch the next page."),
     }),
+    outputSchema: z.object({
+      bans: z.array(z.object({
+        user_id: z.string(),
+        username: z.string(),
+        reason: z.string().nullable(),
+      })),
+      nextCursor: z.string().nullable(),
+    }),
     handle: async ({ guild_id, limit, after }) => {
       const guild = await discord.guilds.fetch(guild_id);
       const bans = await guild.bans.fetch({ limit, after, cache: false });
@@ -186,7 +219,7 @@ const tools = [
         user_id: ban.user.id, username: ban.user.tag, reason: ban.reason ?? null,
       }));
       const nextCursor = bans.size === limit ? bans.lastKey() ?? null : null;
-      return { content: [{ type: "text", text: JSON.stringify({ bans: result, nextCursor }, null, 2) }] };
+      return structured({ bans: result, nextCursor });
     },
   }),
   defineTool({

--- a/src/tools/messages.ts
+++ b/src/tools/messages.ts
@@ -10,10 +10,17 @@ import { z } from "zod";
 import { discord, getTextChannel } from "../client.js";
 import { MAX_FETCH_LIMIT, DEFAULTS } from "../constants.js";
 import { buildEmbed, embedFieldsShape, embedObjectSchema } from "../embeds.js";
-import { defineModule, defineTool, snowflake, intIn } from "./define.js";
+import { defineModule, defineTool, snowflake, intIn, structured } from "./define.js";
 
 const channelId = snowflake.describe("ID (snowflake) of the channel or thread.");
 const messageId = snowflake.describe("ID of the message.");
+
+const messageSummary = z.object({
+  id: z.string(),
+  author: z.string(),
+  content: z.string(),
+  timestamp: z.string(),
+});
 
 /**
  * Looks up a reaction on a message by emoji argument.
@@ -38,6 +45,9 @@ const tools = [
       channel_id: snowflake.describe("ID (snowflake) of the channel or thread to read from."),
       limit: intIn(1, MAX_FETCH_LIMIT).default(DEFAULTS.MESSAGES).describe("How many recent messages to fetch (1–100). Default 20."),
     }),
+    outputSchema: z.object({
+      messages: z.array(messageSummary.extend({ attachments: z.number(), pinned: z.boolean() })),
+    }),
     handle: async ({ channel_id, limit }) => {
       const channel = await getTextChannel(channel_id);
       const messages = await channel.messages.fetch({ limit, cache: false });
@@ -47,7 +57,7 @@ const tools = [
           id: m.id, author: m.author.tag, content: m.content,
           timestamp: m.createdAt.toISOString(), attachments: m.attachments.size, pinned: m.pinned,
         }));
-      return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
+      return structured({ messages: result });
     },
   }),
   defineTool({
@@ -256,6 +266,7 @@ const tools = [
       keyword: z.string().describe("Case-insensitive substring to match within message content."),
       limit: intIn(1, MAX_FETCH_LIMIT).default(MAX_FETCH_LIMIT).describe("Max number of recent messages to scan (1–100). Default 100."),
     }),
+    outputSchema: z.object({ matches: z.array(messageSummary) }),
     handle: async ({ channel_id, keyword, limit }) => {
       const channel = await getTextChannel(channel_id);
       const messages = await channel.messages.fetch({ limit, cache: false });
@@ -264,7 +275,7 @@ const tools = [
         .filter((m) => m.content.toLowerCase().includes(needle))
         .sort((a, b) => a.createdTimestamp - b.createdTimestamp)
         .map((m) => ({ id: m.id, author: m.author.tag, content: m.content, timestamp: m.createdAt.toISOString() }));
-      return { content: [{ type: "text", text: matches.length > 0 ? JSON.stringify(matches, null, 2) : `No messages found containing "${keyword}" in the last ${limit} messages.` }] };
+      return structured({ matches });
     },
   }),
   defineTool({
@@ -322,6 +333,13 @@ const tools = [
       emoji: z.string().describe("Unicode emoji or custom emoji 'name:id' to list reactors for."),
       limit: intIn(1, MAX_FETCH_LIMIT).default(DEFAULTS.LIMIT).describe("Max users to return (1–100). Default 25."),
     }),
+    outputSchema: z.object({
+      reactions: z.array(z.object({
+        id: z.string(),
+        username: z.string(),
+        bot: z.boolean(),
+      })),
+    }),
     handle: async ({ channel_id, message_id, emoji, limit }) => {
       const channel = await getTextChannel(channel_id);
       const msg = await channel.messages.fetch(message_id);
@@ -329,7 +347,7 @@ const tools = [
       if (!reaction) throw new Error(`No reaction found for emoji "${emoji}" on message ${msg.id}.`);
       const users = await reaction.users.fetch({ limit });
       const result = [...users.values()].map((u) => ({ id: u.id, username: u.username, bot: u.bot }));
-      return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
+      return structured({ reactions: result });
     },
   }),
   defineTool({
@@ -340,6 +358,9 @@ const tools = [
     schema: z.object({
       channel_id: snowflake.describe("ID (snowflake) of the channel or thread to list pins from."),
     }),
+    outputSchema: z.object({
+      messages: z.array(messageSummary.extend({ pinnedAt: z.string() })),
+    }),
     handle: async ({ channel_id }) => {
       const channel = await getTextChannel(channel_id);
       const pinned = await channel.messages.fetchPins();
@@ -347,7 +368,7 @@ const tools = [
         id: m.id, author: m.author.tag, content: m.content,
         timestamp: m.createdAt.toISOString(), pinnedAt: pinnedAt.toISOString(),
       }));
-      return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
+      return structured({ messages: result });
     },
   }),
   defineTool({

--- a/src/tools/moderation.ts
+++ b/src/tools/moderation.ts
@@ -1,8 +1,17 @@
 import { z } from "zod";
 import { discord } from "../client.js";
-import { defineTool, defineModule, guildId, intIn } from "./define.js";
+import { defineTool, defineModule, guildId, intIn, structured } from "./define.js";
 
 /** Tool definitions for server moderation (audit log). */
+const auditLogEntry = z.object({
+  id: z.string(),
+  action: z.number(),
+  executor: z.string().nullable(),
+  target: z.string().nullable(),
+  reason: z.string().nullable(),
+  createdAt: z.string(),
+});
+
 const tools = [
   defineTool({
     name: "discord_get_audit_log",
@@ -14,18 +23,19 @@ const tools = [
       limit: intIn(1, 100).default(25).describe("How many recent entries to fetch (1–100). Default 25."),
       action_type: z.int().optional().describe("Optional Discord AuditLogEvent numeric ID to filter by (e.g. 22 = MemberBanAdd). Omit for all action types."),
     }),
+    outputSchema: z.object({ entries: z.array(auditLogEntry) }),
     handle: async ({ guild_id, limit, action_type }) => {
       const guild = await discord.guilds.fetch(guild_id);
       const logs = await guild.fetchAuditLogs({
         limit,
         type: action_type as number | undefined,
       });
-      const result = logs.entries.map((entry) => ({
+      const entries = logs.entries.map((entry) => ({
         id: entry.id, action: entry.action,
-        executor: entry.executor?.tag, target: entry.targetId,
+        executor: entry.executor?.tag ?? null, target: entry.targetId,
         reason: entry.reason, createdAt: entry.createdAt.toISOString(),
       }));
-      return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
+      return structured({ entries });
     },
   }),
 ];

--- a/src/tools/permissions.ts
+++ b/src/tools/permissions.ts
@@ -1,7 +1,7 @@
 import { PermissionOverwriteOptions, GuildChannel } from "discord.js";
 import { z } from "zod";
 import { discord, getGuildChannel, serializePermissions } from "../client.js";
-import { defineTool, defineModule, snowflake, guildId } from "./define.js";
+import { defineTool, defineModule, snowflake, guildId, structured } from "./define.js";
 
 /**
  * Parses a permission array from tool arguments.
@@ -15,6 +15,20 @@ function parsePermArray(value: string[] | string | undefined): string[] {
 
 const permFlags = z.union([z.array(z.string()), z.string()]).optional();
 
+const channelOverwriteSummary = z.object({
+  id: z.string(),
+  type: z.string(),
+  allow: z.array(z.string()),
+  deny: z.array(z.string()),
+});
+
+const auditOverwriteSummary = z.object({
+  entity: z.string(),
+  type: z.string(),
+  allow: z.array(z.string()),
+  deny: z.array(z.string()),
+});
+
 /** Tool definitions for viewing and managing per-channel permission overwrites. */
 const tools = [
   defineTool({
@@ -25,6 +39,9 @@ const tools = [
     schema: z.object({
       channel_id: snowflake.describe("ID (snowflake) of the channel to inspect."),
     }),
+    outputSchema: z.object({
+      overwrites: z.array(channelOverwriteSummary),
+    }),
     handle: async ({ channel_id }) => {
       const channel = await getGuildChannel(channel_id);
       const overwrites = channel.permissionOverwrites.cache.map((ow) => ({
@@ -33,7 +50,7 @@ const tools = [
         allow: serializePermissions(ow.allow),
         deny: serializePermissions(ow.deny),
       }));
-      return { content: [{ type: "text", text: JSON.stringify(overwrites, null, 2) }] };
+      return structured({ overwrites });
     },
   }),
   defineTool({
@@ -121,6 +138,13 @@ const tools = [
     schema: z.object({
       guild_id: guildId,
     }),
+    outputSchema: z.object({
+      channels: z.array(z.object({
+        channel: z.string(),
+        channelId: z.string(),
+        overwrites: z.array(auditOverwriteSummary),
+      })),
+    }),
     handle: async ({ guild_id }) => {
       const guild = await discord.guilds.fetch(guild_id);
       await guild.channels.fetch();
@@ -148,7 +172,7 @@ const tools = [
           });
           if (overwrites.length > 0) report.push({ channel: gch.name, channelId: gch.id, overwrites });
         });
-      return { content: [{ type: "text", text: JSON.stringify(report, null, 2) }] };
+      return structured({ channels: report });
     },
   }),
 ];

--- a/src/tools/roles.ts
+++ b/src/tools/roles.ts
@@ -1,9 +1,26 @@
 import { ColorResolvable, Role, Guild } from "discord.js";
 import { z } from "zod";
 import { discord, serializePermissions, deserializePermissions } from "../client.js";
-import { defineTool, defineModule, snowflake, guildId } from "./define.js";
+import { defineTool, defineModule, snowflake, guildId, structured } from "./define.js";
 
 const roleId = snowflake.describe("ID (snowflake) of the role to edit.");
+
+const roleSummary = z.object({
+  id: z.string(),
+  name: z.string(),
+  color: z.string(),
+  position: z.number(),
+  memberCount: z.number(),
+  permissions: z.array(z.string()),
+  hoist: z.boolean(),
+  mentionable: z.boolean(),
+});
+
+const roleMember = z.object({
+  id: z.string(),
+  username: z.string(),
+  nickname: z.string().nullable(),
+});
 
 /**
  * Parses a permission array from tool arguments.
@@ -35,6 +52,7 @@ const tools = [
     schema: z.object({
       guild_id: guildId,
     }),
+    outputSchema: z.object({ roles: z.array(roleSummary) }),
     handle: async ({ guild_id }) => {
       const guild = await discord.guilds.fetch(guild_id);
       const roles = await guild.roles.fetch();
@@ -46,7 +64,7 @@ const tools = [
           memberCount: r.members.size, permissions: serializePermissions(r.permissions),
           hoist: r.hoist, mentionable: r.mentionable,
         }));
-      return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
+      return structured({ roles: result });
     },
   }),
   defineTool({
@@ -165,6 +183,11 @@ const tools = [
       guild_id: guildId,
       role_id: snowflake.describe("ID (snowflake) of the role to list holders of."),
     }),
+    outputSchema: z.object({
+      members: z.array(roleMember),
+      truncated: z.boolean(),
+      note: z.string().optional(),
+    }),
     handle: async ({ guild_id, role_id }) => {
       const guild = await discord.guilds.fetch(guild_id);
       const role = await fetchRole(guild, role_id);
@@ -178,11 +201,11 @@ const tools = [
         after = page.lastKey();
       }
       const members = role.members.map((m) => ({ id: m.id, username: m.user.tag, nickname: m.nickname }));
-      return { content: [{ type: "text", text: JSON.stringify({
+      return structured({
         members,
         truncated,
         note: truncated ? `Only the first ${MAX_PAGES * 1000} members were scanned; results may be incomplete on very large servers.` : undefined,
-      }, null, 2) }] };
+      });
     },
   }),
   defineTool({

--- a/src/tools/scheduledEvents.ts
+++ b/src/tools/scheduledEvents.ts
@@ -2,7 +2,7 @@ import { GuildScheduledEventEntityType, GuildScheduledEventPrivacyLevel, GuildSc
 import { z } from "zod";
 import { discord } from "../client.js";
 import { MAX_FETCH_LIMIT, DEFAULTS } from "../constants.js";
-import { defineTool, defineModule, snowflake, guildId, intIn } from "./define.js";
+import { defineTool, defineModule, snowflake, guildId, intIn, structured } from "./define.js";
 
 // ─── Helpers ────────────────────────────────────────────────────────────────────
 
@@ -51,6 +51,27 @@ function serializeEvent(event: import("discord.js").GuildScheduledEvent) {
 
 // ─── Tools ──────────────────────────────────────────────────────────────────────
 
+const eventSummary = z.object({
+  id: z.string(),
+  name: z.string(),
+  description: z.string().nullable(),
+  status: z.union([z.string(), z.number()]),
+  entity_type: z.union([z.string(), z.number()]),
+  channel_id: z.string().nullable(),
+  location: z.string().nullable(),
+  scheduled_start_time: z.string().nullable(),
+  scheduled_end_time: z.string().nullable(),
+  creator_id: z.string().nullable(),
+  user_count: z.number().nullable(),
+  image: z.string().nullable(),
+});
+
+const subscriberSummary = z.object({
+  user_id: z.string(),
+  username: z.string(),
+  avatar: z.string(),
+});
+
 /** Tool definitions for managing guild scheduled events. */
 const tools = [
   defineTool({
@@ -61,11 +82,14 @@ const tools = [
     schema: z.object({
       guild_id: guildId,
     }),
+    outputSchema: z.object({
+      events: z.array(eventSummary),
+    }),
     handle: async ({ guild_id }) => {
       const guild = await discord.guilds.fetch(guild_id);
       const events = await guild.scheduledEvents.fetch();
       const list = [...events.values()].map(serializeEvent);
-      return { content: [{ type: "text", text: JSON.stringify(list, null, 2) }] };
+      return structured({ events: list });
     },
   }),
   defineTool({
@@ -77,10 +101,11 @@ const tools = [
       guild_id: guildId,
       event_id: snowflake.describe("ID (snowflake) of the scheduled event."),
     }),
+    outputSchema: eventSummary,
     handle: async ({ guild_id, event_id }) => {
       const guild = await discord.guilds.fetch(guild_id);
       const event = await guild.scheduledEvents.fetch(event_id);
-      return { content: [{ type: "text", text: JSON.stringify(serializeEvent(event), null, 2) }] };
+      return structured(serializeEvent(event));
     },
   }),
   defineTool({
@@ -210,6 +235,10 @@ const tools = [
       limit: intIn(1, MAX_FETCH_LIMIT).default(DEFAULTS.LIMIT).describe("Max subscribers per page (1–100). Default 25."),
       after: snowflake.optional().describe("Pagination cursor: a user ID (snowflake). Pass the previous response's nextCursor to fetch the next page."),
     }),
+    outputSchema: z.object({
+      subscribers: z.array(subscriberSummary),
+      nextCursor: z.string().nullable(),
+    }),
     handle: async ({ guild_id, event_id, limit, after }) => {
       const guild = await discord.guilds.fetch(guild_id);
       const event = await guild.scheduledEvents.fetch(event_id);
@@ -220,7 +249,7 @@ const tools = [
         avatar: sub.user.displayAvatarURL(),
       }));
       const nextCursor = subscribers.size === limit ? subscribers.lastKey() ?? null : null;
-      return { content: [{ type: "text", text: JSON.stringify({ subscribers: list, nextCursor }, null, 2) }] };
+      return structured({ subscribers: list, nextCursor });
     },
   }),
   defineTool({

--- a/src/tools/screening.ts
+++ b/src/tools/screening.ts
@@ -1,6 +1,6 @@
 import { z } from "zod";
 import { discord } from "../client.js";
-import { defineTool, defineModule, guildId } from "./define.js";
+import { defineTool, defineModule, guildId, structured } from "./define.js";
 
 /** Tool definitions for reading and updating the guild membership screening form. */
 const tools = [
@@ -12,9 +12,22 @@ const tools = [
     schema: z.object({
       guild_id: guildId,
     }),
+    outputSchema: z.object({
+      version: z.string().nullable(),
+      form_fields: z.array(
+        z.object({
+          field_type: z.string(),
+          label: z.string(),
+          values: z.array(z.string()).nullable(),
+          required: z.boolean(),
+          description: z.string().nullable(),
+        })
+      ),
+      description: z.string().nullable(),
+    }),
     handle: async ({ guild_id }) => {
-      const data = await discord.rest.get(`/guilds/${guild_id}/member-verification`);
-      return { content: [{ type: "text", text: JSON.stringify(data, null, 2) }] };
+      const data = await discord.rest.get(`/guilds/${guild_id}/member-verification`) as Record<string, unknown>;
+      return structured(data);
     },
   }),
   defineTool({

--- a/src/tools/screening.ts
+++ b/src/tools/screening.ts
@@ -21,33 +21,75 @@ const tools = [
           values: z.array(z.string()).nullable(),
           required: z.boolean(),
           description: z.string().nullable(),
-        })
+        }),
       ),
       description: z.string().nullable(),
     }),
     handle: async ({ guild_id }) => {
-      const data = await discord.rest.get(`/guilds/${guild_id}/member-verification`) as Record<string, unknown>;
-      return structured(data);
+      // Undocumented endpoint — map fields explicitly so payload variations
+      // can't produce structuredContent that violates the declared schema.
+      const data = (await discord.rest.get(`/guilds/${guild_id}/member-verification`)) as {
+        version?: string | null;
+        description?: string | null;
+        form_fields?: {
+          field_type?: string;
+          label?: string;
+          values?: string[] | null;
+          required?: boolean;
+          description?: string | null;
+        }[];
+      };
+      return structured({
+        version: data.version ?? null,
+        description: data.description ?? null,
+        form_fields: (data.form_fields ?? []).map((f) => ({
+          field_type: f.field_type ?? "TERMS",
+          label: f.label ?? "",
+          values: f.values ?? null,
+          required: f.required ?? true,
+          description: f.description ?? null,
+        })),
+      });
     },
   }),
   defineTool({
     name: "discord_update_membership_screening",
     description:
       "Update the server's membership screening form: set the welcome description and the rules new members must agree to. Only provided fields change. Requires the Community feature and the Manage Server permission. Returns the updated form.",
-    annotations: { title: "Update membership screening", readOnlyHint: false, destructiveHint: false, idempotentHint: true, openWorldHint: true },
+    annotations: {
+      title: "Update membership screening",
+      readOnlyHint: false,
+      destructiveHint: false,
+      idempotentHint: true,
+      openWorldHint: true,
+    },
     schema: z.object({
       guild_id: guildId,
-      description: z.string().optional().describe("Welcome message shown at the top of the screening form."),
-      form_fields: z.array(
-        z.object({
-          label: z.string().describe("Title of this rules block."),
-          values: z.array(z.string()).describe("Individual rule lines shown under the label."),
-          required: z.boolean().optional().describe("Whether the member must agree to this block. Default true."),
-        })
-      ).optional().describe("Rules/agreement blocks new members must accept. Replaces the existing fields when provided."),
+      description: z
+        .string()
+        .optional()
+        .describe("Welcome message shown at the top of the screening form."),
+      form_fields: z
+        .array(
+          z.object({
+            label: z.string().describe("Title of this rules block."),
+            values: z.array(z.string()).describe("Individual rule lines shown under the label."),
+            required: z
+              .boolean()
+              .optional()
+              .describe("Whether the member must agree to this block. Default true."),
+          }),
+        )
+        .optional()
+        .describe(
+          "Rules/agreement blocks new members must accept. Replaces the existing fields when provided.",
+        ),
     }),
     handle: async ({ guild_id, description, form_fields }) => {
-      const current = await discord.rest.get(`/guilds/${guild_id}/member-verification`) as Record<string, unknown>;
+      const current = (await discord.rest.get(`/guilds/${guild_id}/member-verification`)) as Record<
+        string,
+        unknown
+      >;
       const body: Record<string, unknown> = { version: current.version };
       if (description !== undefined) body.description = description;
       if (form_fields !== undefined) {
@@ -59,7 +101,14 @@ const tools = [
         }));
       }
       const updated = await discord.rest.patch(`/guilds/${guild_id}/member-verification`, { body });
-      return { content: [{ type: "text", text: `✅ Membership screening updated.\n${JSON.stringify(updated, null, 2)}` }] };
+      return {
+        content: [
+          {
+            type: "text",
+            text: `✅ Membership screening updated.\n${JSON.stringify(updated, null, 2)}`,
+          },
+        ],
+      };
     },
   }),
 ];

--- a/src/tools/screening.ts
+++ b/src/tools/screening.ts
@@ -26,8 +26,6 @@ const tools = [
       description: z.string().nullable(),
     }),
     handle: async ({ guild_id }) => {
-      // Undocumented endpoint — map fields explicitly so payload variations
-      // can't produce structuredContent that violates the declared schema.
       const data = (await discord.rest.get(`/guilds/${guild_id}/member-verification`)) as {
         version?: string | null;
         description?: string | null;

--- a/src/tools/stats.ts
+++ b/src/tools/stats.ts
@@ -1,7 +1,7 @@
 import { ChannelType } from "discord.js";
 import { z } from "zod";
 import { discord } from "../client.js";
-import { defineModule, defineTool, guildId } from "./define.js";
+import { defineModule, defineTool, guildId, structured } from "./define.js";
 
 /** Tool definitions for server statistics (members, channels, boosts). */
 const tools = [
@@ -13,27 +13,39 @@ const tools = [
     schema: z.object({
       guild_id: guildId,
     }),
+    outputSchema: z.object({
+      name: z.string(),
+      totalMembers: z.number(),
+      humans: z.number(),
+      botsInCache: z.number(),
+      channels: z.object({
+        total: z.number(),
+        text: z.number(),
+        voice: z.number(),
+        categories: z.number(),
+      }),
+      roles: z.number(),
+      boostLevel: z.number(),
+      boostCount: z.number(),
+      createdAt: z.string(),
+    }),
     handle: async ({ guild_id }) => {
       const guild = await (await discord.guilds.fetch(guild_id)).fetch();
       await guild.channels.fetch();
       const cachedBots = guild.members.cache.filter((m) => m.user.bot).size;
-      return {
-        content: [{
-          type: "text", text: JSON.stringify({
-            name: guild.name, totalMembers: guild.memberCount,
-            humans: guild.memberCount - cachedBots, botsInCache: cachedBots,
-            channels: {
-              total: guild.channels.cache.size,
-              text: guild.channels.cache.filter((c) => c.type === ChannelType.GuildText).size,
-              voice: guild.channels.cache.filter((c) => c.type === ChannelType.GuildVoice).size,
-              categories: guild.channels.cache.filter((c) => c.type === ChannelType.GuildCategory).size,
-            },
-            roles: guild.roles.cache.size - 1,
-            boostLevel: guild.premiumTier, boostCount: guild.premiumSubscriptionCount ?? 0,
-            createdAt: guild.createdAt.toISOString(),
-          }, null, 2),
-        }],
-      };
+      return structured({
+        name: guild.name, totalMembers: guild.memberCount,
+        humans: guild.memberCount - cachedBots, botsInCache: cachedBots,
+        channels: {
+          total: guild.channels.cache.size,
+          text: guild.channels.cache.filter((c) => c.type === ChannelType.GuildText).size,
+          voice: guild.channels.cache.filter((c) => c.type === ChannelType.GuildVoice).size,
+          categories: guild.channels.cache.filter((c) => c.type === ChannelType.GuildCategory).size,
+        },
+        roles: guild.roles.cache.size - 1,
+        boostLevel: guild.premiumTier, boostCount: guild.premiumSubscriptionCount ?? 0,
+        createdAt: guild.createdAt.toISOString(),
+      });
     },
   }),
 ];

--- a/src/tools/types.ts
+++ b/src/tools/types.ts
@@ -13,18 +13,28 @@ export interface ToolAnnotations {
   openWorldHint?: boolean;
 }
 
-/** Schema definition for a single MCP tool, describing its name, purpose, and expected input. */
+/**
+ * Schema definition for a single MCP tool: its name, purpose, and expected input.
+ * `outputSchema` is the JSON Schema (object root) of the tool's `structuredContent`,
+ * present only on tools that return structured output.
+ */
 export interface ToolDefinition {
   name: string;
   description: string;
   inputSchema: Record<string, unknown>;
+  outputSchema?: Record<string, unknown>;
   annotations?: ToolAnnotations;
 }
 
-/** Standard response returned by every tool handler. */
+/**
+ * Standard response returned by every tool handler. `structuredContent` is an
+ * optional machine-readable mirror of the text block, conforming to the tool's
+ * `outputSchema` when one is declared.
+ */
 export interface ToolResult {
   [key: string]: unknown;
   content: { type: string; text: string }[];
+  structuredContent?: Record<string, unknown>;
   isError?: boolean;
 }
 

--- a/src/tools/webhooks.ts
+++ b/src/tools/webhooks.ts
@@ -22,7 +22,13 @@ const tools = [
     name: "discord_create_webhook",
     description:
       "Create a webhook on a channel and return its ID and token. SECURITY: the returned token grants anyone the ability to post as this webhook without authentication — treat it as a secret. Requires the Manage Webhooks permission. Use the returned id+token with discord_send_webhook_message.",
-    annotations: { title: "Create webhook", readOnlyHint: false, destructiveHint: false, idempotentHint: false, openWorldHint: true },
+    annotations: {
+      title: "Create webhook",
+      readOnlyHint: false,
+      destructiveHint: false,
+      idempotentHint: false,
+      openWorldHint: true,
+    },
     schema: z.object({
       channel_id: snowflake.describe("ID (snowflake) of the channel to attach the webhook to."),
       name: z.string().describe("Display name for the webhook (max 80 characters)."),
@@ -30,13 +36,16 @@ const tools = [
     }),
     handle: async ({ channel_id, name, avatar }) => {
       const channel = await discord.channels.fetch(channel_id);
-      if (!channel || !("createWebhook" in channel)) throw new Error("Channel does not support webhooks.");
+      if (!channel || !("createWebhook" in channel))
+        throw new Error("Channel does not support webhooks.");
       const webhook = await channel.createWebhook({ name, avatar: avatar ?? undefined });
       return {
-        content: [{
-          type: "text",
-          text: `✅ Webhook "${webhook.name}" created (id: ${webhook.id}, token: ${webhook.token}).`,
-        }],
+        content: [
+          {
+            type: "text",
+            text: `✅ Webhook "${webhook.name}" created (id: ${webhook.id}, token: ${webhook.token}).`,
+          },
+        ],
       };
     },
   }),
@@ -45,14 +54,36 @@ const tools = [
     name: "discord_send_webhook_message",
     description:
       "Send a message through a webhook using its ID and token (no bot permissions needed — the token authorizes the send). Supports per-message username/avatar overrides and up to 10 embeds. At least one of content or embeds is required. Returns the new message ID.",
-    annotations: { title: "Send webhook message", readOnlyHint: false, destructiveHint: false, idempotentHint: false, openWorldHint: true },
+    annotations: {
+      title: "Send webhook message",
+      readOnlyHint: false,
+      destructiveHint: false,
+      idempotentHint: false,
+      openWorldHint: true,
+    },
     schema: z.object({
       webhook_id: webhookId.describe("ID (snowflake) of the webhook to send through."),
-      webhook_token: webhookToken.describe("Secret token of the webhook (from discord_create_webhook or discord_list_webhooks)."),
-      content: z.string().optional().describe("Plain-text body of the message (max 2000 characters). Optional if embeds are provided."),
-      username: z.string().optional().describe("Override the webhook's default display name for this message."),
-      avatar_url: z.string().optional().describe("Override the webhook's default avatar for this message."),
-      embeds: z.array(embedObjectSchema).optional().describe("Up to 10 embed objects to attach to the webhook message."),
+      webhook_token: webhookToken.describe(
+        "Secret token of the webhook (from discord_create_webhook or discord_list_webhooks).",
+      ),
+      content: z
+        .string()
+        .optional()
+        .describe(
+          "Plain-text body of the message (max 2000 characters). Optional if embeds are provided.",
+        ),
+      username: z
+        .string()
+        .optional()
+        .describe("Override the webhook's default display name for this message."),
+      avatar_url: z
+        .string()
+        .optional()
+        .describe("Override the webhook's default avatar for this message."),
+      embeds: z
+        .array(embedObjectSchema)
+        .optional()
+        .describe("Up to 10 embed objects to attach to the webhook message."),
     }),
     handle: async ({ webhook_id, webhook_token, content, username, avatar_url, embeds }) => {
       if (!webhook_token) throw new Error("webhook_token is required.");
@@ -63,7 +94,8 @@ const tools = [
         if (username) sendOptions.username = username;
         if (avatar_url) sendOptions.avatarURL = avatar_url;
         if (embeds) {
-          if (embeds.length > 10) throw new Error("Discord allows a maximum of 10 embeds per message.");
+          if (embeds.length > 10)
+            throw new Error("Discord allows a maximum of 10 embeds per message.");
           sendOptions.embeds = embeds.map((e) => buildEmbed(e));
         }
         if (!sendOptions.content && !sendOptions.embeds) {
@@ -81,12 +113,20 @@ const tools = [
     name: "discord_edit_webhook",
     description:
       "Update a webhook's name, avatar, or the channel it posts to. Only provided fields change. Requires the Manage Webhooks permission. Returns a confirmation.",
-    annotations: { title: "Edit webhook", readOnlyHint: false, destructiveHint: false, idempotentHint: true, openWorldHint: true },
+    annotations: {
+      title: "Edit webhook",
+      readOnlyHint: false,
+      destructiveHint: false,
+      idempotentHint: true,
+      openWorldHint: true,
+    },
     schema: z.object({
       webhook_id: webhookId.describe("ID (snowflake) of the webhook to edit."),
       name: z.string().optional().describe("New display name for the webhook (max 80 characters)."),
       avatar: z.string().optional().describe("New avatar image URL for the webhook."),
-      channel_id: snowflake.optional().describe("ID (snowflake) of a channel to move the webhook to."),
+      channel_id: snowflake
+        .optional()
+        .describe("ID (snowflake) of a channel to move the webhook to."),
     }),
     handle: async ({ webhook_id, name, avatar, channel_id }) => {
       const webhook = await discord.fetchWebhook(webhook_id);
@@ -95,7 +135,11 @@ const tools = [
       if (avatar !== undefined) editOptions.avatar = avatar;
       if (channel_id !== undefined) editOptions.channel = channel_id;
       await webhook.edit(editOptions);
-      return { content: [{ type: "text", text: `✅ Webhook "${webhook.name}" (id: ${webhook.id}) updated.` }] };
+      return {
+        content: [
+          { type: "text", text: `✅ Webhook "${webhook.name}" (id: ${webhook.id}) updated.` },
+        ],
+      };
     },
   }),
 
@@ -103,7 +147,13 @@ const tools = [
     name: "discord_delete_webhook",
     description:
       "Permanently delete a webhook by its ID, invalidating its token. IRREVERSIBLE — any integrations using the old token will stop working. Requires the Manage Webhooks permission.",
-    annotations: { title: "Delete webhook", readOnlyHint: false, destructiveHint: true, idempotentHint: false, openWorldHint: true },
+    annotations: {
+      title: "Delete webhook",
+      readOnlyHint: false,
+      destructiveHint: true,
+      idempotentHint: false,
+      openWorldHint: true,
+    },
     schema: z.object({
       webhook_id: webhookId.describe("ID (snowflake) of the webhook to delete."),
     }),
@@ -111,7 +161,11 @@ const tools = [
       const webhook = await discord.fetchWebhook(webhook_id);
       const webhookName = webhook.name;
       await webhook.delete();
-      return { content: [{ type: "text", text: `✅ Webhook "${webhookName}" (id: ${webhook_id}) deleted.` }] };
+      return {
+        content: [
+          { type: "text", text: `✅ Webhook "${webhookName}" (id: ${webhook_id}) deleted.` },
+        ],
+      };
     },
   }),
 
@@ -121,14 +175,23 @@ const tools = [
       "List the webhooks in a single channel or across a whole server (id, name, channel, token when visible, creator). Provide exactly one of channel_id or guild_id. Requires the Manage Webhooks permission. Read-only.",
     annotations: { title: "List webhooks", readOnlyHint: true, openWorldHint: true },
     schema: z.object({
-      channel_id: snowflake.optional().describe("ID (snowflake) of a channel to list webhooks for. Mutually exclusive with guild_id."),
-      guild_id: guildId.optional().describe("Discord server (guild) ID (snowflake) to list all webhooks for. Mutually exclusive with channel_id."),
+      channel_id: snowflake
+        .optional()
+        .describe(
+          "ID (snowflake) of a channel to list webhooks for. Mutually exclusive with guild_id.",
+        ),
+      guild_id: guildId
+        .optional()
+        .describe(
+          "Discord server (guild) ID (snowflake) to list all webhooks for. Mutually exclusive with channel_id.",
+        ),
     }),
     outputSchema: z.object({ webhooks: z.array(webhookSummary) }),
     handle: async ({ channel_id, guild_id }) => {
       if (channel_id) {
         const channel = await discord.channels.fetch(channel_id);
-        if (!channel || !("fetchWebhooks" in channel)) throw new Error("Channel does not support webhooks.");
+        if (!channel || !("fetchWebhooks" in channel))
+          throw new Error("Channel does not support webhooks.");
         const webhooks = await channel.fetchWebhooks();
         const result = [...webhooks.values()].map((w) => ({
           id: w.id,
@@ -159,13 +222,25 @@ const tools = [
     name: "discord_edit_webhook_message",
     description:
       "Edit a message previously sent through a webhook, using the webhook's ID and token. Replaces the provided fields. Requires the original webhook token. Returns a confirmation.",
-    annotations: { title: "Edit webhook message", readOnlyHint: false, destructiveHint: false, idempotentHint: true, openWorldHint: true },
+    annotations: {
+      title: "Edit webhook message",
+      readOnlyHint: false,
+      destructiveHint: false,
+      idempotentHint: true,
+      openWorldHint: true,
+    },
     schema: z.object({
       webhook_id: webhookId.describe("ID (snowflake) of the webhook that sent the message."),
       webhook_token: webhookToken.describe("Secret token of the webhook."),
       message_id: messageId.describe("ID of the webhook message to edit."),
-      content: z.string().optional().describe("New plain-text content for the message (max 2000 characters)."),
-      embeds: z.array(embedObjectSchema).optional().describe("Up to 10 embed objects to attach to the webhook message."),
+      content: z
+        .string()
+        .optional()
+        .describe("New plain-text content for the message (max 2000 characters)."),
+      embeds: z
+        .array(embedObjectSchema)
+        .optional()
+        .describe("Up to 10 embed objects to attach to the webhook message."),
     }),
     handle: async ({ webhook_id, webhook_token, message_id, content, embeds }) => {
       if (!webhook_token) throw new Error("webhook_token is required.");
@@ -186,7 +261,13 @@ const tools = [
     name: "discord_delete_webhook_message",
     description:
       "Permanently delete a message that was sent through a webhook, using the webhook's ID and token. IRREVERSIBLE. Requires the original webhook token.",
-    annotations: { title: "Delete webhook message", readOnlyHint: false, destructiveHint: true, idempotentHint: false, openWorldHint: true },
+    annotations: {
+      title: "Delete webhook message",
+      readOnlyHint: false,
+      destructiveHint: true,
+      idempotentHint: false,
+      openWorldHint: true,
+    },
     schema: z.object({
       webhook_id: webhookId.describe("ID (snowflake) of the webhook that sent the message."),
       webhook_token: webhookToken.describe("Secret token of the webhook."),
@@ -218,7 +299,7 @@ const tools = [
       id: z.string(),
       content: z.string(),
       embeds: z.number(),
-      timestamp: z.number(),
+      timestamp: z.string(),
     }),
     handle: async ({ webhook_id, webhook_token, message_id }) => {
       if (!webhook_token) throw new Error("webhook_token is required.");
@@ -226,7 +307,9 @@ const tools = [
       try {
         const msg = await client.fetchMessage(message_id);
         return structured({
-          id: msg.id, content: msg.content, embeds: msg.embeds.length,
+          id: msg.id,
+          content: msg.content,
+          embeds: msg.embeds.length,
           timestamp: msg.timestamp,
         });
       } finally {

--- a/src/tools/webhooks.ts
+++ b/src/tools/webhooks.ts
@@ -2,11 +2,19 @@ import { WebhookClient } from "discord.js";
 import { z } from "zod";
 import { discord } from "../client.js";
 import { buildEmbed, embedObjectSchema } from "../embeds.js";
-import { defineTool, defineModule, snowflake, guildId } from "./define.js";
+import { defineTool, defineModule, snowflake, guildId, structured } from "./define.js";
 
 const webhookId = snowflake.describe("ID (snowflake) of the webhook.");
 const webhookToken = z.string().describe("Secret token of the webhook.");
 const messageId = snowflake.describe("ID of the webhook message.");
+
+const webhookSummary = z.object({
+  id: z.string(),
+  name: z.string().nullable(),
+  channel_id: z.string(),
+  token: z.string().nullable(),
+  creator: z.string().nullable(),
+});
 
 /** Tool definitions for creating, sending via, editing, deleting, and listing webhooks. */
 const tools = [
@@ -116,6 +124,7 @@ const tools = [
       channel_id: snowflake.optional().describe("ID (snowflake) of a channel to list webhooks for. Mutually exclusive with guild_id."),
       guild_id: guildId.optional().describe("Discord server (guild) ID (snowflake) to list all webhooks for. Mutually exclusive with channel_id."),
     }),
+    outputSchema: z.object({ webhooks: z.array(webhookSummary) }),
     handle: async ({ channel_id, guild_id }) => {
       if (channel_id) {
         const channel = await discord.channels.fetch(channel_id);
@@ -128,7 +137,7 @@ const tools = [
           token: w.token ?? null,
           creator: w.owner && "tag" in w.owner ? w.owner.tag : (w.owner?.username ?? null),
         }));
-        return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
+        return structured({ webhooks: result });
       } else if (guild_id) {
         const guild = await discord.guilds.fetch(guild_id);
         const webhooks = await guild.fetchWebhooks();
@@ -139,7 +148,7 @@ const tools = [
           token: w.token ?? null,
           creator: w.owner && "tag" in w.owner ? w.owner.tag : (w.owner?.username ?? null),
         }));
-        return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
+        return structured({ webhooks: result });
       } else {
         throw new Error("Either channel_id or guild_id is required.");
       }
@@ -205,15 +214,21 @@ const tools = [
       webhook_token: webhookToken.describe("Secret token of the webhook."),
       message_id: messageId.describe("ID of the webhook message to fetch."),
     }),
+    outputSchema: z.object({
+      id: z.string(),
+      content: z.string(),
+      embeds: z.number(),
+      timestamp: z.number(),
+    }),
     handle: async ({ webhook_id, webhook_token, message_id }) => {
       if (!webhook_token) throw new Error("webhook_token is required.");
       const client = new WebhookClient({ id: webhook_id, token: webhook_token });
       try {
         const msg = await client.fetchMessage(message_id);
-        return { content: [{ type: "text", text: JSON.stringify({
+        return structured({
           id: msg.id, content: msg.content, embeds: msg.embeds.length,
           timestamp: msg.timestamp,
-        }, null, 2) }] };
+        });
       } finally {
         client.destroy();
       }

--- a/test/define.test.ts
+++ b/test/define.test.ts
@@ -1,7 +1,7 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
-import { ZodError } from "zod";
-import { snowflake } from "../src/tools/define.js";
+import { ZodError, z } from "zod";
+import { snowflake, defineTool, defineModule, structured } from "../src/tools/define.js";
 import messages from "../src/tools/messages.js";
 
 const VALID_ID = "123456789012345678";
@@ -53,4 +53,56 @@ test("handle rejects out-of-range and non-integer numbers before reaching the Di
   await assert.rejects(() => messages.handle("discord_read_messages", { channel_id: VALID_ID, limit: 500 }), ZodError);
   await assert.rejects(() => messages.handle("discord_read_messages", { channel_id: VALID_ID, limit: 0 }), ZodError);
   await assert.rejects(() => messages.handle("discord_read_messages", { channel_id: VALID_ID, limit: 3.7 }), ZodError);
+});
+
+test("structured() mirrors data into both a text block and structuredContent", () => {
+  const res = structured({ items: [{ id: "1" }] });
+  assert.deepEqual(res.structuredContent, { items: [{ id: "1" }] });
+  assert.equal(res.content[0].type, "text");
+  assert.deepEqual(JSON.parse(res.content[0].text), { items: [{ id: "1" }] });
+});
+
+test("outputSchema is derived (object root) and exposed on the definition", () => {
+  const mod = defineModule([
+    defineTool({
+      name: "t_out",
+      description: "x",
+      schema: z.object({}),
+      outputSchema: z.object({ items: z.array(z.object({ id: z.string() })) }),
+      handle: async () => structured({ items: [{ id: "1" }] }),
+    }),
+  ]);
+  const schema = mod.definitions[0].outputSchema as Record<string, unknown>;
+  assert.equal(schema.type, "object");
+  assert.ok(!("$schema" in schema), "$schema must be stripped from outputSchema");
+  assert.ok((schema.properties as Record<string, unknown>).items, "output properties derived from the zod schema");
+});
+
+test("structuredContent conforming to outputSchema is normalised; extra keys are dropped", async () => {
+  const mod = defineModule([
+    defineTool({
+      name: "t_norm",
+      description: "x",
+      schema: z.object({}),
+      outputSchema: z.object({ id: z.string() }),
+      handle: async () => structured({ id: "1", extra: "dropped" }),
+    }),
+  ]);
+  const res = await mod.handle("t_norm", {});
+  assert.deepEqual(res!.structuredContent, { id: "1" });
+});
+
+test("non-conforming structuredContent is left intact instead of throwing", async () => {
+  const mod = defineModule([
+    defineTool({
+      name: "t_bad",
+      description: "x",
+      schema: z.object({}),
+      outputSchema: z.object({ id: z.string() }),
+      handle: async () => structured({ id: 42 }),
+    }),
+  ]);
+  // safeParse fails (id is a number), so the handler still returns the raw data — no throw.
+  const res = await mod.handle("t_bad", {});
+  assert.deepEqual(res!.structuredContent, { id: 42 });
 });


### PR DESCRIPTION
Audit finding #3: read tools returned only free-text JSON, forcing clients/LLMs to re-parse with no schema. All 32 read-only tools now expose a machine-readable `outputSchema` and return `structuredContent`.

## Infra (define.ts / types.ts)
- `defineTool` accepts an optional zod `outputSchema` (a `z.object`). It derives the advertised `outputSchema` via `z.toJSONSchema(schema, {io:"output"})` and **non-fatally** validates the handler's `structuredContent` against it on the way out: conforming output is normalised (unknown keys dropped), non-conforming output is left intact and a warning is logged — a schema bug can never turn a working tool into a runtime error.
- `structured(obj)` helper mirrors data into both the text block and `structuredContent`.
- `ToolDefinition.outputSchema` and `ToolResult.structuredContent` added.

## Design (verified against the SDK source + spec)
- The low-level `Server` (used here) does not enforce outputSchema — only `McpServer.registerTool` does; the spec says SHOULD-conform. Hence the non-fatal validation.
- `outputSchema` must have an object root, so bare-array outputs are wrapped under a descriptive key (e.g. `{ channels: [...] }`); pagination envelopes keep their existing keys.
- `Date` fields are emitted as ISO strings (`z.string()`).

## Verification
- build + lint (0 warnings) + tests (17/17, incl. 4 new infra tests covering derivation, normalisation, and non-throwing drift).
- All 32 read tools carry an outputSchema (32/97). Sample schemas (get_guild_info, list_roles, get_server_stats, list_members, audit_permissions) checked against real Discord data — conform.

## Notes (minor, 2.0)
- Array-returning read tools now wrap their JSON under a named key (text block changes from `[...]` to `{ "key": [...] }`).
- `discord_search_messages` with no matches now returns `{ "matches": [] }` instead of the prose "No messages found…" sentence.

The connected MCP server must be restarted/reconnected to serve the new build before structuredContent is observable live.