### PR TITLE
refactor(tools): O(1) dispatch + precise ToolResult typing (#25, #20)

### DIFF
--- a/src/tools/define.ts
+++ b/src/tools/define.ts
@@ -128,6 +128,10 @@ export function defineModule(tools: RegisteredTool[]): ToolModule {
     inputSchema: t.inputSchema,
     ...(t.outputSchema ? { outputSchema: t.outputSchema } : {}),
   }));
-  const handlers = new Map(tools.map((t) => [t.name, t.run]));
+  const handlers = new Map<string, RegisteredTool["run"]>();
+  for (const t of tools) {
+    if (handlers.has(t.name)) throw new Error(`Duplicate tool name in module: ${t.name}`);
+    handlers.set(t.name, t.run);
+  }
   return { definitions, handlers };
 }

--- a/src/tools/define.ts
+++ b/src/tools/define.ts
@@ -102,12 +102,11 @@ export function defineTool<S extends z.ZodType>(tool: {
 }
 
 /**
- * Assembles a list of {@link defineTool} tools into a {@link ToolModule}, exposing
- * their definitions and routing a call to the matching tool (or `null` if none owns
- * the name, per the module contract). Validation runs inside each tool's `run`.
+ * Assembles a list of {@link defineTool} tools into a {@link ToolModule}: their
+ * client-facing definitions and a name→handler map the registry merges for O(1)
+ * dispatch. Validation runs inside each tool's `run`.
  */
 export function defineModule(tools: RegisteredTool[]): ToolModule {
-  const byName = new Map(tools.map((t) => [t.name, t]));
   const definitions: ToolDefinition[] = tools.map((t) => ({
     name: t.name,
     description: t.description,
@@ -115,11 +114,6 @@ export function defineModule(tools: RegisteredTool[]): ToolModule {
     inputSchema: t.inputSchema,
     ...(t.outputSchema ? { outputSchema: t.outputSchema } : {}),
   }));
-
-  async function handle(name: string, args: Record<string, unknown>): Promise<ToolResult | null> {
-    const tool = byName.get(name);
-    return tool ? tool.run(args) : null;
-  }
-
-  return { definitions, handle };
+  const handlers = new Map(tools.map((t) => [t.name, t.run]));
+  return { definitions, handlers };
 }

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -4,11 +4,11 @@
  *
  * To add a new tool module:
  * 1. Create a new file in this folder (e.g. `onboarding.ts`)
- * 2. Export `definitions` and `handle()` following the ToolModule interface
+ * 2. Build it with `defineModule([...])` and default-export the result
  * 3. Import and add it to the `modules` array below
  */
 
-import type { ToolModule, ToolDefinition, ToolResult } from "./types.js";
+import type { ToolModule, ToolDefinition, ToolHandler, ToolResult } from "./types.js";
 
 import discovery from "./discovery.js";
 import messages from "./messages.js";
@@ -42,6 +42,18 @@ const modules: ToolModule[] = [
   dm,
 ];
 
+/** One O(1) name→handler table merged from every module, built once at load. */
+const registry: Map<string, ToolHandler> = (() => {
+  const map = new Map<string, ToolHandler>();
+  for (const mod of modules) {
+    for (const [name, handler] of mod.handlers) {
+      if (map.has(name)) throw new Error(`Duplicate tool name across modules: ${name}`);
+      map.set(name, handler);
+    }
+  }
+  return map;
+})();
+
 /**
  * Returns every tool definition across all modules.
  * Called once when the MCP client requests the tool list.
@@ -51,16 +63,11 @@ export function getAllDefinitions(): ToolDefinition[] {
 }
 
 /**
- * Routes a tool call to the first module that recognizes the tool name.
- * @param name - The tool name (e.g. "discord_send_message").
- * @param args - The arguments passed by the MCP client.
- * @returns The tool's response.
- * @throws {Error} If no module handles the given tool name.
+ * Routes a tool call to its handler via the merged registry.
+ * @throws {Error} If no tool owns the given name.
  */
 export async function handleTool(name: string, args: Record<string, unknown>): Promise<ToolResult> {
-  for (const mod of modules) {
-    const result = await mod.handle(name, args);
-    if (result) return result;
-  }
-  throw new Error(`Unknown tool: ${name}`);
+  const handler = registry.get(name);
+  if (!handler) throw new Error(`Unknown tool: ${name}`);
+  return handler(args);
 }

--- a/src/tools/types.ts
+++ b/src/tools/types.ts
@@ -27,23 +27,27 @@ export interface ToolDefinition {
 }
 
 /**
- * Standard response returned by every tool handler. `structuredContent` is an
- * optional machine-readable mirror of the text block, conforming to the tool's
- * `outputSchema` when one is declared.
+ * Standard response returned by every tool handler — a subset of the SDK's
+ * `CallToolResult`. Handlers only ever emit text blocks; `structuredContent` is an
+ * optional machine-readable mirror conforming to the tool's `outputSchema` when one
+ * is declared. The index signature mirrors the SDK's passthrough `Result` (which
+ * carries `_meta` and keeps the value assignable to `CallToolResult`).
  */
 export interface ToolResult {
   [key: string]: unknown;
-  content: { type: string; text: string }[];
+  content: { type: "text"; text: string }[];
   structuredContent?: Record<string, unknown>;
   isError?: boolean;
 }
 
+/** Validates and executes a single tool call, returning its result. */
+export type ToolHandler = (args: Record<string, unknown>) => Promise<ToolResult>;
+
 /**
- * Contract every tool module must satisfy.
- * - `definitions`: the tools this module exposes to the MCP client.
- * - `handle()`: attempts to execute a tool by name; returns `null` if the name doesn't belong to this module.
+ * Contract every tool module must satisfy: the tool definitions it exposes to the
+ * client, and a name→handler map the registry merges into one O(1) dispatch table.
  */
 export interface ToolModule {
   definitions: ToolDefinition[];
-  handle(name: string, args: Record<string, unknown>): Promise<ToolResult | null>;
+  handlers: ReadonlyMap<string, ToolHandler>;
 }

--- a/test/define.test.ts
+++ b/test/define.test.ts
@@ -32,11 +32,11 @@ test("field descriptions propagate from .describe() into the inputSchema", () =>
 
 test("handle rejects invalid args before reaching the Discord API", async () => {
   // A malformed channel_id fails zod validation synchronously, with no network call.
-  await assert.rejects(() => messages.handle("discord_read_messages", { channel_id: "bad" }), ZodError);
+  await assert.rejects(() => messages.handlers.get("discord_read_messages")!({ channel_id: "bad" }), ZodError);
 });
 
-test("handle returns null for a tool it does not own", async () => {
-  assert.equal(await messages.handle("discord_not_a_messages_tool", {}), null);
+test("a module exposes no handler for a tool it does not own", () => {
+  assert.equal(messages.handlers.get("discord_not_a_messages_tool"), undefined);
 });
 
 test("bounded integer fields advertise integer + min/max + default in the inputSchema", () => {
@@ -50,9 +50,10 @@ test("bounded integer fields advertise integer + min/max + default in the inputS
 
 test("handle rejects out-of-range and non-integer numbers before reaching the Discord API", async () => {
   // Valid channel_id, but the bound/integer check on limit fails synchronously with no network call.
-  await assert.rejects(() => messages.handle("discord_read_messages", { channel_id: VALID_ID, limit: 500 }), ZodError);
-  await assert.rejects(() => messages.handle("discord_read_messages", { channel_id: VALID_ID, limit: 0 }), ZodError);
-  await assert.rejects(() => messages.handle("discord_read_messages", { channel_id: VALID_ID, limit: 3.7 }), ZodError);
+  const readMessages = messages.handlers.get("discord_read_messages")!;
+  await assert.rejects(() => readMessages({ channel_id: VALID_ID, limit: 500 }), ZodError);
+  await assert.rejects(() => readMessages({ channel_id: VALID_ID, limit: 0 }), ZodError);
+  await assert.rejects(() => readMessages({ channel_id: VALID_ID, limit: 3.7 }), ZodError);
 });
 
 test("structured() mirrors data into both a text block and structuredContent", () => {
@@ -88,8 +89,8 @@ test("structuredContent conforming to outputSchema is normalised; extra keys are
       handle: async () => structured({ id: "1", extra: "dropped" }),
     }),
   ]);
-  const res = await mod.handle("t_norm", {});
-  assert.deepEqual(res!.structuredContent, { id: "1" });
+  const res = await mod.handlers.get("t_norm")!({});
+  assert.deepEqual(res.structuredContent, { id: "1" });
 });
 
 test("non-conforming structuredContent is left intact instead of throwing", async () => {
@@ -103,6 +104,6 @@ test("non-conforming structuredContent is left intact instead of throwing", asyn
     }),
   ]);
   // safeParse fails (id is a number), so the handler still returns the raw data — no throw.
-  const res = await mod.handle("t_bad", {});
-  assert.deepEqual(res!.structuredContent, { id: 42 });
+  const res = await mod.handlers.get("t_bad")!({});
+  assert.deepEqual(res.structuredContent, { id: 42 });
 });

--- a/test/define.test.ts
+++ b/test/define.test.ts
@@ -26,13 +26,17 @@ test("derived inputSchema is a bare object schema with no $schema key", () => {
 
 test("field descriptions propagate from .describe() into the inputSchema", () => {
   const send = messages.definitions.find((d) => d.name === "discord_send_message");
-  const props = (send!.inputSchema as { properties: Record<string, { description?: string }> }).properties;
+  const props = (send!.inputSchema as { properties: Record<string, { description?: string }> })
+    .properties;
   assert.match(props.content.description ?? "", /Plain-text body/);
 });
 
 test("handle rejects invalid args before reaching the Discord API", async () => {
   // A malformed channel_id fails zod validation synchronously, with no network call.
-  await assert.rejects(() => messages.handlers.get("discord_read_messages")!({ channel_id: "bad" }), ZodError);
+  await assert.rejects(
+    () => messages.handlers.get("discord_read_messages")!({ channel_id: "bad" }),
+    ZodError,
+  );
 });
 
 test("a module exposes no handler for a tool it does not own", () => {
@@ -41,7 +45,8 @@ test("a module exposes no handler for a tool it does not own", () => {
 
 test("bounded integer fields advertise integer + min/max + default in the inputSchema", () => {
   const read = messages.definitions.find((d) => d.name === "discord_read_messages");
-  const limit = (read!.inputSchema as { properties: Record<string, Record<string, unknown>> }).properties.limit;
+  const limit = (read!.inputSchema as { properties: Record<string, Record<string, unknown>> })
+    .properties.limit;
   assert.equal(limit.type, "integer");
   assert.equal(limit.minimum, 1);
   assert.equal(limit.maximum, 100);
@@ -76,7 +81,10 @@ test("outputSchema is derived (object root) and exposed on the definition", () =
   const schema = mod.definitions[0].outputSchema as Record<string, unknown>;
   assert.equal(schema.type, "object");
   assert.ok(!("$schema" in schema), "$schema must be stripped from outputSchema");
-  assert.ok((schema.properties as Record<string, unknown>).items, "output properties derived from the zod schema");
+  assert.ok(
+    (schema.properties as Record<string, unknown>).items,
+    "output properties derived from the zod schema",
+  );
 });
 
 test("structuredContent conforming to outputSchema is normalised; extra keys are dropped", async () => {
@@ -106,4 +114,15 @@ test("non-conforming structuredContent is left intact instead of throwing", asyn
   // safeParse fails (id is a number), so the handler still returns the raw data — no throw.
   const res = await mod.handlers.get("t_bad")!({});
   assert.deepEqual(res.structuredContent, { id: 42 });
+});
+
+test("defineModule throws on duplicate tool names within a module", () => {
+  const dup = () =>
+    defineTool({
+      name: "t_dup",
+      description: "x",
+      schema: z.object({}),
+      handle: async () => ({ content: [{ type: "text" as const, text: "ok" }] }),
+    });
+  assert.throws(() => defineModule([dup(), dup()]), /Duplicate tool name in module: t_dup/);
 });


### PR DESCRIPTION
Findings #25 and #20 — internal dispatch and typing cleanup.

- **#25**: `defineModule` now exposes a `name → handler` map; the registry merges all modules into one table and dispatches in O(1), rejecting duplicate tool names at load. Removes the linear module scan and the fragile "`null` = not mine" contract.
- **#20**: `ToolResult.content` is narrowed to the `{ type: "text" }` blocks handlers actually emit. The `[key: string]: unknown` index signature is kept deliberately — it mirrors the SDK's passthrough `Result` and keeps the value assignable to `CallToolResult` (documented in the type).

#32 (`validateId` vs the zod snowflake) was reviewed and intentionally kept as defense-in-depth at the discord.js boundary.

build + lint (0 warnings) + tests (17/17, dispatch tests updated to the handler map) green. Stacked on #38.