### PR TITLE
feat(tools): toolset gating via DISCORD_MCP_TOOLSETS

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,8 +179,11 @@ The server loads `.env` automatically via `dotenv`.
 | `DISCORD_TOKEN` | — | **Required.** Bot token. |
 | `DISCORD_MESSAGE_CONTENT` | `true` | Set to `false` to drop the Message Content privileged intent (use when it isn't enabled in the portal). Message bodies returned by read tools will be empty. |
 | `DISCORD_GUILD_MEMBERS` | `true` | Set to `false` to drop the Server Members privileged intent. Member listing/search tools degrade accordingly. |
+| `DISCORD_MCP_TOOLSETS` | all | Comma-separated list of toolsets to expose, to keep the tool list small. Unset exposes all 97 tools. |
 
 Disabling an intent lets the server connect without that privileged intent enabled in the Developer Portal, avoiding the `4014` startup failure.
+
+**Toolsets** (`DISCORD_MCP_TOOLSETS`): `discovery`, `messages`, `channels`, `permissions`, `members`, `roles`, `moderation`, `screening`, `stats`, `forums`, `webhooks`, `events`, `invites`, `dm`. Example — read-only navigation only: `DISCORD_MCP_TOOLSETS=discovery,messages,members`. Only the listed toolsets' tools are advertised and callable.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -177,18 +177,18 @@ The server loads `.env` automatically via `dotenv`.
 
 ### Environment variables
 
-| Variable                  | Default | Description                                                                                      |
-| ------------------------- | ------- | ------------------------------------------------------------------------------------------------ |
-| `DISCORD_TOKEN`           | —       | **Required.** Bot token.                                                                         |
-| `DISCORD_MESSAGE_CONTENT` | `true`  | Set to `false` to stop requesting the Message Content privileged gateway intent at connect time. |
-| `DISCORD_GUILD_MEMBERS`   | `true`  | Set to `false` to stop requesting the Server Members privileged gateway intent at connect time.  |
+| Variable                  | Default | Description                                                                                                 |
+| ------------------------- | ------- | ----------------------------------------------------------------------------------------------------------- |
+| `DISCORD_TOKEN`           | —       | **Required.** Bot token.                                                                                    |
+| `DISCORD_MESSAGE_CONTENT` | `true`  | Set to `false` to stop requesting the Message Content privileged gateway intent at connect time.            |
+| `DISCORD_GUILD_MEMBERS`   | `true`  | Set to `false` to stop requesting the Server Members privileged gateway intent at connect time.             |
 | `DISCORD_MCP_TOOLSETS`    | `all`   | Comma-separated list of toolsets to expose, to keep the tool list small. Unset or `all` exposes every tool. |
 
 These flags only control which gateway intents the server requests when identifying. Requesting a privileged intent that is **not** enabled in the Developer Portal makes the connection fail at startup (close code `4014`) — set the flag to `false` to connect anyway.
 
 Data access is governed by the **portal toggles**, not by these flags: this server reads everything over the REST API, which Discord gates on the portal setting alone. So with the portal toggles on, setting these flags to `false` loses nothing. With a portal toggle **off**, the corresponding data is restricted regardless of the flags: message bodies come back empty (`content`, `embeds`, `attachments`) and member listing fails — enable the toggle in the portal to restore it.
 
-**Toolsets** (`DISCORD_MCP_TOOLSETS`): `discovery`, `messages`, `channels`, `permissions`, `members`, `roles`, `moderation`, `screening`, `stats`, `forums`, `webhooks`, `events`, `invites`, `dm`. Example — read-only navigation only: `DISCORD_MCP_TOOLSETS=discovery,messages,members`. Only the listed toolsets' tools are advertised and callable.
+**Toolsets** (`DISCORD_MCP_TOOLSETS`): `discovery`, `messages`, `channels`, `permissions`, `members`, `roles`, `moderation`, `screening`, `stats`, `forums`, `webhooks`, `scheduled_events`, `invites`, `dm`. Example — read-only navigation only: `DISCORD_MCP_TOOLSETS=discovery,messages,members`. Only the listed toolsets' tools are advertised and callable. Unknown names make the server fail at startup instead of silently exposing everything.
 
 ---
 

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -38,30 +38,36 @@ const allToolsets: Record<string, ToolModule> = {
   stats,
   forums,
   webhooks,
-  events: scheduledEvents,
+  scheduled_events: scheduledEvents,
   invites,
   dm,
 };
 
 /**
- * Selects which toolsets to expose from `DISCORD_MCP_TOOLSETS` (comma-separated
- * names). Unset or empty exposes all 97 tools; unknown names are warned and skipped;
- * if nothing valid is selected it falls back to all so the server is never toolless.
+ * Selects which toolsets to expose from `DISCORD_MCP_TOOLSETS` (comma-separated,
+ * case-insensitive; `all` or unset exposes everything). Unknown or empty selections
+ * throw at startup: a typo must not silently expose the full destructive surface.
  */
 function selectModules(): ToolModule[] {
   const raw = process.env.DISCORD_MCP_TOOLSETS?.trim();
   if (!raw) return Object.values(allToolsets);
-  const selected = raw
-    .split(",")
-    .map((name) => name.trim())
-    .filter(Boolean)
-    .map((name) => {
-      const mod = allToolsets[name];
-      if (!mod) console.error(`Unknown toolset in DISCORD_MCP_TOOLSETS: "${name}" (known: ${Object.keys(allToolsets).join(", ")}).`);
-      return mod;
-    })
-    .filter((mod): mod is ToolModule => mod !== undefined);
-  return selected.length > 0 ? selected : Object.values(allToolsets);
+  const names = [
+    ...new Set(
+      raw
+        .split(",")
+        .map((n) => n.trim().toLowerCase())
+        .filter(Boolean),
+    ),
+  ];
+  if (names.includes("all")) return Object.values(allToolsets);
+  const unknown = names.filter((n) => !(n in allToolsets));
+  if (unknown.length > 0 || names.length === 0) {
+    throw new Error(
+      `Invalid DISCORD_MCP_TOOLSETS: unknown toolset(s) ${unknown.map((n) => `"${n}"`).join(", ") || "(none selected)"}. ` +
+        `Known: all, ${Object.keys(allToolsets).join(", ")}.`,
+    );
+  }
+  return names.map((n) => allToolsets[n]);
 }
 
 const modules: ToolModule[] = selectModules();

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -5,7 +5,7 @@
  * To add a new tool module:
  * 1. Create a new file in this folder (e.g. `onboarding.ts`)
  * 2. Build it with `defineModule([...])` and default-export the result
- * 3. Import and add it to the `modules` array below
+ * 3. Import and add it to `allToolsets` below (the key is its `DISCORD_MCP_TOOLSETS` name)
  */
 
 import type { ToolModule, ToolDefinition, ToolHandler, ToolResult } from "./types.js";
@@ -25,7 +25,8 @@ import scheduledEvents from "./scheduledEvents.js";
 import invites from "./invites.js";
 import dm from "./dm.js";
 
-const modules: ToolModule[] = [
+/** Every toolset, keyed by the name used in the `DISCORD_MCP_TOOLSETS` env var. */
+const allToolsets: Record<string, ToolModule> = {
   discovery,
   messages,
   channels,
@@ -37,10 +38,33 @@ const modules: ToolModule[] = [
   stats,
   forums,
   webhooks,
-  scheduledEvents,
+  events: scheduledEvents,
   invites,
   dm,
-];
+};
+
+/**
+ * Selects which toolsets to expose from `DISCORD_MCP_TOOLSETS` (comma-separated
+ * names). Unset or empty exposes all 97 tools; unknown names are warned and skipped;
+ * if nothing valid is selected it falls back to all so the server is never toolless.
+ */
+function selectModules(): ToolModule[] {
+  const raw = process.env.DISCORD_MCP_TOOLSETS?.trim();
+  if (!raw) return Object.values(allToolsets);
+  const selected = raw
+    .split(",")
+    .map((name) => name.trim())
+    .filter(Boolean)
+    .map((name) => {
+      const mod = allToolsets[name];
+      if (!mod) console.error(`Unknown toolset in DISCORD_MCP_TOOLSETS: "${name}" (known: ${Object.keys(allToolsets).join(", ")}).`);
+      return mod;
+    })
+    .filter((mod): mod is ToolModule => mod !== undefined);
+  return selected.length > 0 ? selected : Object.values(allToolsets);
+}
+
+const modules: ToolModule[] = selectModules();
 
 /** One O(1) name→handler table merged from every module, built once at load. */
 const registry: Map<string, ToolHandler> = (() => {


### PR DESCRIPTION
Audit chantier — `getAllDefinitions()` returned all 97 tools, bloating the client's context. The registry now exposes only the selected toolsets.

- `DISCORD_MCP_TOOLSETS` (comma-separated, module-named groups: `discovery`, `messages`, `channels`, `permissions`, `members`, `roles`, `moderation`, `screening`, `stats`, `forums`, `webhooks`, `events`, `invites`, `dm`).
- Unset = all 97 tools (no behaviour change). Unknown names warn and are skipped; an all-invalid selection falls back to all so the server is never toolless.
- Disabled toolsets are neither advertised (`tools/list`) nor callable. README documents the flag and names.

build + lint (0 warnings) + tests (17/17) green; verified `discovery,messages` exposes 22 tools. Stacked on #40.