### PR TITLE
feat(tools): mass-op safety — dry_run + guild allow-list

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,6 +180,7 @@ The server loads `.env` automatically via `dotenv`.
 | `DISCORD_MESSAGE_CONTENT` | `true` | Set to `false` to drop the Message Content privileged intent (use when it isn't enabled in the portal). Message bodies returned by read tools will be empty. |
 | `DISCORD_GUILD_MEMBERS` | `true` | Set to `false` to drop the Server Members privileged intent. Member listing/search tools degrade accordingly. |
 | `DISCORD_MCP_TOOLSETS` | all | Comma-separated list of toolsets to expose, to keep the tool list small. Unset exposes all 97 tools. |
+| `DISCORD_ALLOWED_GUILDS` | all | Comma-separated guild IDs the server may act on. When set, any guild-scoped tool call targeting another guild is rejected. |
 
 Disabling an intent lets the server connect without that privileged intent enabled in the Developer Portal, avoiding the `4014` startup failure.
 
@@ -442,8 +443,8 @@ discord-mcp/
 ### Adding a new tool
 
 1. Create a new file in `src/tools/` (e.g. `events.ts`)
-2. Export `definitions` (tool schemas) and `handle()` (tool logic)
-3. Import and add it to the `modules` array in `src/tools/index.ts`
+2. Declare each tool with `defineTool({ name, description, annotations, schema, handle })` and export `defineModule([...])` as the default
+3. Import it and add it to `allToolsets` in `src/tools/index.ts` (the key is its `DISCORD_MCP_TOOLSETS` name)
 
 ---
 
@@ -452,6 +453,8 @@ discord-mcp/
 - Never commit your Discord token to Git
 - Use environment variables or a `.env` file (not versioned)
 - Give the bot only the permissions it needs
+- Restrict the server to specific servers with `DISCORD_ALLOWED_GUILDS`
+- Irreversible mass actions (`bulk_ban`, `prune_members`, `bulk_delete_messages`, `delete_channel`) default to a `dry_run` preview — pass `dry_run:false` to apply
 
 ---
 

--- a/src/client.ts
+++ b/src/client.ts
@@ -100,6 +100,35 @@ export async function ensureConnected(): Promise<void> {
   await loginPromise;
 }
 
+/** Reads DISCORD_ALLOWED_GUILDS lazily so module import order cannot freeze an empty list. */
+function allowedGuilds(): string[] {
+  return (process.env.DISCORD_ALLOWED_GUILDS ?? "")
+    .split(",")
+    .map((id) => id.trim())
+    .filter(Boolean);
+}
+
+export function isGuildAllowed(guildId: string): boolean {
+  const list = allowedGuilds();
+  return list.length === 0 || list.includes(guildId);
+}
+
+/**
+ * Central allow-list gate for resources reached without a guild_id input
+ * (channel/thread/webhook IDs resolve to a guild only after fetching).
+ */
+export function assertAllowedGuild(guildId: string | null | undefined): void {
+  if (guildId && !isGuildAllowed(guildId))
+    throw new Error(`Guild ${guildId} is not in the DISCORD_ALLOWED_GUILDS allow-list.`);
+}
+
+/** Fetches a channel and enforces the guild allow-list before returning it. */
+export async function fetchChannelChecked(channelId: string) {
+  const channel = await discord.channels.fetch(channelId);
+  if (channel && "guildId" in channel) assertAllowedGuild(channel.guildId);
+  return channel;
+}
+
 /**
  * Fetches a channel by ID and guarantees it is a text-capable guild channel
  * (a TextChannel or any thread inside one — announcement / public / private / forum).
@@ -111,7 +140,7 @@ export async function ensureConnected(): Promise<void> {
  */
 export async function getTextChannel(channelId: string): Promise<TextChannel | ThreadChannel> {
   const id = validateId(channelId, "channel_id");
-  const channel = await discord.channels.fetch(id);
+  const channel = await fetchChannelChecked(id);
   if (!channel || (!(channel instanceof TextChannel) && !(channel instanceof ThreadChannel)))
     throw new Error(`Channel ${id} is not a text or thread channel or doesn't exist.`);
   return channel;
@@ -125,7 +154,7 @@ export async function getTextChannel(channelId: string): Promise<TextChannel | T
  */
 export async function getGuildChannel(channelId: string): Promise<GuildChannel> {
   const id = validateId(channelId, "channel_id");
-  const channel = await discord.channels.fetch(id);
+  const channel = await fetchChannelChecked(id);
   if (!channel || !(channel instanceof GuildChannel))
     throw new Error(`Channel ${id} is not a guild channel or doesn't exist.`);
   return channel;

--- a/src/tools/channels.ts
+++ b/src/tools/channels.ts
@@ -1,6 +1,6 @@
 import { ChannelType, NewsChannel } from "discord.js";
 import { z } from "zod";
-import { discord, getGuildChannel } from "../client.js";
+import { discord, getGuildChannel, fetchChannelChecked } from "../client.js";
 import { defineTool, defineModule, snowflake, guildId, intIn } from "./define.js";
 
 /** Tool definitions for creating, deleting, editing, moving, and cloning channels. */
@@ -39,13 +39,13 @@ const tools = [
     schema: z.object({
       channel_id: snowflake.describe("ID (snowflake) of the channel to delete."),
       reason: z.string().optional().describe("Optional reason recorded in the server audit log."),
-      dry_run: z.boolean().optional().describe("If true (default), only reports which channel would be deleted without deleting it. Set false to actually delete."),
+      dry_run: z.boolean().default(true).describe("If true (default), only reports which channel would be deleted without deleting it. Set false to actually delete."),
     }),
     handle: async ({ channel_id, reason, dry_run }) => {
-      const channel = await discord.channels.fetch(channel_id);
+      const channel = await fetchChannelChecked(channel_id);
       if (!channel) throw new Error("Channel not found.");
       const channelName = "name" in channel ? channel.name : channel.id;
-      if (dry_run !== false) {
+      if (dry_run) {
         return { content: [{ type: "text", text: `🔍 Dry run: channel #${channelName} would be deleted. Re-call with dry_run:false to delete.` }] };
       }
       await channel.delete(reason);
@@ -130,7 +130,7 @@ const tools = [
       target_channel_id: snowflake.describe("ID (snowflake) of the channel that will receive published messages."),
     }),
     handle: async ({ source_channel_id, target_channel_id }) => {
-      const source = await discord.channels.fetch(source_channel_id);
+      const source = await fetchChannelChecked(source_channel_id);
       if (!source || !(source instanceof NewsChannel)) throw new Error("Source channel is not an announcement channel.");
       await source.addFollower(target_channel_id);
       return { content: [{ type: "text", text: `✅ Now following announcement channel in target channel.` }] };

--- a/src/tools/channels.ts
+++ b/src/tools/channels.ts
@@ -34,16 +34,20 @@ const tools = [
   defineTool({
     name: "discord_delete_channel",
     description:
-      "Permanently delete a channel and all of its messages. IRREVERSIBLE. Requires the Manage Channels permission. An optional reason is recorded in the audit log. Returns a confirmation.",
+      "Permanently delete a channel and all of its messages. IRREVERSIBLE. SAFE BY DEFAULT: dry_run is true unless explicitly set to false, so call it first to preview, then re-call with dry_run:false to actually delete. Requires the Manage Channels permission. An optional reason is recorded in the audit log.",
     annotations: { title: "Delete channel", readOnlyHint: false, destructiveHint: true, idempotentHint: false, openWorldHint: true },
     schema: z.object({
       channel_id: snowflake.describe("ID (snowflake) of the channel to delete."),
       reason: z.string().optional().describe("Optional reason recorded in the server audit log."),
+      dry_run: z.boolean().optional().describe("If true (default), only reports which channel would be deleted without deleting it. Set false to actually delete."),
     }),
-    handle: async ({ channel_id, reason }) => {
+    handle: async ({ channel_id, reason, dry_run }) => {
       const channel = await discord.channels.fetch(channel_id);
       if (!channel) throw new Error("Channel not found.");
       const channelName = "name" in channel ? channel.name : channel.id;
+      if (dry_run !== false) {
+        return { content: [{ type: "text", text: `🔍 Dry run: channel #${channelName} would be deleted. Re-call with dry_run:false to delete.` }] };
+      }
       await channel.delete(reason);
       return { content: [{ type: "text", text: `✅ Channel #${channelName} deleted.` }] };
     },

--- a/src/tools/define.ts
+++ b/src/tools/define.ts
@@ -1,4 +1,5 @@
 import { z } from "zod";
+import { isGuildAllowed } from "../client.js";
 import type { ToolModule, ToolDefinition, ToolResult, ToolAnnotations } from "./types.js";
 
 /** A Discord snowflake ID: a 17–20 digit string. Reused by every tool that takes an ID. */
@@ -6,18 +7,12 @@ export const snowflake = z
   .string()
   .regex(/^\d{17,20}$/, "Must be a Discord snowflake ID (17-20 digits).");
 
-/** Guild IDs the server may act on, from `DISCORD_ALLOWED_GUILDS` (empty = no restriction). */
-const allowedGuilds = (process.env.DISCORD_ALLOWED_GUILDS ?? "")
-  .split(",")
-  .map((id) => id.trim())
-  .filter(Boolean);
-
 /**
  * The `guild_id` field, identical across nearly every guild-scoped tool. When
  * `DISCORD_ALLOWED_GUILDS` is set, ids outside the allow-list are rejected at parse time.
  */
 export const guildId = snowflake
-  .refine((id) => allowedGuilds.length === 0 || allowedGuilds.includes(id), "guild_id is not in the DISCORD_ALLOWED_GUILDS allow-list.")
+  .refine(isGuildAllowed, "guild_id is not in the DISCORD_ALLOWED_GUILDS allow-list.")
   .describe("Discord server (guild) ID (snowflake).");
 
 /**

--- a/src/tools/define.ts
+++ b/src/tools/define.ts
@@ -6,8 +6,19 @@ export const snowflake = z
   .string()
   .regex(/^\d{17,20}$/, "Must be a Discord snowflake ID (17-20 digits).");
 
-/** The `guild_id` field, identical across nearly every guild-scoped tool. */
-export const guildId = snowflake.describe("Discord server (guild) ID (snowflake).");
+/** Guild IDs the server may act on, from `DISCORD_ALLOWED_GUILDS` (empty = no restriction). */
+const allowedGuilds = (process.env.DISCORD_ALLOWED_GUILDS ?? "")
+  .split(",")
+  .map((id) => id.trim())
+  .filter(Boolean);
+
+/**
+ * The `guild_id` field, identical across nearly every guild-scoped tool. When
+ * `DISCORD_ALLOWED_GUILDS` is set, ids outside the allow-list are rejected at parse time.
+ */
+export const guildId = snowflake
+  .refine((id) => allowedGuilds.length === 0 || allowedGuilds.includes(id), "guild_id is not in the DISCORD_ALLOWED_GUILDS allow-list.")
+  .describe("Discord server (guild) ID (snowflake).");
 
 /**
  * A bounded integer field: rejects non-integers and out-of-range values at parse

--- a/src/tools/forums.ts
+++ b/src/tools/forums.ts
@@ -1,6 +1,6 @@
 import { ChannelType, ForumChannel, ThreadChannel } from "discord.js";
 import { z } from "zod";
-import { discord } from "../client.js";
+import { discord, fetchChannelChecked } from "../client.js";
 import { defineTool, defineModule, snowflake, guildId, intIn, structured } from "./define.js";
 
 const threadId = snowflake.describe("ID (snowflake) of the forum post (thread).");
@@ -20,7 +20,7 @@ const threadSummary = z.object({
  * Fetches a channel by ID and guarantees it is a forum channel.
  */
 async function getForumChannel(channelId: string): Promise<ForumChannel> {
-  const channel = await discord.channels.fetch(channelId);
+  const channel = await fetchChannelChecked(channelId);
   if (!channel || channel.type !== ChannelType.GuildForum)
     throw new Error(`Channel ${channelId} is not a forum channel or doesn't exist.`);
   return channel as ForumChannel;
@@ -30,7 +30,7 @@ async function getForumChannel(channelId: string): Promise<ForumChannel> {
  * Fetches a channel by ID and guarantees it is a thread channel.
  */
 async function getThreadChannel(id: string): Promise<ThreadChannel> {
-  const channel = await discord.channels.fetch(id);
+  const channel = await fetchChannelChecked(id);
   if (!channel || !channel.isThread())
     throw new Error(`Channel ${id} is not a thread or doesn't exist.`);
   return channel as ThreadChannel;

--- a/src/tools/invites.ts
+++ b/src/tools/invites.ts
@@ -1,5 +1,5 @@
 import { z } from "zod";
-import { discord } from "../client.js";
+import { discord, fetchChannelChecked } from "../client.js";
 import { defineTool, defineModule, snowflake, guildId, intIn, structured } from "./define.js";
 
 // ─── Helpers ────────────────────────────────────────────────────────────────────
@@ -90,7 +90,7 @@ const tools = [
       temporary: z.boolean().optional().describe("If true, members who join via this invite are removed when they disconnect (unless they get a role). Default false."),
     }),
     handle: async ({ channel_id, max_age, max_uses, unique, temporary }) => {
-      const channel = await discord.channels.fetch(channel_id);
+      const channel = await fetchChannelChecked(channel_id);
       if (!channel || !("createInvite" in channel)) {
         throw new Error(`Channel ${channel_id} does not support invites.`);
       }
@@ -136,7 +136,7 @@ const tools = [
       invites: z.array(inviteSummary),
     }),
     handle: async ({ channel_id }) => {
-      const channel = await discord.channels.fetch(channel_id);
+      const channel = await fetchChannelChecked(channel_id);
       if (!channel || !("fetchInvites" in channel)) {
         throw new Error(`Channel ${channel_id} does not support invites.`);
       }

--- a/src/tools/members.ts
+++ b/src/tools/members.ts
@@ -231,13 +231,13 @@ const tools = [
       guild_id: guildId,
       user_ids: z.array(snowflake).describe("Array of user IDs (snowflakes) to ban."),
       delete_message_seconds: intIn(0, 604800).default(0).describe("Also delete each user's messages from the last N seconds (0–604800, i.e. up to 7 days). Default 0."),
-      dry_run: z.boolean().optional().describe("If true (default), only returns the user IDs that would be banned without banning anyone. Set false to actually ban."),
+      dry_run: z.boolean().default(true).describe("If true (default), only returns the user IDs that would be banned without banning anyone. Set false to actually ban."),
       reason: z.string().optional().describe("Optional reason recorded in the server audit log."),
     }),
     handle: async ({ guild_id, user_ids, delete_message_seconds, dry_run, reason }) => {
       const guild = await discord.guilds.fetch(guild_id);
       if (user_ids.length === 0) throw new Error("user_ids must be a non-empty array.");
-      if (dry_run !== false) {
+      if (dry_run) {
         return { content: [{ type: "text", text: `🔍 Dry run: ${user_ids.length} users would be banned:\n${JSON.stringify(user_ids, null, 2)}` }] };
       }
       const result = await guild.members.bulkBan(user_ids, {
@@ -256,19 +256,18 @@ const tools = [
       guild_id: guildId,
       days: intIn(1, 30).describe("Inactivity threshold in days (1–30)."),
       roles: z.array(snowflake).optional().describe("Optional role IDs (snowflakes) to include; by default only members with no roles are counted."),
-      dry_run: z.boolean().optional().describe("If true (default), only returns the count that would be pruned without removing anyone. Set false to actually prune."),
+      dry_run: z.boolean().default(true).describe("If true (default), only returns the count that would be pruned without removing anyone. Set false to actually prune."),
       reason: z.string().optional().describe("Optional reason recorded in the server audit log."),
     }),
     handle: async ({ guild_id, days, roles, dry_run, reason }) => {
       const guild = await discord.guilds.fetch(guild_id);
-      const dryRun = dry_run !== false;
       const pruned = await guild.members.prune({
         days,
-        dry: dryRun,
+        dry: dry_run,
         roles: roles ?? undefined,
         reason,
       });
-      return { content: [{ type: "text", text: dryRun ? `🔍 Dry run: ${pruned} members would be pruned (${days} days inactive).` : `✅ ${pruned} members pruned (${days} days inactive).` }] };
+      return { content: [{ type: "text", text: dry_run ? `🔍 Dry run: ${pruned} members would be pruned (${days} days inactive).` : `✅ ${pruned} members pruned (${days} days inactive).` }] };
     },
   }),
 ];

--- a/src/tools/messages.ts
+++ b/src/tools/messages.ts
@@ -159,14 +159,18 @@ const tools = [
   defineTool({
     name: "discord_bulk_delete_messages",
     description:
-      "Permanently delete multiple recent messages in one call. IRREVERSIBLE. Discord only allows bulk-deleting messages younger than 14 days; older ones are skipped. Requires the Manage Messages permission. Use discord_delete_message to remove a single specific message. Returns the number actually deleted.",
+      "Permanently delete multiple recent messages in one call. IRREVERSIBLE. SAFE BY DEFAULT: dry_run is true unless explicitly set to false, so call it first to preview, then re-call with dry_run:false to actually delete. Discord only allows bulk-deleting messages younger than 14 days; older ones are skipped. Requires the Manage Messages permission. Returns the number deleted.",
     annotations: { title: "Bulk delete messages", readOnlyHint: false, destructiveHint: true, idempotentHint: false, openWorldHint: true },
     schema: z.object({
       channel_id: snowflake.describe("ID (snowflake) of the channel or thread to delete messages from."),
       count: intIn(2, MAX_FETCH_LIMIT).describe("Number of recent messages to delete (2–100)."),
+      dry_run: z.boolean().optional().describe("If true (default), only reports how many would be deleted without deleting. Set false to actually delete."),
     }),
-    handle: async ({ channel_id, count }) => {
+    handle: async ({ channel_id, count, dry_run }) => {
       const channel = await getTextChannel(channel_id);
+      if (dry_run !== false) {
+        return { content: [{ type: "text", text: `🔍 Dry run: up to ${count} recent messages would be deleted in #${channel.name} (those under 14 days old). Re-call with dry_run:false to delete.` }] };
+      }
       const deleted = await channel.bulkDelete(count, true);
       return { content: [{ type: "text", text: `✅ Deleted ${deleted.size} messages in #${channel.name}.` }] };
     },

--- a/src/tools/messages.ts
+++ b/src/tools/messages.ts
@@ -164,12 +164,15 @@ const tools = [
     schema: z.object({
       channel_id: snowflake.describe("ID (snowflake) of the channel or thread to delete messages from."),
       count: intIn(2, MAX_FETCH_LIMIT).describe("Number of recent messages to delete (2–100)."),
-      dry_run: z.boolean().optional().describe("If true (default), only reports how many would be deleted without deleting. Set false to actually delete."),
+      dry_run: z.boolean().default(true).describe("If true (default), only reports how many would be deleted without deleting. Set false to actually delete."),
     }),
     handle: async ({ channel_id, count, dry_run }) => {
       const channel = await getTextChannel(channel_id);
-      if (dry_run !== false) {
-        return { content: [{ type: "text", text: `🔍 Dry run: up to ${count} recent messages would be deleted in #${channel.name} (those under 14 days old). Re-call with dry_run:false to delete.` }] };
+      if (dry_run) {
+        const recent = await channel.messages.fetch({ limit: count, cache: false });
+        const cutoff = Date.now() - 14 * 24 * 60 * 60 * 1000;
+        const deletable = recent.filter((m) => m.createdTimestamp > cutoff).size;
+        return { content: [{ type: "text", text: `🔍 Dry run: ${deletable} of the ${recent.size} most recent messages in #${channel.name} would be deleted (${recent.size - deletable} older than 14 days are skipped). Re-call with dry_run:false to delete.` }] };
       }
       const deleted = await channel.bulkDelete(count, true);
       return { content: [{ type: "text", text: `✅ Deleted ${deleted.size} messages in #${channel.name}.` }] };

--- a/src/tools/webhooks.ts
+++ b/src/tools/webhooks.ts
@@ -1,6 +1,6 @@
 import { WebhookClient } from "discord.js";
 import { z } from "zod";
-import { discord } from "../client.js";
+import { discord, fetchChannelChecked, assertAllowedGuild } from "../client.js";
 import { buildEmbed, embedObjectSchema } from "../embeds.js";
 import { defineTool, defineModule, snowflake, guildId, httpUrl, structured } from "./define.js";
 
@@ -35,7 +35,7 @@ const tools = [
       avatar: httpUrl.optional().describe("Optional avatar image URL for the webhook."),
     }),
     handle: async ({ channel_id, name, avatar }) => {
-      const channel = await discord.channels.fetch(channel_id);
+      const channel = await fetchChannelChecked(channel_id);
       if (!channel || !("createWebhook" in channel))
         throw new Error("Channel does not support webhooks.");
       const webhook = await channel.createWebhook({ name, avatar: avatar ?? undefined });
@@ -129,6 +129,7 @@ const tools = [
     }),
     handle: async ({ webhook_id, name, avatar, channel_id }) => {
       const webhook = await discord.fetchWebhook(webhook_id);
+      assertAllowedGuild(webhook.guildId);
       const editOptions: Record<string, unknown> = {};
       if (name !== undefined) editOptions.name = name;
       if (avatar !== undefined) editOptions.avatar = avatar;
@@ -158,6 +159,7 @@ const tools = [
     }),
     handle: async ({ webhook_id }) => {
       const webhook = await discord.fetchWebhook(webhook_id);
+      assertAllowedGuild(webhook.guildId);
       const webhookName = webhook.name;
       await webhook.delete();
       return {
@@ -188,7 +190,7 @@ const tools = [
     outputSchema: z.object({ webhooks: z.array(webhookSummary) }),
     handle: async ({ channel_id, guild_id }) => {
       if (channel_id) {
-        const channel = await discord.channels.fetch(channel_id);
+        const channel = await fetchChannelChecked(channel_id);
         if (!channel || !("fetchWebhooks" in channel))
           throw new Error("Channel does not support webhooks.");
         const webhooks = await channel.fetchWebhooks();

--- a/test/define.test.ts
+++ b/test/define.test.ts
@@ -1,7 +1,7 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
 import { ZodError, z } from "zod";
-import { snowflake, defineTool, defineModule, structured } from "../src/tools/define.js";
+import { snowflake, guildId, defineTool, defineModule, structured } from "../src/tools/define.js";
 import messages from "../src/tools/messages.js";
 
 const VALID_ID = "123456789012345678";
@@ -125,4 +125,15 @@ test("defineModule throws on duplicate tool names within a module", () => {
       handle: async () => ({ content: [{ type: "text" as const, text: "ok" }] }),
     });
   assert.throws(() => defineModule([dup(), dup()]), /Duplicate tool name in module: t_dup/);
+});
+
+test("guildId enforces DISCORD_ALLOWED_GUILDS lazily", () => {
+  process.env.DISCORD_ALLOWED_GUILDS = "111111111111111111";
+  try {
+    assert.ok(guildId.safeParse("111111111111111111").success);
+    assert.ok(!guildId.safeParse("222222222222222222").success);
+  } finally {
+    delete process.env.DISCORD_ALLOWED_GUILDS;
+  }
+  assert.ok(guildId.safeParse("222222222222222222").success, "no restriction when unset");
 });


### PR DESCRIPTION
Audit chantier "garde-fous ops de masse".

- `bulk_delete_messages` and `delete_channel` gain a `dry_run` flag defaulting to **true** (preview), matching the existing `bulk_ban`/`prune_members` safe-by-default pattern. Pass `dry_run:false` to actually act.
- `DISCORD_ALLOWED_GUILDS` (comma-separated guild IDs): when set, the shared `guildId` schema rejects any guild-scoped call targeting another guild at parse time. Empty = no restriction. Covers all guild-scoped tools centrally via the one shared field; the input JSON Schema (snowflake pattern) is unchanged.
- README env table + Security section updated; stale "Adding a new tool" steps fixed to the current `defineTool`/`defineModule`/`allToolsets` flow.

build + lint (0 warnings) + tests (17/17) green; allow-list verified (allowed parses, disallowed rejected, schema pattern preserved). Stacked on #41.