### PR TITLE
chore: add MCP Registry metadata and bump to 1.7.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@pasympa/discord-mcp",
-  "version": "1.7.0",
+  "version": "1.7.1",
+  "mcpName": "io.github.pasympa/discord-mcp",
   "description": "A lightweight, multi-guild Discord MCP server with 95+ tools",
   "main": "dist/index.js",
   "type": "commonjs",

--- a/server.json
+++ b/server.json
@@ -1,0 +1,29 @@
+{
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+  "name": "io.github.pasympa/discord-mcp",
+  "description": "A lightweight, multi-guild Discord MCP server with 95+ tools",
+  "repository": {
+    "url": "https://github.com/PaSympa/discord-mcp",
+    "source": "github"
+  },
+  "version": "1.7.1",
+  "packages": [
+    {
+      "registryType": "npm",
+      "identifier": "@pasympa/discord-mcp",
+      "version": "1.7.1",
+      "transport": {
+        "type": "stdio"
+      },
+      "environmentVariables": [
+        {
+          "name": "DISCORD_TOKEN",
+          "description": "Discord bot token",
+          "isRequired": true,
+          "isSecret": true,
+          "format": "string"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
Prepares publication to the official MCP Registry (registry.modelcontextprotocol.io), which the GitHub MCP Registry (github.com/mcp) ingests automatically.

- Add `mcpName: io.github.pasympa/discord-mcp` to package.json (required ownership-verification marker for npm packages)
- Add `server.json` registry manifest (npm package, stdio transport, DISCORD_TOKEN env var)
- Bump version to 1.7.1 so the published npm tarball contains `mcpName`

After merge, publishing requires:
1. `npm publish --access public` (1.7.1)
2. `mcp-publisher login github` (device-code flow)
3. `mcp-publisher publish`