### PR TITLE
chore(release): align 1.7.1 everywhere and automate MCP Registry publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,6 +16,15 @@ jobs:
         with:
           node-version: 22
           registry-url: https://registry.npmjs.org
+      - name: Check tag matches package.json and server.json
+        run: |
+          TAG_VERSION="${GITHUB_REF#refs/tags/v}"
+          PKG_VERSION="$(node -p "require('./package.json').version")"
+          SRV_VERSION="$(node -p "require('./server.json').version")"
+          if [ "$TAG_VERSION" != "$PKG_VERSION" ] || [ "$TAG_VERSION" != "$SRV_VERSION" ]; then
+            echo "Version mismatch: tag=$TAG_VERSION package.json=$PKG_VERSION server.json=$SRV_VERSION"
+            exit 1
+          fi
       - run: npm ci
       - run: npm run lint
       - run: npm run build
@@ -23,6 +32,22 @@ jobs:
       - run: npm publish --access public
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+  publish-mcp-registry:
+    runs-on: ubuntu-latest
+    needs: [publish-npm]
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - uses: actions/checkout@v6
+      - name: Install mcp-publisher
+        run: |
+          curl -L "https://github.com/modelcontextprotocol/registry/releases/latest/download/mcp-publisher_$(uname -s | tr '[:upper:]' '[:lower:]')_$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/').tar.gz" | tar xz mcp-publisher
+      - name: Authenticate to MCP Registry
+        run: ./mcp-publisher login github-oidc
+      - name: Publish server to MCP Registry
+        run: ./mcp-publisher publish
 
   publish-docker:
     runs-on: ubuntu-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,14 +1,24 @@
 # Changelog
 
+## [1.7.1] - 2026-06-10
+
+### Added
+
+- Published to the official MCP Registry (registry.modelcontextprotocol.io), surfaced on the GitHub MCP Registry (github.com/mcp): `mcpName` ownership marker in `package.json` and a `server.json` registry manifest
+- Release workflow now publishes to the MCP Registry automatically (GitHub OIDC, no extra secrets) after the npm publish, and guards that the pushed tag matches `package.json`
+- `npm version` now syncs `server.json` automatically, so a single `npm version patch|minor|major` keeps every version location aligned
+
 ## [1.7.0] - 2026-05-29
 
 ### Fixed
+
 - `discord_get_role_members` no longer silently truncates at 1000 members. Discord has no "members of a role" endpoint, so it now paginates the full roster (1000/page, capped at 20 pages) before filtering, and returns a `truncated` flag when the cap is hit on very large servers
 - `discord_list_bans` is now paginated. A single fetch only ever returned the first page (≤1000) while the description claimed it fetched all; it now returns `{ bans, nextCursor }` and accepts an `after` cursor
 - `discord_fetch_pinned_messages` migrated from the deprecated `MessageManager#fetchPinned()` (removed in discord.js v15) to `fetchPins()`, and now also returns `pinnedAt`
 - `discord_timeout_member` and `discord_prune_members` validate their numeric inputs (`duration_minutes`, `days`) instead of casting blindly, rejecting NaN / out-of-range values with a clear error
 
 ### Changed
+
 - Renamed the `ready` gateway listener to `clientReady` — forward-compatible with discord.js v15 (where `ready` no longer fires) and silences the v14 deprecation warning
 - Connection robustness: login now races a 30s READY timeout (no more indefinite hangs), resets its in-flight state on failure so the next call retries, and registers `error` / `shardError` / `invalidated` listeners (an unhandled client error could previously crash the process). REST retries/timeout configured; process-level `unhandledRejection` / `uncaughtException` handlers added
 - Tool errors now surface the underlying `DiscordAPIError` code + HTTP status with a plain-language hint (e.g. 50013 → missing permission, 10008 → unknown message) instead of a bare message
@@ -21,10 +31,12 @@
 ## [1.6.2] - 2026-05-29
 
 ### Fixed
+
 - `discord_get_reactions` / `discord_remove_reactions` now resolve custom emoji passed as `name:id`. The reaction cache is keyed by the emoji id (custom) or the unicode char (standard) — not the `name:id` form the tool schema accepts — so custom-emoji lookups previously failed with "No reaction found" even when the reaction existed. A new `findReaction()` helper normalizes the emoji to the cache key (handles `name:id`, `<:name:id>`, `<a:name:id>`, raw id, and unicode) (#25)
 - The role tools (`discord_edit_role`, `discord_delete_role`, `discord_get_role_members`, `discord_set_role_position`, `discord_set_role_icon`) now return a clear "Role not found" error for an unknown `role_id` instead of crashing on a null dereference — removed the misleading `as Role` cast that hid the `| null` return of `guild.roles.fetch()` (#25)
 
 ### Changed
+
 - Dropped the unused `GuildModeration` and `GuildInvites` gateway intents. All ban/invite operations are REST-only and no code subscribes to their gateway events, so requesting them only widened the gateway footprint. `MessageContent`, `GuildMembers`, and `GuildScheduledEvents` are kept (actually consumed) (#25)
 - Extracted a shared `buildEmbed()` + `EMBED_FIELD_PROPS` into `src/embeds.ts`, removing three drifting copies across the message, DM, and webhook tools (#25)
 - Added a `deserializePermissions()` helper (inverse of `serializePermissions`), reused by `discord_create_role` and `discord_edit_role` instead of an inline `PermissionsBitField` expression duplicated twice (#25)
@@ -32,15 +44,18 @@
 ## [1.6.1] - 2026-05-29
 
 ### Fixed
+
 - `discord_pin_message` description no longer claims "Requires the Manage Messages permission". Discord introduced a dedicated **Pin Messages** permission in early 2026 (separate from Manage Messages), and discord.js dropped the Manage Messages check from `Message#pinnable`. The tool now points at the correct permission so the model expects the right one (#21)
 
 ## [1.6.0] - 2026-05-28
 
 ### Added
+
 - MCP tool `annotations` on all 97 tools (`readOnlyHint`, `destructiveHint`, `idempotentHint`, `openWorldHint`, `title`) so clients can apply safety policies and parallelize read-only calls
 - `ToolAnnotations` type and optional `annotations` field on `ToolDefinition`
 
 ### Changed
+
 - Enriched every tool description with usage guidance, required Discord permissions, side effects / destructive behavior, and return value — improving agent reliability and directory tool-definition-quality scores
 - Documented every input-schema parameter (100% coverage), including nested embed/field properties, with formats and constraints
 - Extracted shared embed schema fragments (`EMBED_FIELD_PROPS`, `WEBHOOK_EMBED_PROPS`) to keep repeated definitions in sync
@@ -49,30 +64,36 @@
 ## [1.5.1] - 2026-05-27
 
 ### Fixed
+
 - `getTextChannel` now accepts `ThreadChannel` (forum / public / private / announcement threads) in addition to `TextChannel`, unblocking all message tools on threads: `discord_edit_message`, `discord_delete_message`, `discord_add_reaction`, `discord_read_messages`, `discord_pin_message`, `discord_fetch_pinned_messages`, `discord_bulk_delete_messages`, `discord_search_messages`, `discord_send_embed`, `discord_edit_embed`, `discord_send_multiple_embeds`, `discord_forward_message` (#17, #18)
 - `discord_create_thread` now throws a clear error if the parent `channel_id` is itself a thread (standalone thread creation requires a `TextChannel`; use `message_id` to start a thread from a message instead)
 
 ## [1.5.0] - 2026-05-04
 
 ### Added
+
 - Full DM toolset (6 new tools, 97 total): `discord_send_dm_embed`, `discord_edit_dm`, `discord_edit_dm_embed`, `discord_delete_dm`, `discord_read_dms`, `discord_reply_dm`
 - All DM tools take `user_id` directly and are self-contained in `dm.ts`
 
 ## [1.4.1] - 2026-04-06
 
 ### Added
+
 - `discord_send_dm` tool for sending direct messages by user ID (auto-creates DM channel)
 - Input validation (`validateId`) on DM tool
 
 ### Changed
+
 - README: DM tool section, tool count bumped to 91, project structure updated
 
 ### Fixed
+
 - Removed `dist/` from git tracking (now in `.gitignore`)
 
 ## [1.4.0] - 2025-03-25
 
 ### Added
+
 - 20 new tools enhancing existing categories (90 total)
 - Messages: crosspost, remove/get reactions, fetch pinned, forward
 - Members: search, set nickname, list bans, bulk ban, prune
@@ -83,11 +104,13 @@
 - Scheduled Events: create event invite
 
 ### Fixed
+
 - `discord_list_bans` now handles empty ban lists gracefully
 
 ## [1.3.0] - 2025-03-24
 
 ### Added
+
 - 10 new tools (70 total)
 - Scheduled Events: list, get, create, edit, delete, get subscribers (6 tools)
 - Invites: list, get, create, delete (4 tools)
@@ -96,6 +119,7 @@
 ## [1.2.0] - 2025-03-20
 
 ### Added
+
 - Forum tools: 10 tools for forum channels, posts, tags, threads
 - Webhook tools: 5 tools for webhook management
 - Docker support with multi-stage build
@@ -104,5 +128,6 @@
 ## [1.1.0] - 2025-03-18
 
 ### Added
+
 - Initial release with 60 tools
 - Messages, channels, roles, permissions, moderation, screening, stats

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -13,4 +13,19 @@ export default tseslint.config(
       "@typescript-eslint/no-unused-vars": ["error", { argsIgnorePattern: "^_" }],
     },
   },
+  {
+    files: ["scripts/**/*.js"],
+    languageOptions: {
+      globals: {
+        require: "readonly",
+        module: "readonly",
+        __dirname: "readonly",
+        console: "readonly",
+        process: "readonly",
+      },
+    },
+    rules: {
+      "@typescript-eslint/no-require-imports": "off",
+    },
+  },
 );

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@pasympa/discord-mcp",
-  "version": "1.7.0",
+  "version": "1.7.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@pasympa/discord-mcp",
-      "version": "1.7.0",
+      "version": "1.7.1",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.27.1",

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "format": "prettier --write .",
     "format:check": "prettier --check .",
     "test": "node --import tsx --test test/*.test.ts",
+    "version": "node scripts/sync-version.js && git add server.json",
     "prepublishOnly": "npm run build"
   },
   "keywords": [

--- a/scripts/sync-version.js
+++ b/scripts/sync-version.js
@@ -1,0 +1,16 @@
+// Keeps server.json (MCP Registry manifest) in lockstep with package.json.
+// Runs as the npm `version` lifecycle script, so `npm version patch|minor|major`
+// bumps package.json, package-lock.json and server.json in one go.
+const fs = require("fs");
+const path = require("path");
+
+const { version } = require(path.join(__dirname, "..", "package.json"));
+const serverJsonPath = path.join(__dirname, "..", "server.json");
+
+const server = JSON.parse(fs.readFileSync(serverJsonPath, "utf8"));
+server.version = version;
+for (const pkg of server.packages ?? []) {
+  pkg.version = version;
+}
+fs.writeFileSync(serverJsonPath, JSON.stringify(server, null, 2) + "\n");
+console.log(`server.json synced to ${version}`);


### PR DESCRIPTION
Follow-up to #45, which bumped only package.json.

Version alignment (1.7.1):
- package-lock.json synced
- CHANGELOG.md entry added
- server.json already at 1.7.1

Keeping them aligned going forward:
- `npm version` lifecycle script (`scripts/sync-version.js`) syncs server.json whenever `npm version patch|minor|major` runs, so one command bumps package.json, package-lock.json and server.json together
- ESLint override block for `scripts/**` (CommonJS + Node globals)

Release automation:
- `publish-npm` now fails fast if the pushed tag does not match package.json/server.json
- new `publish-mcp-registry` job publishes to registry.modelcontextprotocol.io after the npm publish, authenticated via GitHub OIDC (no new secrets); the GitHub MCP Registry (github.com/mcp) ingests from there automatically

After merge, releasing 1.7.1 is just: `git tag v1.7.1 && git push origin v1.7.1`