### PR TITLE
fix(registry): match GitHub account casing in MCP namespace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [1.7.2] - 2026-06-10
+
+### Fixed
+
+- MCP Registry namespace case: GitHub OIDC grants publish rights on `io.github.PaSympa/*` (exact GitHub account casing), but `mcpName` / `server.json` used lowercase `io.github.pasympa`, so the registry publish of 1.7.1 was rejected with a 403. Both now use `io.github.PaSympa/discord-mcp`
+
 ## [1.7.1] - 2026-06-10
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@pasympa/discord-mcp",
   "version": "1.7.1",
-  "mcpName": "io.github.pasympa/discord-mcp",
+  "mcpName": "io.github.PaSympa/discord-mcp",
   "description": "A lightweight, multi-guild Discord MCP server with 95+ tools",
   "main": "dist/index.js",
   "type": "commonjs",

--- a/server.json
+++ b/server.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
-  "name": "io.github.pasympa/discord-mcp",
+  "name": "io.github.PaSympa/discord-mcp",
   "description": "A lightweight, multi-guild Discord MCP server with 95+ tools",
   "repository": {
     "url": "https://github.com/PaSympa/discord-mcp",


### PR DESCRIPTION
The v1.7.1 release published to npm, Docker and GitHub Releases, but the `publish-mcp-registry` job failed with 403: OIDC grants `io.github.PaSympa/*` (exact GitHub account casing) while `mcpName`/`server.json` used lowercase `io.github.pasympa`.

This fixes the casing in both files (the npm scope `@pasympa` is unrelated and stays lowercase) and adds the 1.7.2 CHANGELOG entry. A 1.7.2 patch release is required because the registry validates `mcpName` inside the published npm tarball, and 1.7.1 shipped with the lowercase value.