### PR TITLE
release: 1.7.2

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -98,16 +98,20 @@ npm run dev       # build + run
 
 ## Releasing (maintainers)
 
-Versions live in three files — `package.json`, `package-lock.json` and `server.json` (the MCP Registry manifest) — and must always agree. Never edit them by hand; from an up-to-date `main`, run:
+Versions live in three files — `package.json`, `package-lock.json` and `server.json` (the MCP Registry manifest) — and must always agree. Never edit them by hand. `main` only accepts pull requests, so the flow is:
 
 ```bash
-npm version patch   # or minor / major
+git switch -c release/x.y.z main   # from an up-to-date main
+npm version patch                  # or minor / major
+git push -u origin release/x.y.z
 ```
 
-This bumps all three files (`server.json` via the `version` lifecycle script in `scripts/sync-version.js`), commits, and creates the `vX.Y.Z` tag. Add a `CHANGELOG.md` entry for the new version before or as part of that commit, then push:
+`npm version` bumps all three files (`server.json` via the `version` lifecycle script in `scripts/sync-version.js`), commits, and creates the `vX.Y.Z` tag locally. Make sure `CHANGELOG.md` has an entry for the new version (commit it on the branch if not).
+
+Open a PR and **merge it with a merge commit** (not squash/rebase — the tagged commit must end up in `main`'s history). Then push the tag:
 
 ```bash
-git push origin main --follow-tags
+git push origin vX.Y.Z
 ```
 
 The tag triggers `.github/workflows/release.yml`, which does everything else automatically:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@pasympa/discord-mcp",
-  "version": "1.7.1",
+  "version": "1.7.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@pasympa/discord-mcp",
-      "version": "1.7.1",
+      "version": "1.7.2",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.27.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pasympa/discord-mcp",
-  "version": "1.7.1",
+  "version": "1.7.2",
   "mcpName": "io.github.PaSympa/discord-mcp",
   "description": "A lightweight, multi-guild Discord MCP server with 95+ tools",
   "main": "dist/index.js",

--- a/server.json
+++ b/server.json
@@ -6,12 +6,12 @@
     "url": "https://github.com/PaSympa/discord-mcp",
     "source": "github"
   },
-  "version": "1.7.1",
+  "version": "1.7.2",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "@pasympa/discord-mcp",
-      "version": "1.7.1",
+      "version": "1.7.2",
       "transport": {
         "type": "stdio"
       },


### PR DESCRIPTION
Version bump commit created by `npm version patch` (package.json, package-lock.json, server.json all at 1.7.2 — tag v1.7.2 already points at it and the release workflow has run successfully: npm, MCP Registry, Docker, GitHub Release all green).

Also updates CONTRIBUTING: main is PR-only, so the release flow is bump on a branch, merge with a merge commit, then push the tag.

Merge with a **merge commit** so the tagged commit lands in main's history.