### PR TITLE
fix: close remaining allow-list bypasses, spec-align protocol errors (audit round 2)

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,17 +177,17 @@ The server loads `.env` automatically via `dotenv`.
 
 ### Environment variables
 
-| Variable                  | Default | Description                                                                                                 |
-| ------------------------- | ------- | ----------------------------------------------------------------------------------------------------------- |
-| `DISCORD_TOKEN`           | —       | **Required.** Bot token.                                                                                    |
-| `DISCORD_MESSAGE_CONTENT` | `true`  | Set to `false` to stop requesting the Message Content privileged gateway intent at connect time.            |
-| `DISCORD_GUILD_MEMBERS`   | `true`  | Set to `false` to stop requesting the Server Members privileged gateway intent at connect time.             |
-| `DISCORD_MCP_TOOLSETS`    | `all`   | Comma-separated list of toolsets to expose, to keep the tool list small. Unset or `all` exposes every tool. |
+| Variable                  | Default | Description                                                                                                                                                                      |
+| ------------------------- | ------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `DISCORD_TOKEN`           | —       | **Required.** Bot token.                                                                                                                                                         |
+| `DISCORD_MESSAGE_CONTENT` | `true`  | Set to `false` to stop requesting the Message Content privileged gateway intent at connect time.                                                                                 |
+| `DISCORD_GUILD_MEMBERS`   | `true`  | Set to `false` to stop requesting the Server Members privileged gateway intent at connect time.                                                                                  |
+| `DISCORD_MCP_TOOLSETS`    | `all`   | Comma-separated list of toolsets to expose, to keep the tool list small. Unset or `all` exposes every tool.                                                                      |
 | `DISCORD_ALLOWED_GUILDS`  | all     | Comma-separated guild IDs the server may act on. When set, tool calls targeting any other guild are rejected — whether addressed by guild ID, channel ID, thread ID, or webhook. |
 
 These flags only control which gateway intents the server requests when identifying. Requesting a privileged intent that is **not** enabled in the Developer Portal makes the connection fail at startup (close code `4014`) — set the flag to `false` to connect anyway.
 
-Data access is governed by the **portal toggles**, not by these flags: this server reads everything over the REST API, which Discord gates on the portal setting alone. So with the portal toggles on, setting these flags to `false` loses nothing. With a portal toggle **off**, the corresponding data is restricted regardless of the flags: message bodies come back empty (`content`, `embeds`, `attachments`) and member listing fails — enable the toggle in the portal to restore it.
+Data access is governed by the **portal toggles**, not by these flags: this server reads everything over the REST API, which Discord gates on the portal setting alone. So with the portal toggles on, setting these flags to `false` loses nothing. With a portal toggle **off**, the corresponding data is restricted regardless of the flags: message bodies come back empty (`content`, `embeds`, `attachments` — except the bot's own messages, DMs, and messages that mention the bot) and member listing fails — enable the toggle in the portal to restore it.
 
 **Toolsets** (`DISCORD_MCP_TOOLSETS`): `discovery`, `messages`, `channels`, `permissions`, `members`, `roles`, `moderation`, `screening`, `stats`, `forums`, `webhooks`, `scheduled_events`, `invites`, `dm`. Example — read-only navigation only: `DISCORD_MCP_TOOLSETS=discovery,messages,members`. Only the listed toolsets' tools are advertised and callable. Unknown names make the server fail at startup instead of silently exposing everything.
 

--- a/src/client.ts
+++ b/src/client.ts
@@ -108,6 +108,10 @@ function allowedGuilds(): string[] {
     .filter(Boolean);
 }
 
+export function allowListActive(): boolean {
+  return allowedGuilds().length > 0;
+}
+
 export function isGuildAllowed(guildId: string): boolean {
   const list = allowedGuilds();
   return list.length === 0 || list.includes(guildId);

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,7 +10,9 @@ import { Server } from "@modelcontextprotocol/sdk/server/index.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import {
   CallToolRequestSchema,
+  ErrorCode,
   ListToolsRequestSchema,
+  McpError,
 } from "@modelcontextprotocol/sdk/types.js";
 
 import { DiscordAPIError } from "discord.js";
@@ -18,7 +20,7 @@ import { ZodError } from "zod";
 import { readFileSync } from "fs";
 import { join } from "path";
 import { ensureConnected, discord } from "./client.js";
-import { getAllDefinitions, handleTool } from "./tools/index.js";
+import { getAllDefinitions, handleTool, hasTool } from "./tools/index.js";
 
 /** Plain-language hints for the Discord API error codes most likely to surface through these tools. */
 const DISCORD_ERROR_HINTS: Record<number, string> = {
@@ -58,27 +60,30 @@ const version: string = pkg.version;
 
 // ─── MCP Server ────────────────────────────────────────────────────────────────
 
-const server = new Server(
-  { name: "discord-mcp", version },
-  { capabilities: { tools: {} } }
-);
+const server = new Server({ name: "discord-mcp", version }, { capabilities: { tools: {} } });
 
 // ─── Tool Definitions ──────────────────────────────────────────────────────────
 
-server.setRequestHandler(ListToolsRequestSchema, async () => ({
-  tools: getAllDefinitions(),
-}));
+server.setRequestHandler(ListToolsRequestSchema, async (req) => {
+  if (req.params?.cursor !== undefined)
+    throw new McpError(ErrorCode.InvalidParams, "Invalid cursor: tools/list is not paginated.");
+  return { tools: getAllDefinitions() };
+});
 
 // ─── Tool Handler ───────────────────────────────────────────────────────────────
 
 server.setRequestHandler(CallToolRequestSchema, async (req) => {
   const { name, arguments: args = {} } = req.params;
+  if (!hasTool(name)) throw new McpError(ErrorCode.InvalidParams, `Unknown tool: ${name}`);
 
   try {
     await ensureConnected();
     return await handleTool(name, args);
   } catch (err: unknown) {
-    return { content: [{ type: "text", text: `❌ Error: ${formatToolError(err)}` }], isError: true };
+    return {
+      content: [{ type: "text", text: `❌ Error: ${formatToolError(err)}` }],
+      isError: true,
+    };
   }
 });
 
@@ -101,4 +106,8 @@ process.on("SIGTERM", shutdown);
 process.on("unhandledRejection", (reason) => console.error("Unhandled rejection:", reason));
 process.on("uncaughtException", (err) => console.error("Uncaught exception:", err));
 
-main().catch((err) => { console.error("Fatal:", err); discord.destroy(); process.exit(1); });
+main().catch((err) => {
+  console.error("Fatal:", err);
+  discord.destroy();
+  process.exit(1);
+});

--- a/src/tools/channels.ts
+++ b/src/tools/channels.ts
@@ -9,44 +9,86 @@ const tools = [
     name: "discord_create_channel",
     description:
       "Create a text channel, voice channel, or category in a server. Requires the Manage Channels permission. For forum channels use discord_create_forum_channel instead. Returns the new channel's name and ID.",
-    annotations: { title: "Create channel", readOnlyHint: false, destructiveHint: false, idempotentHint: false, openWorldHint: true },
+    annotations: {
+      title: "Create channel",
+      readOnlyHint: false,
+      destructiveHint: false,
+      idempotentHint: false,
+      openWorldHint: true,
+    },
     schema: z.object({
       guild_id: guildId.describe("Discord server (guild) ID (snowflake) to create the channel in."),
       name: z.string().describe("Name of the new channel (max 100 characters)."),
-      type: z.enum(["text", "voice", "category"]).optional().describe("Channel type to create. Defaults to 'text'."),
-      topic: z.string().optional().describe("Optional channel topic/description. Applies to text channels only."),
-      category_id: snowflake.optional().describe("Optional category (snowflake) to nest the new channel under."),
+      type: z
+        .enum(["text", "voice", "category"])
+        .optional()
+        .describe("Channel type to create. Defaults to 'text'."),
+      topic: z
+        .string()
+        .optional()
+        .describe("Optional channel topic/description. Applies to text channels only."),
+      category_id: snowflake
+        .optional()
+        .describe("Optional category (snowflake) to nest the new channel under."),
     }),
     handle: async ({ guild_id, name, type, topic, category_id }) => {
       const guild = await discord.guilds.fetch(guild_id);
       const typeMap: Record<string, ChannelType> = {
-        text: ChannelType.GuildText, voice: ChannelType.GuildVoice, category: ChannelType.GuildCategory,
+        text: ChannelType.GuildText,
+        voice: ChannelType.GuildVoice,
+        category: ChannelType.GuildCategory,
       };
       const channelType = typeMap[type ?? "text"] ?? ChannelType.GuildText;
       const created = await guild.channels.create({
-        name, type: channelType as ChannelType.GuildText | ChannelType.GuildVoice | ChannelType.GuildCategory,
+        name,
+        type: channelType as
+          | ChannelType.GuildText
+          | ChannelType.GuildVoice
+          | ChannelType.GuildCategory,
         topic: channelType === ChannelType.GuildText ? topic : undefined,
         parent: category_id,
       });
-      return { content: [{ type: "text", text: `✅ Channel #${created.name} created (id: ${created.id}).` }] };
+      return {
+        content: [
+          { type: "text", text: `✅ Channel #${created.name} created (id: ${created.id}).` },
+        ],
+      };
     },
   }),
   defineTool({
     name: "discord_delete_channel",
     description:
       "Permanently delete a channel and all of its messages. IRREVERSIBLE. SAFE BY DEFAULT: dry_run is true unless explicitly set to false, so call it first to preview, then re-call with dry_run:false to actually delete. Requires the Manage Channels permission. An optional reason is recorded in the audit log.",
-    annotations: { title: "Delete channel", readOnlyHint: false, destructiveHint: true, idempotentHint: false, openWorldHint: true },
+    annotations: {
+      title: "Delete channel",
+      readOnlyHint: false,
+      destructiveHint: true,
+      idempotentHint: false,
+      openWorldHint: true,
+    },
     schema: z.object({
       channel_id: snowflake.describe("ID (snowflake) of the channel to delete."),
       reason: z.string().optional().describe("Optional reason recorded in the server audit log."),
-      dry_run: z.boolean().default(true).describe("If true (default), only reports which channel would be deleted without deleting it. Set false to actually delete."),
+      dry_run: z
+        .boolean()
+        .default(true)
+        .describe(
+          "If true (default), only reports which channel would be deleted without deleting it. Set false to actually delete.",
+        ),
     }),
     handle: async ({ channel_id, reason, dry_run }) => {
       const channel = await fetchChannelChecked(channel_id);
       if (!channel) throw new Error("Channel not found.");
       const channelName = "name" in channel ? channel.name : channel.id;
       if (dry_run) {
-        return { content: [{ type: "text", text: `🔍 Dry run: channel #${channelName} would be deleted. Re-call with dry_run:false to delete.` }] };
+        return {
+          content: [
+            {
+              type: "text",
+              text: `🔍 Dry run: channel #${channelName} would be deleted. Re-call with dry_run:false to delete.`,
+            },
+          ],
+        };
       }
       await channel.delete(reason);
       return { content: [{ type: "text", text: `✅ Channel #${channelName} deleted.` }] };
@@ -56,20 +98,32 @@ const tools = [
     name: "discord_edit_channel",
     description:
       "Update a channel's name, topic, slowmode, or NSFW flag. Only provided fields change; topic and slowmode apply to text channels only. Requires the Manage Channels permission. Returns a confirmation.",
-    annotations: { title: "Edit channel", readOnlyHint: false, destructiveHint: false, idempotentHint: true, openWorldHint: true },
+    annotations: {
+      title: "Edit channel",
+      readOnlyHint: false,
+      destructiveHint: false,
+      idempotentHint: true,
+      openWorldHint: true,
+    },
     schema: z.object({
       channel_id: snowflake.describe("ID (snowflake) of the channel to edit."),
       name: z.string().optional().describe("New channel name (max 100 characters)."),
       topic: z.string().optional().describe("New topic/description (text channels only)."),
-      slowmode: intIn(0, 21600).optional().describe("Per-user message cooldown in seconds, 0–21600. 0 disables slowmode."),
-      nsfw: z.boolean().optional().describe("Mark (true) or unmark (false) the channel as age-restricted (NSFW)."),
+      slowmode: intIn(0, 21600)
+        .optional()
+        .describe("Per-user message cooldown in seconds, 0–21600. 0 disables slowmode."),
+      nsfw: z
+        .boolean()
+        .optional()
+        .describe("Mark (true) or unmark (false) the channel as age-restricted (NSFW)."),
     }),
     handle: async ({ channel_id, name, topic, slowmode, nsfw }) => {
       const channel = await getGuildChannel(channel_id);
       const editOptions: Record<string, unknown> = {};
       if (name !== undefined) editOptions.name = name;
       if (topic !== undefined && channel.type === ChannelType.GuildText) editOptions.topic = topic;
-      if (slowmode !== undefined && channel.type === ChannelType.GuildText) editOptions.rateLimitPerUser = slowmode;
+      if (slowmode !== undefined && channel.type === ChannelType.GuildText)
+        editOptions.rateLimitPerUser = slowmode;
       if (nsfw !== undefined) editOptions.nsfw = nsfw;
       await channel.edit(editOptions);
       return { content: [{ type: "text", text: `✅ Channel #${channel.name} updated.` }] };
@@ -79,10 +133,18 @@ const tools = [
     name: "discord_move_channel",
     description:
       "Move a channel into a category, or remove it from its category when category_id is omitted. Requires the Manage Channels permission. Use discord_set_channel_position to reorder within a category. Returns a confirmation.",
-    annotations: { title: "Move channel", readOnlyHint: false, destructiveHint: false, idempotentHint: true, openWorldHint: true },
+    annotations: {
+      title: "Move channel",
+      readOnlyHint: false,
+      destructiveHint: false,
+      idempotentHint: true,
+      openWorldHint: true,
+    },
     schema: z.object({
       channel_id: snowflake.describe("ID (snowflake) of the channel to move."),
-      category_id: snowflake.optional().describe("Target category (snowflake). Omit to move the channel out of any category."),
+      category_id: snowflake
+        .optional()
+        .describe("Target category (snowflake). Omit to move the channel out of any category."),
     }),
     handle: async ({ channel_id, category_id }) => {
       const channel = await getGuildChannel(channel_id);
@@ -94,22 +156,41 @@ const tools = [
     name: "discord_clone_channel",
     description:
       "Create a copy of a channel, including its name, topic, and permission overwrites (but not its messages). Requires the Manage Channels permission. Returns the cloned channel's name and ID.",
-    annotations: { title: "Clone channel", readOnlyHint: false, destructiveHint: false, idempotentHint: false, openWorldHint: true },
+    annotations: {
+      title: "Clone channel",
+      readOnlyHint: false,
+      destructiveHint: false,
+      idempotentHint: false,
+      openWorldHint: true,
+    },
     schema: z.object({
       channel_id: snowflake.describe("ID (snowflake) of the channel to clone."),
-      new_name: z.string().optional().describe("Optional name for the clone. Defaults to the source channel's name."),
+      new_name: z
+        .string()
+        .optional()
+        .describe("Optional name for the clone. Defaults to the source channel's name."),
     }),
     handle: async ({ channel_id, new_name }) => {
       const channel = await getGuildChannel(channel_id);
       const cloned = await channel.clone({ name: new_name });
-      return { content: [{ type: "text", text: `✅ Channel cloned as #${cloned.name} (id: ${cloned.id}).` }] };
+      return {
+        content: [
+          { type: "text", text: `✅ Channel cloned as #${cloned.name} (id: ${cloned.id}).` },
+        ],
+      };
     },
   }),
   defineTool({
     name: "discord_set_channel_position",
     description:
       "Set a channel's display order within its category. Use discord_move_channel to change which category it belongs to. Requires the Manage Channels permission. Returns a confirmation.",
-    annotations: { title: "Set channel position", readOnlyHint: false, destructiveHint: false, idempotentHint: true, openWorldHint: true },
+    annotations: {
+      title: "Set channel position",
+      readOnlyHint: false,
+      destructiveHint: false,
+      idempotentHint: true,
+      openWorldHint: true,
+    },
     schema: z.object({
       channel_id: snowflake.describe("ID (snowflake) of the channel to reposition."),
       position: z.int().min(0).describe("Zero-based position within the category (0 = top)."),
@@ -117,37 +198,72 @@ const tools = [
     handle: async ({ channel_id, position }) => {
       const channel = await getGuildChannel(channel_id);
       await channel.setPosition(position);
-      return { content: [{ type: "text", text: `✅ Channel #${channel.name} moved to position ${position}.` }] };
+      return {
+        content: [
+          { type: "text", text: `✅ Channel #${channel.name} moved to position ${position}.` },
+        ],
+      };
     },
   }),
   defineTool({
     name: "discord_follow_announcement_channel",
     description:
       "Subscribe a target channel to an announcement (news) channel, so the source's published messages are reposted into the target. The source must be an announcement channel. Requires the Manage Webhooks permission in the target. Returns a confirmation.",
-    annotations: { title: "Follow announcement channel", readOnlyHint: false, destructiveHint: false, idempotentHint: false, openWorldHint: true },
+    annotations: {
+      title: "Follow announcement channel",
+      readOnlyHint: false,
+      destructiveHint: false,
+      idempotentHint: false,
+      openWorldHint: true,
+    },
     schema: z.object({
-      source_channel_id: snowflake.describe("ID (snowflake) of the announcement channel to follow."),
-      target_channel_id: snowflake.describe("ID (snowflake) of the channel that will receive published messages."),
+      source_channel_id: snowflake.describe(
+        "ID (snowflake) of the announcement channel to follow.",
+      ),
+      target_channel_id: snowflake.describe(
+        "ID (snowflake) of the channel that will receive published messages.",
+      ),
     }),
     handle: async ({ source_channel_id, target_channel_id }) => {
       const source = await fetchChannelChecked(source_channel_id);
-      if (!source || !(source instanceof NewsChannel)) throw new Error("Source channel is not an announcement channel.");
+      if (!source || !(source instanceof NewsChannel))
+        throw new Error("Source channel is not an announcement channel.");
+      await fetchChannelChecked(target_channel_id);
       await source.addFollower(target_channel_id);
-      return { content: [{ type: "text", text: `✅ Now following announcement channel in target channel.` }] };
+      return {
+        content: [
+          { type: "text", text: `✅ Now following announcement channel in target channel.` },
+        ],
+      };
     },
   }),
   defineTool({
     name: "discord_lock_channel_permissions",
     description:
       "Reset a channel's permission overwrites to exactly match its parent category (Discord's 'sync permissions'). The channel must be inside a category. Requires the Manage Roles permission. Returns a confirmation.",
-    annotations: { title: "Sync channel permissions", readOnlyHint: false, destructiveHint: false, idempotentHint: true, openWorldHint: true },
+    annotations: {
+      title: "Sync channel permissions",
+      readOnlyHint: false,
+      destructiveHint: false,
+      idempotentHint: true,
+      openWorldHint: true,
+    },
     schema: z.object({
-      channel_id: snowflake.describe("ID (snowflake) of the channel to sync with its parent category."),
+      channel_id: snowflake.describe(
+        "ID (snowflake) of the channel to sync with its parent category.",
+      ),
     }),
     handle: async ({ channel_id }) => {
       const channel = await getGuildChannel(channel_id);
       await channel.lockPermissions();
-      return { content: [{ type: "text", text: `✅ Channel #${channel.name} permissions synced with parent category.` }] };
+      return {
+        content: [
+          {
+            type: "text",
+            text: `✅ Channel #${channel.name} permissions synced with parent category.`,
+          },
+        ],
+      };
     },
   }),
 ];

--- a/src/tools/define.ts
+++ b/src/tools/define.ts
@@ -25,9 +25,10 @@ export const intIn = (min: number, max: number) => z.int().min(min).max(max);
 
 /**
  * An http(s)-only URL. Bare `z.url()` accepts any WHATWG scheme (javascript:,
- * ftp:, mailto:…) that Discord rejects for clickable/image links.
+ * ftp:, mailto:…) that Discord rejects for clickable/image links. The protocol
+ * regex is unrepresentable in JSON Schema, so `meta` advertises it as a pattern.
  */
-export const httpUrl = z.url({ protocol: /^https?$/ });
+export const httpUrl = z.url({ protocol: /^https?$/ }).meta({ pattern: "^https?://" });
 
 /**
  * Converts a zod schema into the JSON Schema shape MCP sends over the wire.
@@ -114,6 +115,15 @@ export function defineTool<S extends z.ZodType>(tool: {
             `[${tool.name}] structuredContent does not match outputSchema:`,
             parsed.error.issues,
           );
+          return {
+            content: [
+              {
+                type: "text",
+                text: `❌ Internal error: ${tool.name} produced output that does not match its declared outputSchema. Please report this at https://github.com/PaSympa/discord-mcp/issues.`,
+              },
+            ],
+            isError: true,
+          };
         }
       }
       return result;

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -48,7 +48,7 @@ const allToolsets: Record<string, ToolModule> = {
  * case-insensitive; `all` or unset exposes everything). Unknown or empty selections
  * throw at startup: a typo must not silently expose the full destructive surface.
  */
-function selectModules(): ToolModule[] {
+export function selectModules(): ToolModule[] {
   const raw = process.env.DISCORD_MCP_TOOLSETS?.trim();
   if (!raw) return Object.values(allToolsets);
   const names = [
@@ -90,6 +90,11 @@ const registry: Map<string, ToolHandler> = (() => {
  */
 export function getAllDefinitions(): ToolDefinition[] {
   return modules.flatMap((m) => m.definitions);
+}
+
+/** True if a tool with this name is registered (and not gated off). */
+export function hasTool(name: string): boolean {
+  return registry.has(name);
 }
 
 /**

--- a/src/tools/invites.ts
+++ b/src/tools/invites.ts
@@ -1,5 +1,5 @@
 import { z } from "zod";
-import { discord, fetchChannelChecked } from "../client.js";
+import { discord, fetchChannelChecked, assertAllowedGuild } from "../client.js";
 import { defineTool, defineModule, snowflake, guildId, intIn, structured } from "./define.js";
 
 // ─── Helpers ────────────────────────────────────────────────────────────────────
@@ -29,9 +29,7 @@ function serializeInvite(invite: import("discord.js").Invite) {
     url: invite.url,
     channel_id: invite.channelId ?? null,
     channel_name: invite.channel?.name ?? null,
-    inviter: invite.inviter
-      ? { id: invite.inviter.id, username: invite.inviter.username }
-      : null,
+    inviter: invite.inviter ? { id: invite.inviter.id, username: invite.inviter.username } : null,
     uses: invite.uses ?? 0,
     max_uses: invite.maxUses ?? 0,
     max_age: invite.maxAge ?? 0,
@@ -67,7 +65,11 @@ const tools = [
       "Look up details for a single invite by its code, including the target server/channel and usage stats. Works for any public invite, not just this server's. Read-only. Returns a JSON object.",
     annotations: { title: "Get invite", readOnlyHint: true, openWorldHint: true },
     schema: z.object({
-      invite_code: z.string().describe("The invite code, e.g. 'abc123'. A full discord.gg/abc123 URL is also accepted and stripped."),
+      invite_code: z
+        .string()
+        .describe(
+          "The invite code, e.g. 'abc123'. A full discord.gg/abc123 URL is also accepted and stripped.",
+        ),
     }),
     outputSchema: inviteSummary,
     handle: async ({ invite_code }) => {
@@ -81,13 +83,35 @@ const tools = [
     name: "discord_create_invite",
     description:
       "Create an invite link for a channel, optionally limiting its lifetime, uses, and membership type. SECURITY: anyone with the returned link can join the server. Requires the Create Instant Invite permission. Returns the invite URL and code.",
-    annotations: { title: "Create invite", readOnlyHint: false, destructiveHint: false, idempotentHint: false, openWorldHint: true },
+    annotations: {
+      title: "Create invite",
+      readOnlyHint: false,
+      destructiveHint: false,
+      idempotentHint: false,
+      openWorldHint: true,
+    },
     schema: z.object({
       channel_id: snowflake.describe("ID (snowflake) of the channel the invite leads to."),
-      max_age: intIn(0, 604800).default(86400).describe("Invite lifetime in seconds, 0–604800 (7 days); 0 means it never expires. Default 86400 (24h)."),
-      max_uses: intIn(0, 100).default(0).describe("Maximum number of uses, 0–100; 0 means unlimited. Default 0."),
-      unique: z.boolean().optional().describe("If true, always mint a fresh invite instead of reusing an equivalent existing one. Default false."),
-      temporary: z.boolean().optional().describe("If true, members who join via this invite are removed when they disconnect (unless they get a role). Default false."),
+      max_age: intIn(0, 604800)
+        .default(86400)
+        .describe(
+          "Invite lifetime in seconds, 0–604800 (7 days); 0 means it never expires. Default 86400 (24h).",
+        ),
+      max_uses: intIn(0, 100)
+        .default(0)
+        .describe("Maximum number of uses, 0–100; 0 means unlimited. Default 0."),
+      unique: z
+        .boolean()
+        .optional()
+        .describe(
+          "If true, always mint a fresh invite instead of reusing an equivalent existing one. Default false.",
+        ),
+      temporary: z
+        .boolean()
+        .optional()
+        .describe(
+          "If true, members who join via this invite are removed when they disconnect (unless they get a role). Default false.",
+        ),
     }),
     handle: async ({ channel_id, max_age, max_uses, unique, temporary }) => {
       const channel = await fetchChannelChecked(channel_id);
@@ -101,7 +125,12 @@ const tools = [
         temporary: temporary ?? false,
       });
       return {
-        content: [{ type: "text", text: `✅ Invite created: ${invite.url} (code: ${invite.code}, max_age: ${invite.maxAge}s, max_uses: ${invite.maxUses}).` }],
+        content: [
+          {
+            type: "text",
+            text: `✅ Invite created: ${invite.url} (code: ${invite.code}, max_age: ${invite.maxAge}s, max_uses: ${invite.maxUses}).`,
+          },
+        ],
       };
     },
   }),
@@ -109,15 +138,24 @@ const tools = [
     name: "discord_delete_invite",
     description:
       "Revoke an invite by its code so it can no longer be used. IRREVERSIBLE (the code is freed). Requires the Manage Channels permission (or Manage Server). The reason is recorded in the audit log.",
-    annotations: { title: "Delete invite", readOnlyHint: false, destructiveHint: true, idempotentHint: false, openWorldHint: true },
+    annotations: {
+      title: "Delete invite",
+      readOnlyHint: false,
+      destructiveHint: true,
+      idempotentHint: false,
+      openWorldHint: true,
+    },
     schema: z.object({
-      invite_code: z.string().describe("The invite code to revoke. A full discord.gg/<code> URL is also accepted."),
+      invite_code: z
+        .string()
+        .describe("The invite code to revoke. A full discord.gg/<code> URL is also accepted."),
       reason: z.string().optional().describe("Optional reason recorded in the server audit log."),
     }),
     handle: async ({ invite_code, reason }) => {
       const code = invite_code.replace(/^(https?:\/\/)?(discord\.gg\/)?/, "");
       if (!code) throw new Error("invite_code is required.");
       const invite = await discord.fetchInvite(code);
+      assertAllowedGuild(invite.guild?.id);
       await invite.delete(reason);
       return {
         content: [{ type: "text", text: `✅ Invite "${code}" deleted.` }],

--- a/src/tools/scheduledEvents.ts
+++ b/src/tools/scheduledEvents.ts
@@ -250,10 +250,10 @@ const tools = [
       location: z.string().optional().describe("New free-text location for EXTERNAL events."),
       image: httpUrl.optional().describe("New cover image URL."),
       status: z
-        .enum(["SCHEDULED", "ACTIVE", "COMPLETED", "CANCELED"])
+        .enum(["ACTIVE", "COMPLETED", "CANCELED"])
         .optional()
         .describe(
-          "Change event status. Allowed transitions only: SCHEDULED→ACTIVE→COMPLETED, or SCHEDULED→CANCELED.",
+          "Change event status. Allowed transitions only: SCHEDULED→ACTIVE→COMPLETED, or SCHEDULED→CANCELED (no transition back to SCHEDULED exists).",
         ),
     }),
     handle: async ({
@@ -383,7 +383,7 @@ const tools = [
       channel_id: snowflake
         .optional()
         .describe(
-          "Channel (snowflake) the invite points to. Defaults to the server's first text channel if omitted.",
+          "Channel (snowflake) the invite points to. Defaults to the event's own channel; REQUIRED for EXTERNAL events, which have none.",
         ),
       max_age: intIn(0, 604800)
         .default(86400)
@@ -397,6 +397,10 @@ const tools = [
     handle: async ({ guild_id, event_id, channel_id, max_age, max_uses }) => {
       const guild = await discord.guilds.fetch(guild_id);
       const event = await guild.scheduledEvents.fetch(event_id);
+      if (event.entityType === GuildScheduledEventEntityType.External && !channel_id)
+        throw new Error(
+          "channel_id is required for EXTERNAL events (they have no channel of their own).",
+        );
       const url = await event.createInviteURL({
         channel: channel_id,
         maxAge: max_age,

--- a/src/tools/webhooks.ts
+++ b/src/tools/webhooks.ts
@@ -1,6 +1,6 @@
 import { WebhookClient } from "discord.js";
 import { z } from "zod";
-import { discord, fetchChannelChecked, assertAllowedGuild } from "../client.js";
+import { discord, fetchChannelChecked, assertAllowedGuild, allowListActive } from "../client.js";
 import { buildEmbed, embedObjectSchema } from "../embeds.js";
 import { defineTool, defineModule, snowflake, guildId, httpUrl, structured } from "./define.js";
 
@@ -86,6 +86,8 @@ const tools = [
     }),
     handle: async ({ webhook_id, webhook_token, content, username, avatar_url, embeds }) => {
       if (!webhook_token) throw new Error("webhook_token is required.");
+      if (allowListActive())
+        assertAllowedGuild((await discord.fetchWebhook(webhook_id, webhook_token)).guildId);
       const client = new WebhookClient({ id: webhook_id, token: webhook_token });
       try {
         const sendOptions: Record<string, unknown> = {};
@@ -245,6 +247,8 @@ const tools = [
     }),
     handle: async ({ webhook_id, webhook_token, message_id, content, embeds }) => {
       if (!webhook_token) throw new Error("webhook_token is required.");
+      if (allowListActive())
+        assertAllowedGuild((await discord.fetchWebhook(webhook_id, webhook_token)).guildId);
       const client = new WebhookClient({ id: webhook_id, token: webhook_token });
       try {
         const editOptions: Record<string, unknown> = {};
@@ -276,6 +280,8 @@ const tools = [
     }),
     handle: async ({ webhook_id, webhook_token, message_id }) => {
       if (!webhook_token) throw new Error("webhook_token is required.");
+      if (allowListActive())
+        assertAllowedGuild((await discord.fetchWebhook(webhook_id, webhook_token)).guildId);
       const client = new WebhookClient({ id: webhook_id, token: webhook_token });
       try {
         await client.deleteMessage(message_id);
@@ -304,6 +310,8 @@ const tools = [
     }),
     handle: async ({ webhook_id, webhook_token, message_id }) => {
       if (!webhook_token) throw new Error("webhook_token is required.");
+      if (allowListActive())
+        assertAllowedGuild((await discord.fetchWebhook(webhook_id, webhook_token)).guildId);
       const client = new WebhookClient({ id: webhook_id, token: webhook_token });
       try {
         const msg = await client.fetchMessage(message_id);

--- a/test/define.test.ts
+++ b/test/define.test.ts
@@ -101,7 +101,7 @@ test("structuredContent conforming to outputSchema is normalised; extra keys are
   assert.deepEqual(res.structuredContent, { id: "1" });
 });
 
-test("non-conforming structuredContent is left intact instead of throwing", async () => {
+test("non-conforming structuredContent becomes an isError result, never ships", async () => {
   const mod = defineModule([
     defineTool({
       name: "t_bad",
@@ -111,9 +111,9 @@ test("non-conforming structuredContent is left intact instead of throwing", asyn
       handle: async () => structured({ id: 42 }),
     }),
   ]);
-  // safeParse fails (id is a number), so the handler still returns the raw data — no throw.
   const res = await mod.handlers.get("t_bad")!({});
-  assert.deepEqual(res.structuredContent, { id: 42 });
+  assert.equal(res.isError, true);
+  assert.equal(res.structuredContent, undefined);
 });
 
 test("defineModule throws on duplicate tool names within a module", () => {

--- a/test/registry.test.ts
+++ b/test/registry.test.ts
@@ -1,22 +1,50 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
-import { getAllDefinitions, handleTool } from "../src/tools/index.js";
+import { selectModules, hasTool } from "../src/tools/index.js";
+import { assertAllowedGuild, isGuildAllowed } from "../src/client.js";
 
-test("tool definitions are non-empty and uniquely named", () => {
-  const defs = getAllDefinitions();
-  assert.ok(defs.length > 0, "expected at least one tool definition");
-  const names = defs.map((d) => d.name);
-  assert.equal(new Set(names).size, names.length, "duplicate tool names found");
-  for (const n of names) assert.match(n, /^discord_/, `tool name should start with discord_: ${n}`);
+test("selectModules exposes everything when unset or `all`", () => {
+  delete process.env.DISCORD_MCP_TOOLSETS;
+  const all = selectModules().length;
+  process.env.DISCORD_MCP_TOOLSETS = "all";
+  assert.equal(selectModules().length, all);
+  delete process.env.DISCORD_MCP_TOOLSETS;
 });
 
-test("every definition has a description and inputSchema", () => {
-  for (const d of getAllDefinitions()) {
-    assert.ok(d.description && d.description.length > 0, `${d.name} missing description`);
-    assert.equal(typeof d.inputSchema, "object", `${d.name} missing inputSchema`);
+test("selectModules picks listed toolsets, case-insensitive", () => {
+  process.env.DISCORD_MCP_TOOLSETS = "Discovery, MESSAGES";
+  try {
+    assert.equal(selectModules().length, 2);
+  } finally {
+    delete process.env.DISCORD_MCP_TOOLSETS;
   }
 });
 
-test("an unknown tool name is rejected", async () => {
-  await assert.rejects(() => handleTool("discord_nonexistent_tool", {}));
+test("selectModules fails fast on unknown or empty selections", () => {
+  for (const value of ["messsages", "discovery messages", ",,"]) {
+    process.env.DISCORD_MCP_TOOLSETS = value;
+    try {
+      assert.throws(() => selectModules(), /Invalid DISCORD_MCP_TOOLSETS/, value);
+    } finally {
+      delete process.env.DISCORD_MCP_TOOLSETS;
+    }
+  }
+});
+
+test("hasTool reflects the registry", () => {
+  assert.ok(hasTool("discord_list_guilds"));
+  assert.ok(!hasTool("discord_nonexistent"));
+});
+
+test("assertAllowedGuild enforces the allow-list lazily and ignores null", () => {
+  process.env.DISCORD_ALLOWED_GUILDS = "111111111111111111";
+  try {
+    assert.ok(isGuildAllowed("111111111111111111"));
+    assert.throws(() => assertAllowedGuild("222222222222222222"), /allow-list/);
+    assertAllowedGuild(null);
+    assertAllowedGuild(undefined);
+  } finally {
+    delete process.env.DISCORD_ALLOWED_GUILDS;
+  }
+  assertAllowedGuild("222222222222222222");
 });


### PR DESCRIPTION
Fixes from the release/2.0 branch audit (5 dimensions, web-verified):

Security:
- `discord_delete_invite` asserted no guild — any invite code from any guild was revocable; now checks `invite.guild?.id`
- `discord_follow_announcement_channel` now validates the TARGET channel too (could pipe announcements into a foreign guild)
- Token-webhook flows (send/edit/delete/fetch message) assert the webhook's guild when the allow-list is active (one extra fetch, skipped otherwise)

MCP spec (2025-11-25):
- Unknown tool and invalid `tools/list` cursor now raise `McpError` InvalidParams (-32602) per spec, and the lookup happens BEFORE `ensureConnected()` — no Discord login for nonexistent tools
- Non-conforming `structuredContent` returns an `isError` result instead of shipping a MUST violation that strict clients hard-fail

Discord API:
- `create_event_invite`: corrected false description; EXTERNAL events fail clearly without `channel_id` (discord.js throws otherwise)
- `edit_scheduled_event`: dropped `SCHEDULED` from the status enum (no transition back to it exists)

zod:
- `httpUrl` advertises `pattern: ^https?://` via `.meta()` (the protocol regex is unrepresentable in JSON Schema)

Tests: 21/21 — new coverage for `selectModules` (gating incl. fail-fast), `hasTool`, `assertAllowedGuild`, and the isError-on-drift path.