### PR TITLE
chore(release): sync main and prep v2.0 metadata

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,3 +4,11 @@ DISCORD_TOKEN=your_bot_token_here
 # Set to false if the matching toggle is off in the Developer Portal (avoids 4014).
 # DISCORD_MESSAGE_CONTENT=true
 # DISCORD_GUILD_MEMBERS=true
+
+# Expose only selected toolsets (comma-separated; `all` or unset = everything).
+# Unknown names abort startup. See README for the toolset list.
+# DISCORD_MCP_TOOLSETS=discovery,messages,members
+
+# Restrict the server to specific guild IDs (comma-separated). When set, calls
+# addressed by guild, channel, thread, webhook or invite outside the list fail.
+# DISCORD_ALLOWED_GUILDS=123456789012345678,234567890123456789

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,6 +16,15 @@ jobs:
         with:
           node-version: 22
           registry-url: https://registry.npmjs.org
+      - name: Check tag matches package.json and server.json
+        run: |
+          TAG_VERSION="${GITHUB_REF#refs/tags/v}"
+          PKG_VERSION="$(node -p "require('./package.json').version")"
+          SRV_VERSION="$(node -p "require('./server.json').version")"
+          if [ "$TAG_VERSION" != "$PKG_VERSION" ] || [ "$TAG_VERSION" != "$SRV_VERSION" ]; then
+            echo "Version mismatch: tag=$TAG_VERSION package.json=$PKG_VERSION server.json=$SRV_VERSION"
+            exit 1
+          fi
       - run: npm ci
       - run: npm run lint
       - run: npm run build
@@ -23,6 +32,22 @@ jobs:
       - run: npm publish --access public
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+  publish-mcp-registry:
+    runs-on: ubuntu-latest
+    needs: [publish-npm]
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - uses: actions/checkout@v6
+      - name: Install mcp-publisher
+        run: |
+          curl -L "https://github.com/modelcontextprotocol/registry/releases/latest/download/mcp-publisher_$(uname -s | tr '[:upper:]' '[:lower:]')_$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/').tar.gz" | tar xz mcp-publisher
+      - name: Authenticate to MCP Registry
+        run: ./mcp-publisher login github-oidc
+      - name: Publish server to MCP Registry
+        run: ./mcp-publisher publish
 
   publish-docker:
     runs-on: ubuntu-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [1.7.2] - 2026-06-10
+
+### Fixed
+
+- MCP Registry namespace case: GitHub OIDC grants publish rights on `io.github.PaSympa/*` (exact GitHub account casing), but `mcpName` / `server.json` used lowercase `io.github.pasympa`, so the registry publish of 1.7.1 was rejected with a 403. Both now use `io.github.PaSympa/discord-mcp`
+
 ## [1.7.1] - 2026-06-10
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,25 @@
 # Changelog
 
+## [Unreleased — 2.0.0]
+
+### Breaking
+
+- Every tool input is validated by a zod schema that also derives the advertised `inputSchema` (single source of truth). Numeric inputs are strictly bounded: out-of-range, non-integer, or string numbers are rejected with a clear error instead of being coerced/clamped
+- Embed and role colors are hex-only (`#RRGGBB`); named colors ("Red") and raw integers are rejected
+- All URL inputs must be `http(s)` (`javascript:`, `ftp:`, … rejected); the constraint is advertised as a `pattern` in the schema
+- Scheduled-event datetimes must be ISO 8601 with an explicit offset or `Z`; offset-less strings are rejected, and event `entity_type`/`status` enums are case-sensitive uppercase (`status` no longer accepts `SCHEDULED` — no transition back to it exists)
+- `discord_delete_channel` and `discord_bulk_delete_messages` are safe-by-default: `dry_run` defaults to `true` (advertised in the schema), so existing callers preview instead of deleting until they pass `dry_run:false`. The bulk-delete dry run reports the real deletable count (14-day rule applied)
+- Unknown tool names and unexpected `tools/list` cursors are JSON-RPC protocol errors (`-32602`) instead of `isError` results, and validation failures surface as `Invalid arguments — field: message`
+- Read tools (32) now advertise `outputSchema` and return `structuredContent`; conforming outputs are normalised (unknown keys dropped) and non-conforming output is converted to an error instead of being shipped. `discord_fetch_webhook_message` `timestamp` is an ISO string (was mistyped as a number)
+- The `events` toolset is renamed `scheduled_events`
+
+### Added
+
+- `DISCORD_MCP_TOOLSETS`: expose only selected toolsets (comma-separated, case-insensitive, `all` keyword). Unknown names abort startup instead of silently exposing all 97 tools
+- `DISCORD_ALLOWED_GUILDS`: guild allow-list enforced at the schema for `guild_id` inputs AND centrally on every channel/thread/webhook/invite fetch, so channel-addressed calls cannot bypass it (token-webhook flows verify the webhook's guild when the list is active)
+- `DISCORD_MESSAGE_CONTENT` / `DISCORD_GUILD_MEMBERS`: opt out of the privileged gateway intents at connect time (avoids the 4014 startup failure when the portal toggles are off; REST data access is governed by the portal toggles alone)
+- O(1) tool dispatch with duplicate-name detection at load (cross-module and within-module)
+
 ## [1.7.2] - 2026-06-10
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,14 +1,24 @@
 # Changelog
 
+## [1.7.1] - 2026-06-10
+
+### Added
+
+- Published to the official MCP Registry (registry.modelcontextprotocol.io), surfaced on the GitHub MCP Registry (github.com/mcp): `mcpName` ownership marker in `package.json` and a `server.json` registry manifest
+- Release workflow now publishes to the MCP Registry automatically (GitHub OIDC, no extra secrets) after the npm publish, and guards that the pushed tag matches `package.json`
+- `npm version` now syncs `server.json` automatically, so a single `npm version patch|minor|major` keeps every version location aligned
+
 ## [1.7.0] - 2026-05-29
 
 ### Fixed
+
 - `discord_get_role_members` no longer silently truncates at 1000 members. Discord has no "members of a role" endpoint, so it now paginates the full roster (1000/page, capped at 20 pages) before filtering, and returns a `truncated` flag when the cap is hit on very large servers
 - `discord_list_bans` is now paginated. A single fetch only ever returned the first page (≤1000) while the description claimed it fetched all; it now returns `{ bans, nextCursor }` and accepts an `after` cursor
 - `discord_fetch_pinned_messages` migrated from the deprecated `MessageManager#fetchPinned()` (removed in discord.js v15) to `fetchPins()`, and now also returns `pinnedAt`
 - `discord_timeout_member` and `discord_prune_members` validate their numeric inputs (`duration_minutes`, `days`) instead of casting blindly, rejecting NaN / out-of-range values with a clear error
 
 ### Changed
+
 - Renamed the `ready` gateway listener to `clientReady` — forward-compatible with discord.js v15 (where `ready` no longer fires) and silences the v14 deprecation warning
 - Connection robustness: login now races a 30s READY timeout (no more indefinite hangs), resets its in-flight state on failure so the next call retries, and registers `error` / `shardError` / `invalidated` listeners (an unhandled client error could previously crash the process). REST retries/timeout configured; process-level `unhandledRejection` / `uncaughtException` handlers added
 - Tool errors now surface the underlying `DiscordAPIError` code + HTTP status with a plain-language hint (e.g. 50013 → missing permission, 10008 → unknown message) instead of a bare message
@@ -21,10 +31,12 @@
 ## [1.6.2] - 2026-05-29
 
 ### Fixed
+
 - `discord_get_reactions` / `discord_remove_reactions` now resolve custom emoji passed as `name:id`. The reaction cache is keyed by the emoji id (custom) or the unicode char (standard) — not the `name:id` form the tool schema accepts — so custom-emoji lookups previously failed with "No reaction found" even when the reaction existed. A new `findReaction()` helper normalizes the emoji to the cache key (handles `name:id`, `<:name:id>`, `<a:name:id>`, raw id, and unicode) (#25)
 - The role tools (`discord_edit_role`, `discord_delete_role`, `discord_get_role_members`, `discord_set_role_position`, `discord_set_role_icon`) now return a clear "Role not found" error for an unknown `role_id` instead of crashing on a null dereference — removed the misleading `as Role` cast that hid the `| null` return of `guild.roles.fetch()` (#25)
 
 ### Changed
+
 - Dropped the unused `GuildModeration` and `GuildInvites` gateway intents. All ban/invite operations are REST-only and no code subscribes to their gateway events, so requesting them only widened the gateway footprint. `MessageContent`, `GuildMembers`, and `GuildScheduledEvents` are kept (actually consumed) (#25)
 - Extracted a shared `buildEmbed()` + `EMBED_FIELD_PROPS` into `src/embeds.ts`, removing three drifting copies across the message, DM, and webhook tools (#25)
 - Added a `deserializePermissions()` helper (inverse of `serializePermissions`), reused by `discord_create_role` and `discord_edit_role` instead of an inline `PermissionsBitField` expression duplicated twice (#25)
@@ -32,15 +44,18 @@
 ## [1.6.1] - 2026-05-29
 
 ### Fixed
+
 - `discord_pin_message` description no longer claims "Requires the Manage Messages permission". Discord introduced a dedicated **Pin Messages** permission in early 2026 (separate from Manage Messages), and discord.js dropped the Manage Messages check from `Message#pinnable`. The tool now points at the correct permission so the model expects the right one (#21)
 
 ## [1.6.0] - 2026-05-28
 
 ### Added
+
 - MCP tool `annotations` on all 97 tools (`readOnlyHint`, `destructiveHint`, `idempotentHint`, `openWorldHint`, `title`) so clients can apply safety policies and parallelize read-only calls
 - `ToolAnnotations` type and optional `annotations` field on `ToolDefinition`
 
 ### Changed
+
 - Enriched every tool description with usage guidance, required Discord permissions, side effects / destructive behavior, and return value — improving agent reliability and directory tool-definition-quality scores
 - Documented every input-schema parameter (100% coverage), including nested embed/field properties, with formats and constraints
 - Extracted shared embed schema fragments (`EMBED_FIELD_PROPS`, `WEBHOOK_EMBED_PROPS`) to keep repeated definitions in sync
@@ -49,30 +64,36 @@
 ## [1.5.1] - 2026-05-27
 
 ### Fixed
+
 - `getTextChannel` now accepts `ThreadChannel` (forum / public / private / announcement threads) in addition to `TextChannel`, unblocking all message tools on threads: `discord_edit_message`, `discord_delete_message`, `discord_add_reaction`, `discord_read_messages`, `discord_pin_message`, `discord_fetch_pinned_messages`, `discord_bulk_delete_messages`, `discord_search_messages`, `discord_send_embed`, `discord_edit_embed`, `discord_send_multiple_embeds`, `discord_forward_message` (#17, #18)
 - `discord_create_thread` now throws a clear error if the parent `channel_id` is itself a thread (standalone thread creation requires a `TextChannel`; use `message_id` to start a thread from a message instead)
 
 ## [1.5.0] - 2026-05-04
 
 ### Added
+
 - Full DM toolset (6 new tools, 97 total): `discord_send_dm_embed`, `discord_edit_dm`, `discord_edit_dm_embed`, `discord_delete_dm`, `discord_read_dms`, `discord_reply_dm`
 - All DM tools take `user_id` directly and are self-contained in `dm.ts`
 
 ## [1.4.1] - 2026-04-06
 
 ### Added
+
 - `discord_send_dm` tool for sending direct messages by user ID (auto-creates DM channel)
 - Input validation (`validateId`) on DM tool
 
 ### Changed
+
 - README: DM tool section, tool count bumped to 91, project structure updated
 
 ### Fixed
+
 - Removed `dist/` from git tracking (now in `.gitignore`)
 
 ## [1.4.0] - 2025-03-25
 
 ### Added
+
 - 20 new tools enhancing existing categories (90 total)
 - Messages: crosspost, remove/get reactions, fetch pinned, forward
 - Members: search, set nickname, list bans, bulk ban, prune
@@ -83,11 +104,13 @@
 - Scheduled Events: create event invite
 
 ### Fixed
+
 - `discord_list_bans` now handles empty ban lists gracefully
 
 ## [1.3.0] - 2025-03-24
 
 ### Added
+
 - 10 new tools (70 total)
 - Scheduled Events: list, get, create, edit, delete, get subscribers (6 tools)
 - Invites: list, get, create, delete (4 tools)
@@ -96,6 +119,7 @@
 ## [1.2.0] - 2025-03-20
 
 ### Added
+
 - Forum tools: 10 tools for forum channels, posts, tags, threads
 - Webhook tools: 5 tools for webhook management
 - Docker support with multi-stage build
@@ -104,5 +128,6 @@
 ## [1.1.0] - 2025-03-18
 
 ### Added
+
 - Initial release with 60 tools
 - Messages, channels, roles, permissions, moderation, screening, stats

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,7 +22,13 @@ export const definitions = [
     name: "discord_my_tool",
     description:
       "One clear action sentence. Then: when to use it vs. similar tools, required Discord permissions, any side effects or destructive/irreversible behavior, and what it returns.",
-    annotations: { title: "My tool", readOnlyHint: false, destructiveHint: false, idempotentHint: false, openWorldHint: true },
+    annotations: {
+      title: "My tool",
+      readOnlyHint: false,
+      destructiveHint: false,
+      idempotentHint: false,
+      openWorldHint: true,
+    },
     inputSchema: {
       type: "object",
       properties: {
@@ -62,7 +68,7 @@ export default { definitions, handle } satisfies ToolModule;
 ### Tool definition quality
 
 Every tool definition must carry its weight — directory scanners (e.g. Glama) score the
-*lowest*-quality tool heavily, so one thin definition drags the whole server's grade down.
+_lowest_-quality tool heavily, so one thin definition drags the whole server's grade down.
 
 - **Description**: action statement + when to use it vs. similar tools + required Discord
   permissions + side effects / destructive behavior + what it returns.
@@ -89,3 +95,26 @@ npm run dev       # build + run
 3. Build and test your changes
 4. Commit with a descriptive message (e.g. `feat: add my-tool`)
 5. Open a pull request against `main`
+
+## Releasing (maintainers)
+
+Versions live in three files — `package.json`, `package-lock.json` and `server.json` (the MCP Registry manifest) — and must always agree. Never edit them by hand; from an up-to-date `main`, run:
+
+```bash
+npm version patch   # or minor / major
+```
+
+This bumps all three files (`server.json` via the `version` lifecycle script in `scripts/sync-version.js`), commits, and creates the `vX.Y.Z` tag. Add a `CHANGELOG.md` entry for the new version before or as part of that commit, then push:
+
+```bash
+git push origin main --follow-tags
+```
+
+The tag triggers `.github/workflows/release.yml`, which does everything else automatically:
+
+1. Fails fast if the tag does not match `package.json` / `server.json`
+2. Lints, builds, tests, then publishes to npm (`NPM_TOKEN` secret)
+3. Publishes to the official MCP Registry via GitHub OIDC (no secret needed) — the [GitHub MCP Registry](https://github.com/mcp) picks it up automatically
+4. Pushes the Docker images and creates the GitHub Release
+
+No manual `npm publish` — local publishes are blocked by npm's 2FA policy anyway.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,20 +5,27 @@ Thanks for your interest in contributing to Discord MCP Server!
 ## Adding a New Tool
 
 1. Create a new file in `src/tools/` (e.g. `myfeature.ts`)
-2. Export `definitions` (tool schemas) and `handle()` (tool logic)
-3. Import and add it to the `modules` array in `src/tools/index.ts`
-4. Update `README.md` with the new tool(s)
+2. Build it with `defineTool` entries assembled by `defineModule([...])`, and default-export the result
+3. Add it to `allToolsets` in `src/tools/index.ts` — the key becomes its `DISCORD_MCP_TOOLSETS` name
+4. Update `README.md` (tool tables, counts, toolset list)
 
 ### Tool Module Structure
 
-Every tool module must satisfy the `ToolModule` interface:
-
 ```typescript
-import { discord, validateId } from "../client.js";
-import type { ToolModule, ToolResult } from "./types.js";
+import { z } from "zod";
+import { discord } from "../client.js";
+import {
+  defineTool,
+  defineModule,
+  guildId,
+  snowflake,
+  intIn,
+  httpUrl,
+  structured,
+} from "./define.js";
 
-export const definitions = [
-  {
+const tools = [
+  defineTool({
     name: "discord_my_tool",
     description:
       "One clear action sentence. Then: when to use it vs. similar tools, required Discord permissions, any side effects or destructive/irreversible behavior, and what it returns.",
@@ -29,41 +36,29 @@ export const definitions = [
       idempotentHint: false,
       openWorldHint: true,
     },
-    inputSchema: {
-      type: "object",
-      properties: {
-        guild_id: { type: "string", description: "Discord server (guild) ID (snowflake)." },
-      },
-      required: ["guild_id"],
+    schema: z.object({
+      guild_id: guildId,
+      limit: intIn(1, 100).default(25).describe("How many entries to return (1–100). Default 25."),
+    }),
+    outputSchema: z.object({ items: z.array(z.object({ id: z.string() })) }),
+    handle: async ({ guild_id, limit }) => {
+      const guild = await discord.guilds.fetch(guild_id);
+      // ... tool logic — args arrive validated and typed
+      return structured({ items: [] });
     },
-  },
+  }),
 ];
 
-export async function handle(
-  name: string,
-  args: Record<string, unknown>,
-): Promise<ToolResult | null> {
-  switch (name) {
-    case "discord_my_tool": {
-      const guildId = validateId(args.guild_id, "guild_id");
-      // ... tool logic
-      return { content: [{ type: "text", text: "result" }] };
-    }
-    default:
-      return null;
-  }
-}
-
-export default { definitions, handle } satisfies ToolModule;
+export default defineModule(tools);
 ```
 
 ### Conventions
 
-- Use `validateId()` for all Discord snowflake IDs
-- Return `null` from `handle()` if the tool name doesn't match (routing)
-- Success messages start with `✅`
-- Use `JSON.stringify(data, null, 2)` for list responses
-- Tool names are prefixed with `discord_`
+- The zod `schema` is the single source of truth: it derives the advertised `inputSchema` and validates args before `handle` runs — no manual validation, no `as` casts
+- Reuse the shared fields from `define.ts`: `snowflake`, `guildId` (enforces `DISCORD_ALLOWED_GUILDS`), `intIn(min, max)` for bounded integers, `httpUrl` for http(s)-only URLs; embed inputs come from `embedFieldsShape` in `src/embeds.ts`
+- Resolve channels through `getTextChannel` / `getGuildChannel` / `fetchChannelChecked` from `client.ts` — never `discord.channels.fetch` directly, so the guild allow-list stays enforced centrally
+- Read tools declare an `outputSchema` (object root — wrap arrays as `{ items: [...] }`) and return via `structured(data)`, which emits matching text + `structuredContent`
+- Success messages start with `✅`; tool names are prefixed with `discord_`
 
 ### Tool definition quality
 
@@ -76,9 +71,9 @@ _lowest_-quality tool heavily, so one thin definition drags the whole server's g
   (true for delete/ban/prune/irreversible writes), `idempotentHint` (true if repeating the call
   changes nothing further), and `openWorldHint: true` (every tool calls the Discord API). Add a
   short `title`.
-- **Parameters**: give every `inputSchema` property a `description` with its format and constraints
-  (e.g. snowflake, value range, defaults). When the same schema block repeats across tools, extract
-  it into a shared `const` and spread it (see `EMBED_FIELD_PROPS` in `messages.ts`).
+- **Parameters**: give every schema field a `.describe()` with its format and constraints
+  (e.g. snowflake, value range, defaults). When the same fields repeat across tools, extract
+  them into a shared shape and spread it (see `embedFieldsShape` in `src/embeds.ts`).
 
 ## Development
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -98,16 +98,20 @@ npm run dev       # build + run
 
 ## Releasing (maintainers)
 
-Versions live in three files — `package.json`, `package-lock.json` and `server.json` (the MCP Registry manifest) — and must always agree. Never edit them by hand; from an up-to-date `main`, run:
+Versions live in three files — `package.json`, `package-lock.json` and `server.json` (the MCP Registry manifest) — and must always agree. Never edit them by hand. `main` only accepts pull requests, so the flow is:
 
 ```bash
-npm version patch   # or minor / major
+git switch -c release/x.y.z main   # from an up-to-date main
+npm version patch                  # or minor / major
+git push -u origin release/x.y.z
 ```
 
-This bumps all three files (`server.json` via the `version` lifecycle script in `scripts/sync-version.js`), commits, and creates the `vX.Y.Z` tag. Add a `CHANGELOG.md` entry for the new version before or as part of that commit, then push:
+`npm version` bumps all three files (`server.json` via the `version` lifecycle script in `scripts/sync-version.js`), commits, and creates the `vX.Y.Z` tag locally. Make sure `CHANGELOG.md` has an entry for the new version (commit it on the branch if not).
+
+Open a PR and **merge it with a merge commit** (not squash/rebase — the tagged commit must end up in `main`'s history). Then push the tag:
 
 ```bash
-git push origin main --follow-tags
+git push origin vX.Y.Z
 ```
 
 The tag triggers `.github/workflows/release.yml`, which does everything else automatically:

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -13,4 +13,19 @@ export default tseslint.config(
       "@typescript-eslint/no-unused-vars": ["error", { argsIgnorePattern: "^_" }],
     },
   },
+  {
+    files: ["scripts/**/*.js"],
+    languageOptions: {
+      globals: {
+        require: "readonly",
+        module: "readonly",
+        __dirname: "readonly",
+        console: "readonly",
+        process: "readonly",
+      },
+    },
+    rules: {
+      "@typescript-eslint/no-require-imports": "off",
+    },
+  },
 );

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@pasympa/discord-mcp",
-  "version": "1.7.1",
+  "version": "1.7.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@pasympa/discord-mcp",
-      "version": "1.7.1",
+      "version": "1.7.2",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.27.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -3125,9 +3125,9 @@
       }
     },
     "node_modules/zod": {
-      "version": "4.3.6",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
-      "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
+      "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@pasympa/discord-mcp",
-  "version": "1.7.0",
+  "version": "1.7.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@pasympa/discord-mcp",
-      "version": "1.7.0",
+      "version": "1.7.1",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.27.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -931,17 +931,17 @@
       }
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
-      "version": "8.60.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.60.0.tgz",
-      "integrity": "sha512-QYb/sa74/s7OKMbACMjrYnGspj9Hs5YI5aaffSL65UfeBUzVzBJfVo3oWSpbzPurvm7yaCCo2Lk7lVj610HqKw==",
+      "version": "8.60.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.60.1.tgz",
+      "integrity": "sha512-JQ4S5GB0tfjO8BuJ4fcX+HodkzJjYBV+7OJ+wLygaX7OGQ7FudyHL4NSCA6ob+w3Yn+5MkKIozOwQhXeM7opVg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/regexpp": "^4.12.2",
-        "@typescript-eslint/scope-manager": "8.60.0",
-        "@typescript-eslint/type-utils": "8.60.0",
-        "@typescript-eslint/utils": "8.60.0",
-        "@typescript-eslint/visitor-keys": "8.60.0",
+        "@typescript-eslint/scope-manager": "8.60.1",
+        "@typescript-eslint/type-utils": "8.60.1",
+        "@typescript-eslint/utils": "8.60.1",
+        "@typescript-eslint/visitor-keys": "8.60.1",
         "ignore": "^7.0.5",
         "natural-compare": "^1.4.0",
         "ts-api-utils": "^2.5.0"
@@ -954,7 +954,7 @@
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "@typescript-eslint/parser": "^8.60.0",
+        "@typescript-eslint/parser": "^8.60.1",
         "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
         "typescript": ">=4.8.4 <6.1.0"
       }
@@ -970,16 +970,16 @@
       }
     },
     "node_modules/@typescript-eslint/parser": {
-      "version": "8.60.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.60.0.tgz",
-      "integrity": "sha512-fcqpj/MyK4sxDPcbe7STNPbpQL4RLZOPWuaTmwZYuc+hJKzRf58yRxfhqGpc6PIq9ZyfSBpfHgmUHmHs0KwHwg==",
+      "version": "8.60.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.60.1.tgz",
+      "integrity": "sha512-A0M6ua6H252bVjPvvtSgl2QA4+ET9S5Mtkb2GDyTxIhH/C4qDItT7RQNO5PhMC6NXGYXOR9dIalcDDgBKT7oFA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/scope-manager": "8.60.0",
-        "@typescript-eslint/types": "8.60.0",
-        "@typescript-eslint/typescript-estree": "8.60.0",
-        "@typescript-eslint/visitor-keys": "8.60.0",
+        "@typescript-eslint/scope-manager": "8.60.1",
+        "@typescript-eslint/types": "8.60.1",
+        "@typescript-eslint/typescript-estree": "8.60.1",
+        "@typescript-eslint/visitor-keys": "8.60.1",
         "debug": "^4.4.3"
       },
       "engines": {
@@ -995,14 +995,14 @@
       }
     },
     "node_modules/@typescript-eslint/project-service": {
-      "version": "8.60.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.60.0.tgz",
-      "integrity": "sha512-aZu74NNKJeUWqCjDddzdiKaS82dgYgV/vmf+Ui3ZdZejmgfXR/q+pRumgobnQ2cCJTgGTWp4ypiwsuofFubavg==",
+      "version": "8.60.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.60.1.tgz",
+      "integrity": "sha512-eXkTH2bxmXlqD1RnOPmLZ9ZM9D3VwSx04JOwBnP9RQ+yUA5a2Mu7SfW8uaV2Aon53NJzZlZYuX7tn91Izf+xaw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/tsconfig-utils": "^8.60.0",
-        "@typescript-eslint/types": "^8.60.0",
+        "@typescript-eslint/tsconfig-utils": "^8.60.1",
+        "@typescript-eslint/types": "^8.60.1",
         "debug": "^4.4.3"
       },
       "engines": {
@@ -1017,14 +1017,14 @@
       }
     },
     "node_modules/@typescript-eslint/scope-manager": {
-      "version": "8.60.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.60.0.tgz",
-      "integrity": "sha512-pFzqhllJMs+jghLQWzV00ds39xLzuyqPSev5pd8f4Ir0rtKR3ZLUB4/4dhjOFighWb9larvtfJvqL+4yKDI3Xw==",
+      "version": "8.60.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.60.1.tgz",
+      "integrity": "sha512-gvI5OQoptnxQnchOirukCuQ55svJSTuD/4k5+pC267xyBtYry748R9/c3tYUzb/iE6RZfllRz2lVulLCHkTm4w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.60.0",
-        "@typescript-eslint/visitor-keys": "8.60.0"
+        "@typescript-eslint/types": "8.60.1",
+        "@typescript-eslint/visitor-keys": "8.60.1"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -1035,9 +1035,9 @@
       }
     },
     "node_modules/@typescript-eslint/tsconfig-utils": {
-      "version": "8.60.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.60.0.tgz",
-      "integrity": "sha512-BZPR3RGYlAXnly6ymAxfkVn5rCbZzQNou0rxv3GfWZ8cTQp+hhVd73khbGLAd8k1TlAPLISH337M+tAgAnaJDQ==",
+      "version": "8.60.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.60.1.tgz",
+      "integrity": "sha512-nh8w4qAteiKuZu3pSSzG/yGKpw0OlkrKnzFmbVRenKaD4qc+7i1GrmZaLVkr8rk4uipiPGMOW4YsM6WmKZ5CvA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1052,15 +1052,15 @@
       }
     },
     "node_modules/@typescript-eslint/type-utils": {
-      "version": "8.60.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.60.0.tgz",
-      "integrity": "sha512-SX46wEUtitCpq7AN38HkUU/+zvUpdKf7ephtWAFgckH8O7PQIyL5gvrhQgBLuEYgLfuKWOVvWVskMbuFHAz5xg==",
+      "version": "8.60.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.60.1.tgz",
+      "integrity": "sha512-sdwTrpjosW7ANQYJ39ZBF1ZyEMEGVB2UsikrserVM/30a/F1dTLnu9bGxEdosugyu5caigjLrR2qiD11asjI1A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.60.0",
-        "@typescript-eslint/typescript-estree": "8.60.0",
-        "@typescript-eslint/utils": "8.60.0",
+        "@typescript-eslint/types": "8.60.1",
+        "@typescript-eslint/typescript-estree": "8.60.1",
+        "@typescript-eslint/utils": "8.60.1",
         "debug": "^4.4.3",
         "ts-api-utils": "^2.5.0"
       },
@@ -1077,9 +1077,9 @@
       }
     },
     "node_modules/@typescript-eslint/types": {
-      "version": "8.60.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.60.0.tgz",
-      "integrity": "sha512-AsE7x2XaAK+CVbeih0Fvbn+r1qHxtpLDJ3XUuFcIinT318T90yHMJC+Zgv+jUuDjQQd06HKwxnDu6sz1IcTilA==",
+      "version": "8.60.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.60.1.tgz",
+      "integrity": "sha512-4h0tY8ppCkdCzcrl2YM5M3my0xsE1Tf8om3owEu5oPWmXwkKRmk0j0LGDzYBGUcAlesEbxBhazqu/K4cu3Ug7w==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1091,16 +1091,16 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree": {
-      "version": "8.60.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.60.0.tgz",
-      "integrity": "sha512-3AcZNBGMClm6CXDyo8kYvVGT/sx29sS0oBsIb9oZI2gunA4Vm2M3YHzRLPvsUBBsl+yB5FPtltq7gGH0iTlp9g==",
+      "version": "8.60.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.60.1.tgz",
+      "integrity": "sha512-alpRkfG8hlVE5kdJW2GkfgDgXxold3e8e4l6EnmhRmRLbekgAPCCGDVD++sABy9FcgPFroq+uFcCSM1vR57Cew==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/project-service": "8.60.0",
-        "@typescript-eslint/tsconfig-utils": "8.60.0",
-        "@typescript-eslint/types": "8.60.0",
-        "@typescript-eslint/visitor-keys": "8.60.0",
+        "@typescript-eslint/project-service": "8.60.1",
+        "@typescript-eslint/tsconfig-utils": "8.60.1",
+        "@typescript-eslint/types": "8.60.1",
+        "@typescript-eslint/visitor-keys": "8.60.1",
         "debug": "^4.4.3",
         "minimatch": "^10.2.2",
         "semver": "^7.7.3",
@@ -1119,16 +1119,16 @@
       }
     },
     "node_modules/@typescript-eslint/utils": {
-      "version": "8.60.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.60.0.tgz",
-      "integrity": "sha512-HtXuPfrHTyBDkameWpl+vJb1Uevu2tznAyahM1Oc4AENidCLTPiZDWIo4GfcxNdC/RcfGcadzzkqbRG87dUrQA==",
+      "version": "8.60.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.60.1.tgz",
+      "integrity": "sha512-h2MPBLoNtjc3qZWfY3Tl51yPorQ2McHn8pJfcMNTcIvrrZrr90Ykffit0yjrPFWQcRcUxzH20+6OcVdW4yHtUg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.9.1",
-        "@typescript-eslint/scope-manager": "8.60.0",
-        "@typescript-eslint/types": "8.60.0",
-        "@typescript-eslint/typescript-estree": "8.60.0"
+        "@typescript-eslint/scope-manager": "8.60.1",
+        "@typescript-eslint/types": "8.60.1",
+        "@typescript-eslint/typescript-estree": "8.60.1"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -1143,13 +1143,13 @@
       }
     },
     "node_modules/@typescript-eslint/visitor-keys": {
-      "version": "8.60.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.60.0.tgz",
-      "integrity": "sha512-9WI52t8ZGLVGrPMBet25yAftqY/n95+zmoUUtJBBQTKDSKUu7OsPTroT2op7U9JatkoRccL0YkWDNMFfC4Sjxg==",
+      "version": "8.60.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.60.1.tgz",
+      "integrity": "sha512-EbGRQg4FhrmwLodl+t3JNAnXHWVr9Vp+Zl1QBZVPY4ByfkzIT8cX3K6QWODHtkIZqqJVEWvhHSx3v5PDHsaQag==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.60.0",
+        "@typescript-eslint/types": "8.60.1",
         "eslint-visitor-keys": "^5.0.0"
       },
       "engines": {
@@ -2715,9 +2715,9 @@
       "license": "MIT"
     },
     "node_modules/semver": {
-      "version": "7.8.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.1.tgz",
-      "integrity": "sha512-rkVq3IXh+4FDGch+KwzX3aV9W3kO54GyEgpvBzSyctDA6Xtd7RJQV1xmXbeQp5v7+VzLOfVqiutSE6GICgPFvg==",
+      "version": "7.8.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.2.tgz",
+      "integrity": "sha512-c8jsqUZm3omBOI66G90z1Dyw5z622G8oLG+omfsHBJf3CWQTlOcwOjvOG6wtiNfW6anKm/eA39LMwMtMez2TiQ==",
       "dev": true,
       "license": "ISC",
       "bin": {
@@ -2992,16 +2992,16 @@
       }
     },
     "node_modules/typescript-eslint": {
-      "version": "8.60.0",
-      "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.60.0.tgz",
-      "integrity": "sha512-9f65qWLZdAW9m1JaxBDUHcqRUfL8bkxxXL7XxEfI+F09q56PkBvIfCjLF3yInsDM/BBmwkqmCQdCZe/RYlIWEw==",
+      "version": "8.60.1",
+      "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.60.1.tgz",
+      "integrity": "sha512-6m5hkkRAp8lKvhVpcprAIn5KkehQEh+47oHH2VGnExEh7dhNxXlg6GPAOIu6TxbVQxhebrJDvjl3020ooiWCMA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/eslint-plugin": "8.60.0",
-        "@typescript-eslint/parser": "8.60.0",
-        "@typescript-eslint/typescript-estree": "8.60.0",
-        "@typescript-eslint/utils": "8.60.0"
+        "@typescript-eslint/eslint-plugin": "8.60.1",
+        "@typescript-eslint/parser": "8.60.1",
+        "@typescript-eslint/typescript-estree": "8.60.1",
+        "@typescript-eslint/utils": "8.60.1"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -913,9 +913,9 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "25.9.1",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.9.1.tgz",
-      "integrity": "sha512-xfrlY7UD5rMJk3ZVJP8BNzS28J36YJg+xp+LPXV1TdWxr8uMH5A860QNxYDGQe/ylDSgjxE52Q9VnO7p75tJxg==",
+      "version": "25.9.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.9.2.tgz",
+      "integrity": "sha512-G05zqtJhcDLb8uslf5EjCxXg9G1KQxiV8OS0R26IC//Eoyitzqe8z37I7cqvnZlrlSfgocQRfSn/AHBZJJFyGw==",
       "license": "MIT",
       "dependencies": {
         "undici-types": ">=7.24.0 <7.24.7"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@pasympa/discord-mcp",
   "version": "1.7.1",
-  "mcpName": "io.github.pasympa/discord-mcp",
+  "mcpName": "io.github.PaSympa/discord-mcp",
   "description": "A lightweight, multi-guild Discord MCP server with 95+ tools",
   "main": "dist/index.js",
   "type": "commonjs",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pasympa/discord-mcp",
-  "version": "1.7.1",
+  "version": "1.7.2",
   "mcpName": "io.github.PaSympa/discord-mcp",
   "description": "A lightweight, multi-guild Discord MCP server with 95+ tools",
   "main": "dist/index.js",

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "format": "prettier --write .",
     "format:check": "prettier --check .",
     "test": "node --import tsx --test test/*.test.ts",
+    "version": "node scripts/sync-version.js && git add server.json",
     "prepublishOnly": "npm run build"
   },
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@pasympa/discord-mcp",
-  "version": "1.7.0",
+  "version": "1.7.1",
+  "mcpName": "io.github.pasympa/discord-mcp",
   "description": "A lightweight, multi-guild Discord MCP server with 95+ tools",
   "main": "dist/index.js",
   "type": "commonjs",

--- a/scripts/sync-version.js
+++ b/scripts/sync-version.js
@@ -1,0 +1,16 @@
+// Keeps server.json (MCP Registry manifest) in lockstep with package.json.
+// Runs as the npm `version` lifecycle script, so `npm version patch|minor|major`
+// bumps package.json, package-lock.json and server.json in one go.
+const fs = require("fs");
+const path = require("path");
+
+const { version } = require(path.join(__dirname, "..", "package.json"));
+const serverJsonPath = path.join(__dirname, "..", "server.json");
+
+const server = JSON.parse(fs.readFileSync(serverJsonPath, "utf8"));
+server.version = version;
+for (const pkg of server.packages ?? []) {
+  pkg.version = version;
+}
+fs.writeFileSync(serverJsonPath, JSON.stringify(server, null, 2) + "\n");
+console.log(`server.json synced to ${version}`);

--- a/server.json
+++ b/server.json
@@ -1,0 +1,29 @@
+{
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+  "name": "io.github.pasympa/discord-mcp",
+  "description": "A lightweight, multi-guild Discord MCP server with 95+ tools",
+  "repository": {
+    "url": "https://github.com/PaSympa/discord-mcp",
+    "source": "github"
+  },
+  "version": "1.7.1",
+  "packages": [
+    {
+      "registryType": "npm",
+      "identifier": "@pasympa/discord-mcp",
+      "version": "1.7.1",
+      "transport": {
+        "type": "stdio"
+      },
+      "environmentVariables": [
+        {
+          "name": "DISCORD_TOKEN",
+          "description": "Discord bot token",
+          "isRequired": true,
+          "isSecret": true,
+          "format": "string"
+        }
+      ]
+    }
+  ]
+}

--- a/server.json
+++ b/server.json
@@ -6,12 +6,12 @@
     "url": "https://github.com/PaSympa/discord-mcp",
     "source": "github"
   },
-  "version": "1.7.1",
+  "version": "1.7.2",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "@pasympa/discord-mcp",
-      "version": "1.7.1",
+      "version": "1.7.2",
       "transport": {
         "type": "stdio"
       },

--- a/server.json
+++ b/server.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
-  "name": "io.github.pasympa/discord-mcp",
+  "name": "io.github.PaSympa/discord-mcp",
   "description": "A lightweight, multi-guild Discord MCP server with 95+ tools",
   "repository": {
     "url": "https://github.com/PaSympa/discord-mcp",


### PR DESCRIPTION
Closes the release-readiness findings from the branch audit:

- Merges `main` into `release/2.0`: brings 1.7.2 version, `mcpName`, `server.json`, the release automation (MCP Registry OIDC job, version-sync script, tag guard) and the 1.7.1/1.7.2 changelog entries. Dep ranges verified post-merge (the known silent-keep pitfall did not recur); lockfile keeps Dependabot's 25.9.2/8.60.1 and bumps zod to 4.4.3 (suite green, httpUrl behavior verified)
- CHANGELOG: new `Unreleased — 2.0.0` section with the full breaking-changes inventory (strict numeric bounds, hex-only colors, http(s)-only URLs, offset-required datetimes, dry_run safe defaults, protocol errors, structured output, `scheduled_events` rename) and the three new env vars
- CONTRIBUTING: tool template rewritten to the actual `defineTool`/`defineModule`/zod API (was still teaching the removed `definitions`/`handle()` switch pattern), conventions updated (shared fields, central channel resolution, `structured()`)
- .env.example: documents `DISCORD_MCP_TOOLSETS` and `DISCORD_ALLOWED_GUILDS`

Note: version stays 1.7.2 here — the 2.0.0 bump happens at release time via `npm version major` per the documented process.