### PR TITLE
fix: doc-audit round — docs aligned with behavior, crosspost + delete-reason bugs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,9 +10,9 @@ RUN npm run build
 FROM node:26-alpine
 
 LABEL org.opencontainers.image.title="Discord MCP Server"
-LABEL org.opencontainers.image.description="A lightweight, multi-guild Discord MCP server with 90+ tools"
+LABEL org.opencontainers.image.description="A lightweight, multi-guild Discord MCP server with 97 tools"
 LABEL org.opencontainers.image.source="https://github.com/PaSympa/discord-mcp"
-LABEL org.opencontainers.image.license="MIT"
+LABEL org.opencontainers.image.licenses="MIT"
 
 WORKDIR /app
 COPY package*.json ./

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 [![npm](https://img.shields.io/npm/v/@pasympa/discord-mcp)](https://www.npmjs.com/package/@pasympa/discord-mcp)
 [![License](https://img.shields.io/github/license/PaSympa/discord-mcp)](LICENSE)
-[![Node](https://img.shields.io/badge/node-%3E%3D18-green)](https://nodejs.org)
+[![Node](https://img.shields.io/badge/node-%3E%3D20-green)](https://nodejs.org)
 [![Discord.js](https://img.shields.io/badge/discord.js-v14-5865F2)](https://discord.js.org)
 [![MCP](https://img.shields.io/badge/MCP-compatible-purple)](https://modelcontextprotocol.io)
 
@@ -23,7 +23,7 @@ Messages, channels, roles, permissions, moderation, forums, webhooks — all thr
 
 - **95+ tools** — messages, channels, roles, permissions, moderation, forums, webhooks, scheduled events, invites, DMs, embeds, and more
 - **Multi-guild** — works across multiple servers, no `GUILD_ID` lock-in
-- **Lightweight** — TypeScript + Node.js, ~25kB package, ~73MB Docker image (vs 400MB+ for Java alternatives)
+- **Lightweight** — TypeScript + Node.js, ~70kB package, ~73MB Docker image (vs 400MB+ for Java alternatives)
 - **Modular** — clean architecture, easy to extend with new tools
 - **Two install methods** — npm or Docker, your choice
 
@@ -177,19 +177,19 @@ The server loads `.env` automatically via `dotenv`.
 
 ### Environment variables
 
-| Variable                  | Default | Description                                                                                                                                                                      |
-| ------------------------- | ------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `DISCORD_TOKEN`           | —       | **Required.** Bot token.                                                                                                                                                         |
-| `DISCORD_MESSAGE_CONTENT` | `true`  | Set to `false` to stop requesting the Message Content privileged gateway intent at connect time.                                                                                 |
-| `DISCORD_GUILD_MEMBERS`   | `true`  | Set to `false` to stop requesting the Server Members privileged gateway intent at connect time.                                                                                  |
-| `DISCORD_MCP_TOOLSETS`    | `all`   | Comma-separated list of toolsets to expose, to keep the tool list small. Unset or `all` exposes every tool.                                                                      |
-| `DISCORD_ALLOWED_GUILDS`  | all     | Comma-separated guild IDs the server may act on. When set, tool calls targeting any other guild are rejected — whether addressed by guild ID, channel ID, thread ID, or webhook. |
+| Variable                  | Default | Description                                                                                                                                                                                   |
+| ------------------------- | ------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `DISCORD_TOKEN`           | —       | **Required.** Bot token.                                                                                                                                                                      |
+| `DISCORD_MESSAGE_CONTENT` | `true`  | Set to `false` to stop requesting the Message Content privileged gateway intent at connect time.                                                                                              |
+| `DISCORD_GUILD_MEMBERS`   | `true`  | Set to `false` to stop requesting the Server Members privileged gateway intent at connect time.                                                                                               |
+| `DISCORD_MCP_TOOLSETS`    | `all`   | Comma-separated list of toolsets to expose, to keep the tool list small. Unset or `all` exposes every tool.                                                                                   |
+| `DISCORD_ALLOWED_GUILDS`  | all     | Comma-separated guild IDs the server may act on. When set, tool calls targeting any other guild are rejected — whether addressed by guild ID, channel ID, thread ID, webhook, or invite code. |
 
-These flags only control which gateway intents the server requests when identifying. Requesting a privileged intent that is **not** enabled in the Developer Portal makes the connection fail at startup (close code `4014`) — set the flag to `false` to connect anyway.
+These flags only control which gateway intents the server requests when identifying. Requesting a privileged intent that is **not** enabled in the Developer Portal makes the connection fail at the first tool call (close code `4014`) — set the flag to `false` to connect anyway.
 
 Data access is governed by the **portal toggles**, not by these flags: this server reads everything over the REST API, which Discord gates on the portal setting alone. So with the portal toggles on, setting these flags to `false` loses nothing. With a portal toggle **off**, the corresponding data is restricted regardless of the flags: message bodies come back empty (`content`, `embeds`, `attachments` — except the bot's own messages, DMs, and messages that mention the bot) and member listing fails — enable the toggle in the portal to restore it.
 
-**Toolsets** (`DISCORD_MCP_TOOLSETS`): `discovery`, `messages`, `channels`, `permissions`, `members`, `roles`, `moderation`, `screening`, `stats`, `forums`, `webhooks`, `scheduled_events`, `invites`, `dm`. Example — read-only navigation only: `DISCORD_MCP_TOOLSETS=discovery,messages,members`. Only the listed toolsets' tools are advertised and callable. Unknown names make the server fail at startup instead of silently exposing everything.
+**Toolsets** (`DISCORD_MCP_TOOLSETS`): `discovery`, `messages`, `channels`, `permissions`, `members`, `roles`, `moderation`, `screening`, `stats`, `forums`, `webhooks`, `scheduled_events`, `invites`, `dm`. Example — read-only navigation only: `DISCORD_MCP_TOOLSETS=discovery,messages,members`. Only the listed toolsets' tools are advertised and callable. Unknown names make the server fail at startup instead of silently exposing everything (an empty value counts as unset and exposes all).
 
 ---
 
@@ -202,11 +202,11 @@ Data access is governed by the **portal toggles**, not by these flags: this serv
    - Server Members Intent
    - Message Content Intent
 
-   > **Important:** if the bot requests a privileged intent that is not enabled here, Discord closes the connection with code `4014` and every tool call fails at startup. Enable both, or disable the ones you don't need via the env flags below.
+   > **Important:** if the bot requests a privileged intent that is not enabled here, Discord closes the connection with code `4014` and every tool call fails. Enable both, or disable the ones you don't need via the env flags below.
 
 5. **OAuth2 > URL Generator**:
    - Scopes: `bot`
-   - Permissions: `Send Messages`, `Read Message History`, `Manage Channels`, `Manage Roles`, `Kick Members`, `Ban Members`, `Moderate Members`, `View Audit Log`, `Manage Messages`, `Manage Threads`, `Add Reactions`, `Manage Guild`, `Manage Webhooks`, `Manage Events`, `Create Instant Invite`
+   - Permissions: `Send Messages`, `Read Message History`, `Manage Channels`, `Manage Roles`, `Kick Members`, `Ban Members`, `Moderate Members`, `View Audit Log`, `Manage Messages`, `Manage Threads`, `Add Reactions`, `Manage Guild`, `Manage Webhooks`, `Manage Events`, `Create Instant Invite`, `Manage Nicknames`, `Pin Messages`, `Embed Links`, `Create Public Threads`
 6. Copy the generated URL and invite the bot to your server
 
 ---
@@ -417,8 +417,10 @@ discord-mcp/
 │   ├── index.ts             ← Entry point (MCP server + transport)
 │   ├── client.ts            ← Discord client + shared helpers
 │   ├── constants.ts         ← Shared constants (limits, defaults)
+│   ├── embeds.ts            ← Shared embed schema + builder
 │   └── tools/
-│       ├── index.ts         ← Tool registry
+│       ├── index.ts         ← Tool registry (toolset gating, dispatch)
+│       ├── define.ts        ← defineTool/defineModule + shared zod fields
 │       ├── types.ts         ← Shared TypeScript interfaces
 │       ├── discovery.ts     ← Guild/channel discovery
 │       ├── messages.ts      ← Message CRUD, reactions, threads, embeds

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -5,7 +5,7 @@
 If you discover a security vulnerability in this project, please report it responsibly:
 
 1. **Do not** open a public GitHub issue
-2. Email the maintainer or use [GitHub Security Advisories](https://github.com/PaSympa/discord-mcp/security/advisories/new)
+2. Use [GitHub Security Advisories](https://github.com/PaSympa/discord-mcp/security/advisories/new) (private report to the maintainer)
 3. Include a description of the vulnerability and steps to reproduce
 
 ## Bot Token Security

--- a/src/client.ts
+++ b/src/client.ts
@@ -10,7 +10,7 @@ import {
 } from "discord.js";
 
 // ─── Discord Client ────────────────────────────────────────────────────────────
-// Initializes the Discord.js client with the required gateway intents
+// Initializes the Discord.js client with the gateway intents (privileged ones are opt-out via env)
 // and exposes shared helper functions used across all tool modules.
 // ────────────────────────────────────────────────────────────────────────────────
 
@@ -108,10 +108,12 @@ function allowedGuilds(): string[] {
     .filter(Boolean);
 }
 
+/** True when DISCORD_ALLOWED_GUILDS contains at least one guild ID. */
 export function allowListActive(): boolean {
   return allowedGuilds().length > 0;
 }
 
+/** True if the guild is in DISCORD_ALLOWED_GUILDS — or when no allow-list is configured (empty list allows all guilds). */
 export function isGuildAllowed(guildId: string): boolean {
   const list = allowedGuilds();
   return list.length === 0 || list.includes(guildId);
@@ -134,12 +136,11 @@ export async function fetchChannelChecked(channelId: string) {
 }
 
 /**
- * Fetches a channel by ID and guarantees it is a text-capable guild channel
- * (a TextChannel or any thread inside one — announcement / public / private / forum).
- * Both class hierarchies expose the message-send / edit / fetch surface used by
- * the message tools, so the wrapper accepts either.
+ * Fetches a channel by ID and guarantees it is a TextChannel or a thread of any
+ * kind (public / private / forum post / announcement thread) — both expose the
+ * message-send / edit / fetch surface the message tools use. Announcement (News)
+ * channels themselves do NOT pass this check.
  * @param channelId - Discord snowflake ID of the channel.
- * @returns The resolved TextChannel or ThreadChannel instance.
  * @throws {Error} If the channel does not exist or is neither a text channel nor a thread.
  */
 export async function getTextChannel(channelId: string): Promise<TextChannel | ThreadChannel> {
@@ -151,9 +152,9 @@ export async function getTextChannel(channelId: string): Promise<TextChannel | T
 }
 
 /**
- * Fetches a channel by ID and guarantees it is a guild channel (text, voice, or category).
+ * Fetches a channel by ID and guarantees it is a non-thread guild channel
+ * (text, voice, category, announcement, stage, forum…).
  * @param channelId - Discord snowflake ID of the channel.
- * @returns The resolved GuildChannel instance.
  * @throws {Error} If the channel does not exist or is not a guild channel.
  */
 export async function getGuildChannel(channelId: string): Promise<GuildChannel> {

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -3,7 +3,7 @@
 /** Maximum number of items the Discord API returns per fetch. */
 export const MAX_FETCH_LIMIT = 100;
 
-/** Default fetch limits by context. */
+/** Default and maximum fetch limits by context. */
 export const DEFAULTS = {
   MESSAGES: 20,
   MEMBERS: 50,

--- a/src/embeds.ts
+++ b/src/embeds.ts
@@ -47,7 +47,7 @@ export const embedFieldsShape = {
 /** Schema for a single embed object (e.g. an item of `discord_send_multiple_embeds`). */
 export const embedObjectSchema = z.object(embedFieldsShape);
 
-/** Validated embed input — the typed shape `buildEmbed` consumes from migrated tools. */
+/** Validated embed input — the typed shape `buildEmbed` consumes. */
 export type EmbedInput = z.infer<typeof embedObjectSchema>;
 
 /**

--- a/src/tools/define.ts
+++ b/src/tools/define.ts
@@ -82,11 +82,11 @@ interface RegisteredTool {
  * client-facing `inputSchema` and validates incoming args, so `handle` receives
  * values already typed and checked — no `as` casts, no schema/handler drift.
  * An optional `outputSchema` (a `z.object`) derives the advertised `outputSchema`
- * and checks the handler's `structuredContent` against it on the way out. The check
- * is non-fatal here, but conformance is a spec MUST and SDK clients reject
- * non-conforming results — so a logged drift warning is a release blocker, not noise.
- * A conforming result is normalised (unknown keys dropped) and its text block
- * regenerated so both representations stay identical.
+ * and checks the handler's `structuredContent` against it on the way out: a
+ * conforming result is normalised (unknown keys dropped, text block regenerated to
+ * match); a non-conforming one is rejected — the call returns an `isError` result
+ * and the mismatch is logged, because conformance is a spec MUST and SDK clients
+ * reject non-conforming results anyway.
  */
 export function defineTool<S extends z.ZodType>(tool: {
   name: string;
@@ -135,6 +135,7 @@ export function defineTool<S extends z.ZodType>(tool: {
  * Assembles a list of {@link defineTool} tools into a {@link ToolModule}: their
  * client-facing definitions and a name→handler map the registry merges for O(1)
  * dispatch. Validation runs inside each tool's `run`.
+ * @throws {Error} If two tools in the list share a name.
  */
 export function defineModule(tools: RegisteredTool[]): ToolModule {
   const definitions: ToolDefinition[] = tools.map((t) => ({

--- a/src/tools/dm.ts
+++ b/src/tools/dm.ts
@@ -105,7 +105,7 @@ const tools = [
   defineTool({
     name: "discord_read_dms",
     description:
-      "Read the most recent messages from the bot's DM conversation with a user, oldest-to-newest. Returns a JSON array (id, author, content, embed count, timestamp). Read-only.",
+      "Read the most recent messages from the bot's DM conversation with a user, oldest-to-newest. Returns { messages: [...] } with id, author, content, embed count, timestamp. Read-only.",
     annotations: { title: "Read DMs", readOnlyHint: true, openWorldHint: true },
     schema: z.object({
       user_id: userId,

--- a/src/tools/forums.ts
+++ b/src/tools/forums.ts
@@ -117,7 +117,7 @@ const tools = [
       "Get a forum post's details (title, archived/locked state, applied tags, message count) plus its recent messages, oldest-to-newest. Read-only. Pass the post's thread_id. Returns a JSON object.",
     annotations: { title: "Get forum post", readOnlyHint: true, openWorldHint: true },
     schema: z.object({
-      thread_id: threadId.describe("ID (snowflake) of the forum post (thread)."),
+      thread_id: threadId,
       limit: intIn(1, 100).default(20).describe("How many recent messages to include (1–100). Default 20."),
     }),
     outputSchema: threadSummary.extend({
@@ -193,7 +193,7 @@ const tools = [
   defineTool({
     name: "discord_reply_to_forum",
     description:
-      "Post a follow-up message inside an existing forum post (thread). Requires the Send Messages permission. Use discord_create_forum_post to start a new post instead. Returns the new message ID.",
+      "Post a follow-up message inside an existing forum post (thread). Requires the Send Messages in Threads permission (shown as 'Send Messages in Posts' for forums). Use discord_create_forum_post to start a new post instead. Returns the new message ID.",
     annotations: { title: "Reply to forum post", readOnlyHint: false, destructiveHint: false, idempotentHint: false, openWorldHint: true },
     schema: z.object({
       thread_id: snowflake.describe("ID (snowflake) of the forum post (thread) to reply in."),
@@ -208,7 +208,7 @@ const tools = [
   defineTool({
     name: "discord_delete_forum_post",
     description:
-      "Permanently delete a forum post (thread) and all its messages. IRREVERSIBLE. To merely close it without deleting, use discord_update_forum_post with archived:true. Requires the Manage Threads permission (or thread ownership).",
+      "Permanently delete a forum post (thread) and all its messages. IRREVERSIBLE. To merely close it without deleting, use discord_update_forum_post with archived:true. Requires the Manage Threads permission.",
     annotations: { title: "Delete forum post", readOnlyHint: false, destructiveHint: true, idempotentHint: false, openWorldHint: true },
     schema: z.object({
       thread_id: snowflake.describe("ID (snowflake) of the forum post (thread) to delete."),
@@ -274,7 +274,7 @@ const tools = [
   defineTool({
     name: "discord_update_forum_post",
     description:
-      "Update a forum post's title, archived/locked state, or applied tags. Only provided fields change; passing applied_tags replaces the post's tags. Set archived:true to close a post without deleting it. Requires the Manage Threads permission (or thread ownership).",
+      "Update a forum post's title, archived/locked state, or applied tags. Only provided fields change; passing applied_tags replaces the post's tags. Set archived:true to close a post without deleting it. Requires the Manage Threads permission.",
     annotations: { title: "Update forum post", readOnlyHint: false, destructiveHint: false, idempotentHint: true, openWorldHint: true },
     schema: z.object({
       thread_id: snowflake.describe("ID (snowflake) of the forum post (thread) to update."),

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -45,8 +45,8 @@ const allToolsets: Record<string, ToolModule> = {
 
 /**
  * Selects which toolsets to expose from `DISCORD_MCP_TOOLSETS` (comma-separated,
- * case-insensitive; `all` or unset exposes everything). Unknown or empty selections
- * throw at startup: a typo must not silently expose the full destructive surface.
+ * case-insensitive). Unset, empty, or `all` exposes everything; unknown names throw
+ * at startup — a typo must not silently expose the full destructive surface.
  */
 export function selectModules(): ToolModule[] {
   const raw = process.env.DISCORD_MCP_TOOLSETS?.trim();
@@ -86,7 +86,7 @@ const registry: Map<string, ToolHandler> = (() => {
 
 /**
  * Returns every tool definition across all modules.
- * Called once when the MCP client requests the tool list.
+ * Called on each tools/list request from the MCP client.
  */
 export function getAllDefinitions(): ToolDefinition[] {
   return modules.flatMap((m) => m.definitions);

--- a/src/tools/invites.ts
+++ b/src/tools/invites.ts
@@ -7,6 +7,8 @@ import { defineTool, defineModule, snowflake, guildId, intIn, structured } from 
 const inviteSummary = z.object({
   code: z.string(),
   url: z.string(),
+  guild_id: z.string().nullable(),
+  guild_name: z.string().nullable(),
   channel_id: z.string().nullable(),
   channel_name: z.string().nullable(),
   inviter: z
@@ -27,6 +29,8 @@ function serializeInvite(invite: import("discord.js").Invite) {
   return {
     code: invite.code,
     url: invite.url,
+    guild_id: invite.guild?.id ?? null,
+    guild_name: invite.guild?.name ?? null,
     channel_id: invite.channelId ?? null,
     channel_name: invite.channel?.name ?? null,
     inviter: invite.inviter ? { id: invite.inviter.id, username: invite.inviter.username } : null,
@@ -62,7 +66,7 @@ const tools = [
   defineTool({
     name: "discord_get_invite",
     description:
-      "Look up details for a single invite by its code, including the target server/channel and usage stats. Works for any public invite, not just this server's. Read-only. Returns a JSON object.",
+      "Look up a single invite by its code: target server and channel, inviter, uses, and expiry. Works for any public invite, but usage counters are only populated for servers the bot is in (0 otherwise). Read-only. Returns a JSON object.",
     annotations: { title: "Get invite", readOnlyHint: true, openWorldHint: true },
     schema: z.object({
       invite_code: z

--- a/src/tools/members.ts
+++ b/src/tools/members.ts
@@ -150,7 +150,7 @@ const tools = [
   defineTool({
     name: "discord_search_members",
     description:
-      "Find server members whose username or nickname starts with a query string (prefix match). Returns a JSON array (id, username, nickname, roles). Use discord_list_members to page through everyone. Read-only.",
+      "Find server members whose username or nickname starts with a query string (prefix match). Returns { members: [...] } with id, username, nickname, roles. Use discord_list_members to page through everyone. Read-only.",
     annotations: { title: "Search members", readOnlyHint: true, openWorldHint: true },
     schema: z.object({
       guild_id: guildId,

--- a/src/tools/messages.ts
+++ b/src/tools/messages.ts
@@ -5,9 +5,10 @@ import {
   PrivateThreadChannel,
   Message,
   MessageReaction,
+  Routes,
 } from "discord.js";
 import { z } from "zod";
-import { discord, getTextChannel } from "../client.js";
+import { discord, getTextChannel, fetchChannelChecked } from "../client.js";
 import { MAX_FETCH_LIMIT, DEFAULTS } from "../constants.js";
 import { buildEmbed, embedFieldsShape, embedObjectSchema } from "../embeds.js";
 import { defineModule, defineTool, snowflake, intIn, structured } from "./define.js";
@@ -34,12 +35,12 @@ function findReaction(msg: Message, emoji: string): MessageReaction | undefined 
   return msg.reactions.cache.get(key);
 }
 
-/** Tool definitions for reading, sending, replying, editing, reacting, threading, embedding, deleting, pinning, and searching messages. */
+/** Tool definitions for channel and thread messages. */
 const tools = [
   defineTool({
     name: "discord_read_messages",
     description:
-      "Read the most recent messages from a text channel or thread, oldest-to-newest. Returns a JSON array of messages (id, author, content, timestamp, attachment count, pinned flag). Use discord_search_messages to filter by keyword, or discord_fetch_pinned_messages for pinned messages only.",
+      "Read the most recent messages from a text channel or thread, oldest-to-newest. Returns { messages: [...] } with id, author, content, timestamp, attachment count, pinned flag. Use discord_search_messages to filter by keyword, or discord_fetch_pinned_messages for pinned messages only.",
     annotations: { title: "Read messages", readOnlyHint: true, openWorldHint: true },
     schema: z.object({
       channel_id: snowflake.describe("ID (snowflake) of the channel or thread to read from."),
@@ -239,10 +240,11 @@ const tools = [
       message_id: messageId.describe("ID of the message to delete."),
       reason: z.string().optional().describe("Optional reason recorded in the server audit log."),
     }),
-    handle: async ({ channel_id, message_id }) => {
+    handle: async ({ channel_id, message_id, reason }) => {
       const channel = await getTextChannel(channel_id);
-      const msg = await channel.messages.fetch(message_id);
-      await msg.delete();
+      await channel.messages.fetch(message_id);
+      // msg.delete() cannot carry an audit-log reason; the raw REST call sets X-Audit-Log-Reason.
+      await discord.rest.delete(Routes.channelMessage(channel.id, message_id), { reason });
       return { content: [{ type: "text", text: `✅ Message ${message_id} deleted.` }] };
     },
   }),
@@ -295,7 +297,9 @@ const tools = [
       message_id: messageId.describe("ID of the message to publish to followers."),
     }),
     handle: async ({ channel_id, message_id }) => {
-      const channel = await getTextChannel(channel_id);
+      const channel = await fetchChannelChecked(channel_id);
+      if (!channel || channel.type !== ChannelType.GuildAnnouncement)
+        throw new Error("Channel is not an announcement channel — only announcement-channel messages can be published.");
       const msg = await channel.messages.fetch(message_id);
       await msg.crosspost();
       return { content: [{ type: "text", text: `✅ Message ${msg.id} published to all followers of #${channel.name}.` }] };
@@ -332,7 +336,7 @@ const tools = [
   defineTool({
     name: "discord_get_reactions",
     description:
-      "List the users who reacted to a message with a specific emoji. Returns a JSON array of users (id, username, bot flag). Read-only.",
+      "List the users who reacted to a message with a specific emoji. Returns { reactions: [...] } with id, username, bot flag. Read-only.",
     annotations: { title: "Get reactions", readOnlyHint: true, openWorldHint: true },
     schema: z.object({
       channel_id: channelId.describe("ID (snowflake) of the channel or thread containing the message."),

--- a/src/tools/moderation.ts
+++ b/src/tools/moderation.ts
@@ -3,7 +3,6 @@ import { z } from "zod";
 import { discord } from "../client.js";
 import { defineTool, defineModule, guildId, intIn, structured } from "./define.js";
 
-/** Tool definitions for server moderation (audit log). */
 const auditLogEntry = z.object({
   id: z.string(),
   action: z.number(),
@@ -13,11 +12,12 @@ const auditLogEntry = z.object({
   createdAt: z.string(),
 });
 
+/** Tool definitions for server moderation (audit log). */
 const tools = [
   defineTool({
     name: "discord_get_audit_log",
     description:
-      "Fetch the server's audit log — a record of administrative actions (bans, kicks, role/channel changes, etc.) with who performed them and when. Requires the View Audit Log permission. Returns a JSON array (id, action, executor, target, reason, timestamp). Read-only.",
+      "Fetch the server's audit log — a record of administrative actions (bans, kicks, role/channel changes, etc.) with who performed them and when. Requires the View Audit Log permission. Returns { entries: [...] } with id, action, executor, target, reason, createdAt. Read-only.",
     annotations: { title: "Get audit log", readOnlyHint: true, openWorldHint: true },
     schema: z.object({
       guild_id: guildId,

--- a/src/tools/permissions.ts
+++ b/src/tools/permissions.ts
@@ -133,7 +133,7 @@ const tools = [
   defineTool({
     name: "discord_audit_permissions",
     description:
-      "Generate a server-wide permission report: for every channel that has overwrites, lists each role/member and their allowed/denied permissions (entity names resolved). Read-only. Returns a JSON array. Use discord_get_channel_permissions for a single channel.",
+      "Generate a server-wide permission report: for every channel that has overwrites, lists each role/member and their allowed/denied permissions (entity names resolved). Read-only. Returns { channels: [...] } with channel, channelId, overwrites. Use discord_get_channel_permissions for a single channel.",
     annotations: { title: "Audit permissions", readOnlyHint: true, openWorldHint: true },
     schema: z.object({
       guild_id: guildId,

--- a/src/tools/roles.ts
+++ b/src/tools/roles.ts
@@ -32,10 +32,7 @@ function parsePerms(raw: string[] | string | undefined): string[] | undefined {
   return undefined;
 }
 
-/**
- * Validates a role_id argument, fetches the role, and guarantees it exists.
- * @throws {Error} If the id is not a valid snowflake or the role is not found.
- */
+/** Fetches a role by ID, throwing a clear error if it does not exist in the guild. */
 async function fetchRole(guild: Guild, rawId: string): Promise<Role> {
   const role = await guild.roles.fetch(rawId);
   if (!role) throw new Error(`Role ${rawId} not found in this server.`);
@@ -47,7 +44,7 @@ const tools = [
   defineTool({
     name: "discord_list_roles",
     description:
-      "List all roles in a server (excluding @everyone), highest-first, with color, position, member count, and permissions. Read-only. Returns a JSON array. Use discord_get_role_members to see who holds a given role.",
+      "List all roles in a server (excluding @everyone), highest-first, with color, position, member count, and permissions. Read-only. Returns { roles: [...] }. Use discord_get_role_members to see who holds a given role.",
     annotations: { title: "List roles", readOnlyHint: true, openWorldHint: true },
     schema: z.object({
       guild_id: guildId,
@@ -240,7 +237,7 @@ const tools = [
   defineTool({
     name: "discord_get_role_members",
     description:
-      "List every member who currently holds a specific role. Returns a JSON array (id, username, nickname). Read-only. Use discord_list_roles to discover role IDs first.",
+      "List members who currently hold a specific role, scanning up to 20,000 members. Returns { members: [...], truncated } — check `truncated` on very large servers. Read-only. Use discord_list_roles to discover role IDs first.",
     annotations: { title: "Get role members", readOnlyHint: true, openWorldHint: true },
     schema: z.object({
       guild_id: guildId,

--- a/src/tools/scheduledEvents.ts
+++ b/src/tools/scheduledEvents.ts
@@ -279,14 +279,7 @@ const tools = [
       if (channel_id) options.channel = channel_id;
       if (location) options.entityMetadata = { location };
       if (image) options.image = image;
-      if (status) {
-        const statusVal = STATUS_MAP[status];
-        if (!statusVal)
-          throw new Error(
-            `Invalid status: "${status}". Must be SCHEDULED, ACTIVE, COMPLETED, or CANCELED.`,
-          );
-        options.status = statusVal;
-      }
+      if (status) options.status = STATUS_MAP[status];
 
       const updated = await event.edit(
         options as unknown as GuildScheduledEventEditOptions<

--- a/src/tools/screening.ts
+++ b/src/tools/screening.ts
@@ -7,7 +7,7 @@ const tools = [
   defineTool({
     name: "discord_get_membership_screening",
     description:
-      "Fetch the server's membership screening form — the rules/questions new members must accept before gaining access. Requires the server to have the Community feature enabled. Read-only. Returns the raw form as JSON (including its version, needed by the update tool).",
+      "Fetch the server's membership screening form — the rules/questions new members must accept before gaining access. Requires the server to have the Community feature enabled. Read-only. Returns the form as JSON, including its version.",
     annotations: { title: "Get membership screening", readOnlyHint: true, openWorldHint: true },
     schema: z.object({
       guild_id: guildId,

--- a/src/tools/stats.ts
+++ b/src/tools/stats.ts
@@ -34,16 +34,19 @@ const tools = [
       await guild.channels.fetch();
       const cachedBots = guild.members.cache.filter((m) => m.user.bot).size;
       return structured({
-        name: guild.name, totalMembers: guild.memberCount,
-        humans: guild.memberCount - cachedBots, botsInCache: cachedBots,
+        name: guild.name,
+        totalMembers: guild.memberCount,
+        humans: guild.memberCount - cachedBots,
+        botsInCache: cachedBots,
         channels: {
           total: guild.channels.cache.size,
           text: guild.channels.cache.filter((c) => c.type === ChannelType.GuildText).size,
           voice: guild.channels.cache.filter((c) => c.type === ChannelType.GuildVoice).size,
           categories: guild.channels.cache.filter((c) => c.type === ChannelType.GuildCategory).size,
         },
-        roles: guild.roles.cache.size - 1,
-        boostLevel: guild.premiumTier, boostCount: guild.premiumSubscriptionCount ?? 0,
+        roles: guild.roles.cache.size - 1 /* excludes @everyone */,
+        boostLevel: guild.premiumTier,
+        boostCount: guild.premiumSubscriptionCount ?? 0,
         createdAt: guild.createdAt.toISOString(),
       });
     },

--- a/src/tools/webhooks.ts
+++ b/src/tools/webhooks.ts
@@ -16,7 +16,7 @@ const webhookSummary = z.object({
   creator: z.string().nullable(),
 });
 
-/** Tool definitions for creating, sending via, editing, deleting, and listing webhooks. */
+/** Tool definitions for managing webhooks and webhook-sent messages. */
 const tools = [
   defineTool({
     name: "discord_create_webhook",


### PR DESCRIPTION
Implements all 42 confirmed findings from the web-verified documentation workflow audit (20 agents, adversarial verification).

Code bugs found through doc audit:
- `discord_crosspost_message` could never work: it resolved the channel via `getTextChannel`, which rejects announcement channels — the only type crosspost serves. Now fetches via `fetchChannelChecked` and checks `GuildAnnouncement`
- `discord_delete_message` silently ignored its `reason` parameter; now deletes via the raw REST route so `X-Audit-Log-Reason` is sent
- `discord_get_invite` now returns `guild_id`/`guild_name` (description promised the target server; schema had no guild field) and documents the foreign-invite counter caveat
- dead `SCHEDULED` status guard removed (zod enum already excludes it)

Doc corrections (~38): stale "non-fatal" docblock in define.ts; missing JSDoc on the security-relevant `isGuildAllowed`/`allowListActive`; 10 tool descriptions claiming "Returns a JSON array" when they return object wrappers; forum reply permission (Send Messages in Threads); README badge node>=20, real package size, lazy-connect wording, OAuth list +4 permissions, project tree; SECURITY.md actionable channel; Dockerfile OCI `licenses` key + 97 tools; `DISCORD_MCP_TOOLSETS` empty value documented as unset (decision: empty ≠ typo, fail-fast stays for unknown names).

21/21 tests.