### PR TITLE
fix: doc-audit round 2 — 20 confirmed findings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - `discord_delete_channel` and `discord_bulk_delete_messages` are safe-by-default: `dry_run` defaults to `true` (advertised in the schema), so existing callers preview instead of deleting until they pass `dry_run:false`. The bulk-delete dry run reports the real deletable count (14-day rule applied)
 - Unknown tool names and unexpected `tools/list` cursors are JSON-RPC protocol errors (`-32602`) instead of `isError` results, and validation failures surface as `Invalid arguments — field: message`
 - Read tools (32) now advertise `outputSchema` and return `structuredContent`; conforming outputs are normalised (unknown keys dropped) and non-conforming output is converted to an error instead of being shipped. `discord_fetch_webhook_message` `timestamp` is an ISO string (was mistyped as a number)
+- `discord_set_nickname` now requires the `nickname` field (string or null) — omitting it used to silently clear the nickname; `discord_bulk_ban` caps `user_ids` at 200 (Discord API limit) and `discord_set_role_position` requires `position >= 1`
 - The `events` toolset is renamed `scheduled_events`
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -189,7 +189,7 @@ These flags only control which gateway intents the server requests when identify
 
 Data access is governed by the **portal toggles**, not by these flags: this server reads everything over the REST API, which Discord gates on the portal setting alone. So with the portal toggles on, setting these flags to `false` loses nothing. With a portal toggle **off**, the corresponding data is restricted regardless of the flags: message bodies come back empty (`content`, `embeds`, `attachments` — except the bot's own messages, DMs, and messages that mention the bot) and member listing fails — enable the toggle in the portal to restore it.
 
-**Toolsets** (`DISCORD_MCP_TOOLSETS`): `discovery`, `messages`, `channels`, `permissions`, `members`, `roles`, `moderation`, `screening`, `stats`, `forums`, `webhooks`, `scheduled_events`, `invites`, `dm`. Example — read-only navigation only: `DISCORD_MCP_TOOLSETS=discovery,messages,members`. Only the listed toolsets' tools are advertised and callable. Unknown names make the server fail at startup instead of silently exposing everything (an empty value counts as unset and exposes all).
+**Toolsets** (`DISCORD_MCP_TOOLSETS`): `discovery`, `messages`, `channels`, `permissions`, `members`, `roles`, `moderation`, `screening`, `stats`, `forums`, `webhooks`, `scheduled_events`, `invites`, `dm`. Example — `DISCORD_MCP_TOOLSETS=discovery,messages,members` exposes only the discovery, message, and member tools. Note: a toolset ships its whole module, including its destructive tools (`messages` includes bulk delete; `members` includes kick/ban) — use `DISCORD_ALLOWED_GUILDS` and the dry-run defaults to bound them. Only the listed toolsets' tools are advertised and callable. Unknown names make the server fail at startup instead of silently exposing everything (an empty value counts as unset and exposes all).
 
 ---
 
@@ -198,11 +198,11 @@ Data access is governed by the **portal toggles**, not by these flags: this serv
 1. Go to [discord.com/developers/applications](https://discord.com/developers/applications)
 2. **New Application** > give it a name
 3. **Bot** tab > **Reset Token** > copy the token
-4. Enable **Privileged Gateway Intents** (both are on by default):
+4. Enable **Privileged Gateway Intents** (this server requests both by default, but new Discord apps have the portal toggles OFF):
    - Server Members Intent
    - Message Content Intent
 
-   > **Important:** if the bot requests a privileged intent that is not enabled here, Discord closes the connection with code `4014` and every tool call fails. Enable both, or disable the ones you don't need via the env flags below.
+   > **Important:** if the bot requests a privileged intent that is not enabled here, Discord closes the connection with code `4014` and every tool call fails. Enable both, or stop requesting the ones you don't need via the [environment variables](#environment-variables) above.
 
 5. **OAuth2 > URL Generator**:
    - Scopes: `bot`
@@ -386,12 +386,12 @@ Data access is governed by the **portal toggles**, not by these flags: this serv
 "Create a forum channel called 'feedback' with tags Bug, Feature, Question"
 "Show the full permission audit for the server"
 "Create a webhook on #notifications and send a test message"
-"Ban user 112233445566 and delete their messages from the last 3 days"
+"Ban user 112233445566778899 and delete their messages from the last 3 days"
 "Create an event called 'Game Night' for next Friday at 8pm"
 "List all upcoming events in the server"
 "Create a permanent invite for #general"
 "List all active invites and delete expired ones"
-"Send a DM to user 112233445566 saying 'Your build passed!'"
+"Send a DM to user 112233445566778899 saying 'Your build passed!'"
 "Search for members named 'john'"
 "List all banned users in the server"
 "Show all pinned messages in #general"
@@ -436,7 +436,9 @@ discord-mcp/
 │       ├── scheduledEvents.ts ← Scheduled events
 │       ├── invites.ts        ← Invite management
 │       └── dm.ts             ← Direct messages
-├── .github/workflows/       ← CI/CD (build check + auto release)
+├── test/                     ← node:test suite (schemas, gating, allow-list)
+├── scripts/                  ← sync-version.js (npm version hook)
+├── .github/workflows/        ← CI/CD (build check + auto release)
 ├── Dockerfile
 ├── .dockerignore
 ├── .env.example

--- a/src/client.ts
+++ b/src/client.ts
@@ -9,10 +9,12 @@ import {
   PermissionsBitField,
 } from "discord.js";
 
+/**
+ * Initializes the Discord.js client with the gateway intents (privileged ones
+ * are opt-out via env) and exposes shared helpers used across all tool modules.
+ */
+
 // ─── Discord Client ────────────────────────────────────────────────────────────
-// Initializes the Discord.js client with the gateway intents (privileged ones are opt-out via env)
-// and exposes shared helper functions used across all tool modules.
-// ────────────────────────────────────────────────────────────────────────────────
 
 const DISCORD_TOKEN = process.env.DISCORD_TOKEN;
 

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,6 +1,6 @@
 /** Shared constants used across tool modules. */
 
-/** Maximum number of items the Discord API returns per fetch. */
+/** Per-fetch cap for most Discord list endpoints (messages, reactions, events); members/bans use DEFAULTS.MEMBERS_MAX. */
 export const MAX_FETCH_LIMIT = 100;
 
 /** Default and maximum fetch limits by context. */

--- a/src/tools/channels.ts
+++ b/src/tools/channels.ts
@@ -3,7 +3,7 @@ import { z } from "zod";
 import { discord, getGuildChannel, fetchChannelChecked } from "../client.js";
 import { defineTool, defineModule, snowflake, guildId, intIn } from "./define.js";
 
-/** Tool definitions for creating, deleting, editing, moving, and cloning channels. */
+/** Tool definitions for guild channels: lifecycle, layout, following, and permission sync. */
 const tools = [
   defineTool({
     name: "discord_create_channel",

--- a/src/tools/discovery.ts
+++ b/src/tools/discovery.ts
@@ -53,7 +53,7 @@ const tools = [
       owner: z.string(),
     }),
     handle: async ({ guild_id }) => {
-      const guild = await (await discord.guilds.fetch(guild_id)).fetch();
+      const guild = await discord.guilds.fetch(guild_id);
       return structured({
         id: guild.id, name: guild.name, description: guild.description,
         memberCount: guild.memberCount, channelCount: guild.channels.cache.size,

--- a/src/tools/invites.ts
+++ b/src/tools/invites.ts
@@ -66,7 +66,7 @@ const tools = [
   defineTool({
     name: "discord_get_invite",
     description:
-      "Look up a single invite by its code: target server and channel, inviter, uses, and expiry. Works for any public invite, but usage counters are only populated for servers the bot is in (0 otherwise). Read-only. Returns a JSON object.",
+      "Look up a single invite by its code: target server and channel, inviter, and expiry. Works for any public invite, but this endpoint never returns usage counters (uses/max_uses/max_age read 0) — use discord_list_invites or discord_list_channel_invites for real counters. Read-only. Returns a JSON object.",
     annotations: { title: "Get invite", readOnlyHint: true, openWorldHint: true },
     schema: z.object({
       invite_code: z

--- a/src/tools/members.ts
+++ b/src/tools/members.ts
@@ -183,13 +183,13 @@ const tools = [
     schema: z.object({
       guild_id: guildId,
       user_id: snowflake.describe("Discord user ID (snowflake) of the member."),
-      nickname: z.string().nullable().optional().describe("New nickname (max 32 characters), or null to clear it."),
+      nickname: z.string().max(32).nullable().describe("New nickname (max 32 characters), or null to clear it."),
       reason: z.string().optional().describe("Optional reason recorded in the server audit log."),
     }),
     handle: async ({ guild_id, user_id, nickname, reason }) => {
       const guild = await discord.guilds.fetch(guild_id);
       const member = await guild.members.fetch(user_id);
-      const nick = nickname === null || nickname === "null" ? null : (nickname ?? null);
+      const nick = nickname === null || nickname === "null" ? null : nickname;
       await member.setNickname(nick, reason);
       return { content: [{ type: "text", text: nick ? `✅ Nickname for ${member.user.tag} set to "${nick}".` : `✅ Nickname cleared for ${member.user.tag}.` }] };
     },
@@ -225,18 +225,17 @@ const tools = [
   defineTool({
     name: "discord_bulk_ban",
     description:
-      "Ban many users in a single call, intended for raid mitigation. SAFE BY DEFAULT: dry_run is true unless explicitly set to false, so call it first to preview the resolved user IDs, then re-call with dry_run:false to actually ban them. Requires the Ban Members permission. Returns counts of banned vs failed users. Use discord_ban_member for a single ban with finer control.",
+      "Ban many users in a single call, intended for raid mitigation. SAFE BY DEFAULT: dry_run is true unless explicitly set to false, so call it first to preview the exact list of user IDs that would be banned, then re-call with dry_run:false to actually ban them. Requires the Ban Members permission. Returns counts of banned vs failed users. Use discord_ban_member for a single ban with finer control.",
     annotations: { title: "Bulk ban", readOnlyHint: false, destructiveHint: true, idempotentHint: false, openWorldHint: true },
     schema: z.object({
       guild_id: guildId,
-      user_ids: z.array(snowflake).describe("Array of user IDs (snowflakes) to ban."),
+      user_ids: z.array(snowflake).min(1).max(200).describe("Array of user IDs (snowflakes) to ban (max 200 per call — Discord API limit)."),
       delete_message_seconds: intIn(0, 604800).default(0).describe("Also delete each user's messages from the last N seconds (0–604800, i.e. up to 7 days). Default 0."),
       dry_run: z.boolean().default(true).describe("If true (default), only returns the user IDs that would be banned without banning anyone. Set false to actually ban."),
       reason: z.string().optional().describe("Optional reason recorded in the server audit log."),
     }),
     handle: async ({ guild_id, user_ids, delete_message_seconds, dry_run, reason }) => {
       const guild = await discord.guilds.fetch(guild_id);
-      if (user_ids.length === 0) throw new Error("user_ids must be a non-empty array.");
       if (dry_run) {
         return { content: [{ type: "text", text: `🔍 Dry run: ${user_ids.length} users would be banned:\n${JSON.stringify(user_ids, null, 2)}` }] };
       }

--- a/src/tools/messages.ts
+++ b/src/tools/messages.ts
@@ -201,7 +201,7 @@ const tools = [
     annotations: { title: "Edit embed", readOnlyHint: false, destructiveHint: false, idempotentHint: true, openWorldHint: true },
     schema: z.object({
       channel_id: channelId.describe("ID (snowflake) of the channel or thread containing the message."),
-      message_id: messageId.describe("ID of the message to edit. Must be a bot message that already contains an embed."),
+      message_id: messageId.describe("ID of the message to edit. Must be a message authored by this bot (an embed is added if it has none)."),
       ...embedFieldsShape,
     }),
     handle: async ({ channel_id, message_id, ...embedArgs }) => {
@@ -268,7 +268,7 @@ const tools = [
   defineTool({
     name: "discord_search_messages",
     description:
-      "Keyword search over a channel's recent messages using case-insensitive substring matching. Scans only up to the last 100 messages — it does not search full history. Returns matching messages as a JSON array. Use discord_read_messages to fetch recent messages without filtering.",
+      "Keyword search over a channel's recent messages using case-insensitive substring matching. Scans only up to the last 100 messages — it does not search full history. Returns { matches: [...] } with id, author, content, timestamp. Use discord_read_messages to fetch recent messages without filtering.",
     annotations: { title: "Search messages", readOnlyHint: true, openWorldHint: true },
     schema: z.object({
       channel_id: snowflake.describe("ID (snowflake) of the channel or thread to search."),
@@ -364,7 +364,7 @@ const tools = [
   defineTool({
     name: "discord_fetch_pinned_messages",
     description:
-      "List all pinned messages in a channel as a JSON array (id, author, content, timestamp, pinnedAt). Read-only. Use discord_pin_message to change which messages are pinned.",
+      "List all pinned messages in a channel. Returns { messages: [...] } with id, author, content, timestamp, pinnedAt. Read-only. Use discord_pin_message to change which messages are pinned.",
     annotations: { title: "Fetch pinned messages", readOnlyHint: true, openWorldHint: true },
     schema: z.object({
       channel_id: snowflake.describe("ID (snowflake) of the channel or thread to list pins from."),

--- a/src/tools/permissions.ts
+++ b/src/tools/permissions.ts
@@ -13,6 +13,7 @@ function parsePermArray(value: string[] | string | undefined): string[] {
   return [];
 }
 
+/** Flag names as an array, or a JSON-encoded array string (some clients serialize arrays). */
 const permFlags = z.union([z.array(z.string()), z.string()]).optional();
 
 const channelOverwriteSummary = z.object({
@@ -61,8 +62,8 @@ const tools = [
     schema: z.object({
       channel_id: snowflake.describe("ID (snowflake) of the channel to set the overwrite on."),
       role_id: snowflake.describe("ID (snowflake) of the role to grant/deny permissions for."),
-      allow: permFlags.describe("Permission flag names to allow, e.g. ['SendMessages','ViewChannel']. Uses Discord PermissionsBitField flag names."),
-      deny: permFlags.describe("Permission flag names to deny, e.g. ['SendMessages']."),
+      allow: permFlags.describe("Permission flag names to allow, e.g. ['SendMessages','ViewChannel'] (or the same array JSON-encoded as a string). Uses Discord PermissionsBitField flag names."),
+      deny: permFlags.describe("Permission flag names to deny, e.g. ['SendMessages'] (or the same array JSON-encoded as a string)."),
       reason: z.string().optional().describe("Optional reason recorded in the server audit log."),
     }),
     handle: async ({ channel_id, role_id, allow, deny, reason }) => {
@@ -82,8 +83,8 @@ const tools = [
     schema: z.object({
       channel_id: snowflake.describe("ID (snowflake) of the channel to set the overwrite on."),
       user_id: snowflake.describe("ID (snowflake) of the member to grant/deny permissions for."),
-      allow: permFlags.describe("Permission flag names to allow, e.g. ['ViewChannel']. Uses Discord PermissionsBitField flag names."),
-      deny: permFlags.describe("Permission flag names to deny."),
+      allow: permFlags.describe("Permission flag names to allow, e.g. ['ViewChannel'] (or the same array JSON-encoded as a string). Uses Discord PermissionsBitField flag names."),
+      deny: permFlags.describe("Permission flag names to deny (array, or JSON-encoded array string)."),
       reason: z.string().optional().describe("Optional reason recorded in the server audit log."),
     }),
     handle: async ({ channel_id, user_id, allow, deny, reason }) => {
@@ -98,7 +99,7 @@ const tools = [
   defineTool({
     name: "discord_reset_channel_permissions",
     description:
-      "Remove ALL permission overwrites on a channel, resetting it to inherit from its category/server defaults. IRREVERSIBLE — the cleared overwrites cannot be recovered. Requires the Manage Roles permission.",
+      "Remove ALL permission overwrites on a channel, so only role/server-level permissions apply. Does NOT re-sync with the category — use discord_lock_channel_permissions for that. IRREVERSIBLE — the cleared overwrites cannot be recovered. Requires the Manage Roles permission.",
     annotations: { title: "Reset channel permissions", readOnlyHint: false, destructiveHint: true, idempotentHint: true, openWorldHint: true },
     schema: z.object({
       channel_id: snowflake.describe("ID (snowflake) of the channel whose overwrites will be cleared."),

--- a/src/tools/roles.ts
+++ b/src/tools/roles.ts
@@ -293,9 +293,9 @@ const tools = [
       role_id: snowflake.describe("ID (snowflake) of the role to reposition."),
       position: z
         .int()
-        .min(0)
+        .min(1)
         .describe(
-          "New hierarchy position (0 = lowest, just above @everyone). Higher numbers rank higher.",
+          "New hierarchy position (1 = lowest, just above @everyone, which sits at 0). Higher numbers rank higher.",
         ),
     }),
     handle: async ({ guild_id, role_id, position }) => {

--- a/src/tools/stats.ts
+++ b/src/tools/stats.ts
@@ -30,7 +30,7 @@ const tools = [
       createdAt: z.string(),
     }),
     handle: async ({ guild_id }) => {
-      const guild = await (await discord.guilds.fetch(guild_id)).fetch();
+      const guild = await discord.guilds.fetch(guild_id);
       await guild.channels.fetch();
       const cachedBots = guild.members.cache.filter((m) => m.user.bot).size;
       return structured({


### PR DESCRIPTION
Second documentation workflow audit (18 agents, adversarial web verification): 42 → 20 findings, 0 high (was 3). All 20 implemented.

Schema/code tightenings:
- `discord_set_nickname`: `nickname` is now required (string or null) — omitting it used to silently CLEAR the nickname via `?? null`
- `discord_bulk_ban`: `user_ids` capped at `.min(1).max(200)` (Discord bulk-ban API limit, was undocumented and unenforced)
- `discord_set_role_position`: `position >= 1` (0 is @everyone)
- redundant `(await guilds.fetch(id)).fetch()` double fetch dropped in discovery/stats

Doc corrections:
- README: toolsets example no longer claims "read-only" (modules ship their destructive tools too — with pointers to ALLOWED_GUILDS/dry-run), portal-toggle wording fixed (new apps have them OFF), 18-digit example IDs, tree includes test/ and scripts/
- `get_invite`: this endpoint NEVER returns usage counters (corrects the previous round's own fix — verified against APIInvite)
- `reset_channel_permissions`: does not re-sync category (points to lock_channel_permissions)
- `edit_embed` precondition, bulk_ban dry-run wording, 2 last "JSON array" → wrappers, permFlags string form documented on all 4 fields, channels module summary, client.ts file docblock, constants caveat

21/21 tests; CHANGELOG breaking section updated.