### PR TITLE
fix: audit round 5 — pipeline, robustness, test debt (22 findings)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,5 +26,6 @@ jobs:
           node-version: ${{ matrix.node-version }}
       - run: npm ci
       - run: npm run lint
+      - run: npm run format:check
       - run: npm run build
       - run: npm test

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,6 +51,9 @@ jobs:
 
   publish-docker:
     runs-on: ubuntu-latest
+    needs: [publish-npm]
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v6
       - name: Extract version from tag

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,3 @@
+live-test*.mjs
+REMAINING_AUDIT.md
+CLAUDE.md

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,8 @@
 - `discord_delete_channel` and `discord_bulk_delete_messages` are safe-by-default: `dry_run` defaults to `true` (advertised in the schema), so existing callers preview instead of deleting until they pass `dry_run:false`. The bulk-delete dry run reports the real deletable count (14-day rule applied)
 - Unknown tool names and unexpected `tools/list` cursors are JSON-RPC protocol errors (`-32602`) instead of `isError` results, and validation failures surface as `Invalid arguments — field: message`
 - Read tools (32) now advertise `outputSchema` and return `structuredContent`; conforming outputs are normalised (unknown keys dropped) and non-conforming output is converted to an error instead of being shipped. `discord_fetch_webhook_message` `timestamp` is an ISO string (was mistyped as a number)
-- `discord_set_nickname` now requires the `nickname` field (string or null) — omitting it used to silently clear the nickname; `discord_bulk_ban` caps `user_ids` at 200 (Discord API limit) and `discord_set_role_position` requires `position >= 1`
+- `discord_set_nickname` now requires the `nickname` field (string or null) — omitting it used to silently clear the nickname; `discord_bulk_ban` caps `user_ids` at 200 (Discord API limit) and `discord_set_role_position` requires `position >= 1` (and rejects positions above the server's highest role instead of silently doing nothing)
+- `discord_set_role_icon` requires at least one of `icon`/`unicode_emoji` (both omitted used to report success without doing anything); `discord_create_event_invite` rejects `channel_id` on non-EXTERNAL events (it was silently ignored); embed arrays advertise and enforce `maxItems: 10`; invalid permission flag names are rejected with the culprit named instead of crashing with an opaque internal error
 - The `events` toolset is renamed `scheduled_events`
 
 ### Added
@@ -20,6 +21,11 @@
 - `DISCORD_ALLOWED_GUILDS`: guild allow-list enforced at the schema for `guild_id` inputs AND centrally on every channel/thread/webhook/invite fetch, so channel-addressed calls cannot bypass it (token-webhook flows verify the webhook's guild when the list is active)
 - `DISCORD_MESSAGE_CONTENT` / `DISCORD_GUILD_MEMBERS`: opt out of the privileged gateway intents at connect time (avoids the 4014 startup failure when the portal toggles are off; REST data access is governed by the portal toggles alone)
 - O(1) tool dispatch with duplicate-name detection at load (cross-module and within-module)
+
+### Fixed
+
+- Message tools (read, delete, pin, search…) now work in announcement channels, which the channel guard previously rejected
+- A Discord READY arriving after the 30s login timeout no longer wedges the server permanently
 
 ## [1.7.2] - 2026-06-10
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Stage 1: Build
-FROM node:26-alpine AS builder
+FROM node:24-alpine AS builder
 WORKDIR /app
 COPY package*.json tsconfig.json ./
 RUN npm ci
@@ -7,7 +7,7 @@ COPY src/ src/
 RUN npm run build
 
 # Stage 2: Run
-FROM node:26-alpine
+FROM node:24-alpine
 
 LABEL org.opencontainers.image.title="Discord MCP Server"
 LABEL org.opencontainers.image.description="A lightweight, multi-guild Discord MCP server with 97 tools"

--- a/package-lock.json
+++ b/package-lock.json
@@ -742,9 +742,9 @@
       }
     },
     "node_modules/@hono/node-server": {
-      "version": "1.19.11",
-      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.11.tgz",
-      "integrity": "sha512-dr8/3zEaB+p0D2n/IUrlPF1HZm586qgJNXK1a9fhg/PzdtkK7Ksd5l312tJX2yBuALqDYBlG20QEbayqPyxn+g==",
+      "version": "1.19.14",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.14.tgz",
+      "integrity": "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==",
       "license": "MIT",
       "engines": {
         "node": ">=18.14.1"
@@ -1863,12 +1863,12 @@
       }
     },
     "node_modules/express-rate-limit": {
-      "version": "8.3.1",
-      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.3.1.tgz",
-      "integrity": "sha512-D1dKN+cmyPWuvB+G2SREQDzPY1agpBIcTa9sJxOPMCNeH3gwzhqJRDWCXW3gg0y//+LQ/8j52JbMROWyrKdMdw==",
+      "version": "8.5.2",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.5.2.tgz",
+      "integrity": "sha512-5Kb34ipNX694DH48vN9irak1Qx30nb0PLYHXfJgw4YEjiC3ZEmZJhwOp+VfiCYwFzvFTdB9QkArYS5kXa2cx2A==",
       "license": "MIT",
       "dependencies": {
-        "ip-address": "10.1.0"
+        "ip-address": "^10.2.0"
       },
       "engines": {
         "node": ">= 16"
@@ -1901,9 +1901,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
-      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
+      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
       "funding": [
         {
           "type": "github",
@@ -2135,9 +2135,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.12.8",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.8.tgz",
-      "integrity": "sha512-VJCEvtrezO1IAR+kqEYnxUOoStaQPGrCmX3j4wDTNOcD1uRPFpGlwQUIW8niPuvHXaTUxeOUl5MMDGrl+tmO9A==",
+      "version": "4.12.25",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.25.tgz",
+      "integrity": "sha512-2NFaIyNVgJmBs/ecmtGzlmluTFs5cHEWGTdu0t1HBwYzoGXOL5nUQBRMXsXWla5i4KkG//QMzVP88m1+I3fdAQ==",
       "license": "MIT",
       "engines": {
         "node": ">=16.9.0"
@@ -2206,9 +2206,9 @@
       "license": "ISC"
     },
     "node_modules/ip-address": {
-      "version": "10.1.0",
-      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.1.0.tgz",
-      "integrity": "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==",
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
+      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
       "license": "MIT",
       "engines": {
         "node": ">= 12"
@@ -2565,9 +2565,9 @@
       }
     },
     "node_modules/path-to-regexp": {
-      "version": "8.3.0",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.3.0.tgz",
-      "integrity": "sha512-7jdwVIRtsP8MYpdXSwOS0YdD0Du+qOoF/AEPIt88PcCFrZCzx41oxku1jD88hZBwbNUIEfpqvuhjFaMAqMTWnA==",
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
+      "integrity": "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==",
       "license": "MIT",
       "funding": {
         "type": "opencollective",
@@ -2646,9 +2646,9 @@
       }
     },
     "node_modules/qs": {
-      "version": "6.15.0",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.0.tgz",
-      "integrity": "sha512-mAZTtNCeetKMH+pSjrb76NAM8V9a05I9aBZOHztWy/UqcJdQYNsf59vrRKWnojAT9Y+GbIvoTBC++CPHqpDBhQ==",
+      "version": "6.15.2",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.2.tgz",
+      "integrity": "sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "side-channel": "^1.1.0"
@@ -3091,9 +3091,9 @@
       "license": "ISC"
     },
     "node_modules/ws": {
-      "version": "8.19.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.19.0.tgz",
-      "integrity": "sha512-blAT2mjOEIi0ZzruJfIhb3nps74PRWTCz1IjglWEEpQl5XS/UNama6u2/rjFkDDouqr4L67ry+1aGIALViWjDg==",
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"

--- a/src/client.ts
+++ b/src/client.ts
@@ -7,6 +7,7 @@ import {
   ThreadChannel,
   GuildChannel,
   PermissionsBitField,
+  type GuildTextBasedChannel,
 } from "discord.js";
 
 /**
@@ -67,6 +68,12 @@ discord.on(Events.Invalidated, () => {
  */
 export async function ensureConnected(): Promise<void> {
   if (discordReady) return;
+  // A late READY (after the 30s timeout cleared the listener) must not wedge the
+  // server forever: trust the client state, not only our flag.
+  if (discord.isReady()) {
+    discordReady = true;
+    return;
+  }
 
   if (!DISCORD_TOKEN) {
     throw new Error("DISCORD_TOKEN is required. Set it in your MCP client config or a .env file.");
@@ -138,18 +145,16 @@ export async function fetchChannelChecked(channelId: string) {
 }
 
 /**
- * Fetches a channel by ID and guarantees it is a TextChannel or a thread of any
- * kind (public / private / forum post / announcement thread) — both expose the
- * message-send / edit / fetch surface the message tools use. Announcement (News)
- * channels themselves do NOT pass this check.
+ * Fetches a channel by ID and guarantees it is a guild channel that holds
+ * messages: text, announcement, voice/stage text, or a thread of any kind.
  * @param channelId - Discord snowflake ID of the channel.
- * @throws {Error} If the channel does not exist or is neither a text channel nor a thread.
+ * @throws {Error} If the channel does not exist or is not a message-capable guild channel.
  */
-export async function getTextChannel(channelId: string): Promise<TextChannel | ThreadChannel> {
+export async function getTextChannel(channelId: string): Promise<GuildTextBasedChannel> {
   const id = validateId(channelId, "channel_id");
   const channel = await fetchChannelChecked(id);
-  if (!channel || (!(channel instanceof TextChannel) && !(channel instanceof ThreadChannel)))
-    throw new Error(`Channel ${id} is not a text or thread channel or doesn't exist.`);
+  if (!channel || channel.isDMBased() || !channel.isTextBased())
+    throw new Error(`Channel ${id} is not a message-capable guild channel or doesn't exist.`);
   return channel;
 }
 
@@ -165,6 +170,34 @@ export async function getGuildChannel(channelId: string): Promise<GuildChannel> 
   if (!channel || !(channel instanceof GuildChannel))
     throw new Error(`Channel ${id} is not a guild channel or doesn't exist.`);
   return channel;
+}
+
+/**
+ * Parses permission flag names from an array or a JSON-encoded array string
+ * (some MCP clients serialize arrays), validating every name against
+ * PermissionsBitField.Flags so unknown flags fail with the culprit named.
+ */
+export function parsePermissionNames(value: string[] | string | undefined): string[] {
+  if (value === undefined) return [];
+  let names: unknown = value;
+  if (typeof value === "string") {
+    try {
+      names = JSON.parse(value);
+    } catch {
+      throw new Error(
+        `Invalid permission list: "${value}" is not a JSON array. Pass an array like ["SendMessages"].`,
+      );
+    }
+  }
+  if (!Array.isArray(names) || !names.every((n) => typeof n === "string"))
+    throw new Error("Invalid permission list: expected an array of permission flag names.");
+  for (const name of names) {
+    if (!(name in PermissionsBitField.Flags))
+      throw new Error(
+        `Unknown permission flag: "${name}". Use Discord PermissionsBitField flag names like "SendMessages".`,
+      );
+  }
+  return names;
 }
 
 /**

--- a/src/embeds.ts
+++ b/src/embeds.ts
@@ -47,6 +47,11 @@ export const embedFieldsShape = {
 /** Schema for a single embed object (e.g. an item of `discord_send_multiple_embeds`). */
 export const embedObjectSchema = z.object(embedFieldsShape);
 
+/** Up to 10 embeds — Discord's per-message cap, enforced at parse time and advertised as maxItems. */
+export const embedArraySchema = z
+  .array(embedObjectSchema)
+  .max(10, "Discord allows a maximum of 10 embeds per message.");
+
 /** Validated embed input — the typed shape `buildEmbed` consumes. */
 export type EmbedInput = z.infer<typeof embedObjectSchema>;
 

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -1,0 +1,35 @@
+import { DiscordAPIError } from "discord.js";
+import { ZodError } from "zod";
+
+/** Plain-language hints for the Discord API error codes most likely to surface through these tools. */
+const DISCORD_ERROR_HINTS: Record<number, string> = {
+  10003: "Unknown channel — check channel_id.",
+  10004: "Unknown guild — the bot is not in that server or guild_id is wrong.",
+  10008: "Unknown message — wrong message_id, or it was already deleted.",
+  10011: "Unknown role — check role_id.",
+  10013: "Unknown user — check user_id.",
+  10026: "Unknown ban — the user is not banned.",
+  50001: "Missing access — the bot is not in the guild or cannot see this channel.",
+  50013: "Missing permissions — the bot lacks the permission this action requires.",
+  50035: "Invalid form body — one or more arguments are invalid.",
+};
+
+/** Formats an error for the MCP client, surfacing DiscordAPIError code/status and an actionable hint. */
+export function formatToolError(err: unknown): string {
+  if (err instanceof ZodError) {
+    const detail = err.issues
+      .map((i) => {
+        const path = i.path.join(".");
+        return path ? `${path}: ${i.message}` : i.message;
+      })
+      .join("; ");
+    return `Invalid arguments — ${detail}`;
+  }
+  if (err instanceof DiscordAPIError) {
+    const code = Number(err.code);
+    const hint = DISCORD_ERROR_HINTS[code];
+    const base = `Discord API error ${err.code} (HTTP ${err.status}): ${err.message}`;
+    return hint ? `${base} — ${hint}` : base;
+  }
+  return err instanceof Error ? err.message : String(err);
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,97 +1,20 @@
 #!/usr/bin/env node
 /**
- * Discord MCP Server — Entry point.
- *
- * Sets up the MCP server over stdio, registers tool definitions from
- * the modular `tools/` directory, and routes incoming tool calls.
- * The Discord client is initialized in `client.ts`.
+ * Discord MCP Server — stdio entry point. Server construction lives in
+ * `server.ts` (testable via in-memory transport); the Discord client in `client.ts`.
  */
-import { Server } from "@modelcontextprotocol/sdk/server/index.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
-import {
-  CallToolRequestSchema,
-  ErrorCode,
-  ListToolsRequestSchema,
-  McpError,
-} from "@modelcontextprotocol/sdk/types.js";
-
-import { DiscordAPIError } from "discord.js";
-import { ZodError } from "zod";
 import { readFileSync } from "fs";
 import { join } from "path";
-import { ensureConnected, discord } from "./client.js";
-import { getAllDefinitions, handleTool, hasTool } from "./tools/index.js";
-
-/** Plain-language hints for the Discord API error codes most likely to surface through these tools. */
-const DISCORD_ERROR_HINTS: Record<number, string> = {
-  10003: "Unknown channel — check channel_id.",
-  10004: "Unknown guild — the bot is not in that server or guild_id is wrong.",
-  10008: "Unknown message — wrong message_id, or it was already deleted.",
-  10011: "Unknown role — check role_id.",
-  10013: "Unknown user — check user_id.",
-  10026: "Unknown ban — the user is not banned.",
-  50001: "Missing access — the bot is not in the guild or cannot see this channel.",
-  50013: "Missing permissions — the bot lacks the permission this action requires.",
-  50035: "Invalid form body — one or more arguments are invalid.",
-};
-
-/** Formats an error for the MCP client, surfacing DiscordAPIError code/status and an actionable hint. */
-function formatToolError(err: unknown): string {
-  if (err instanceof ZodError) {
-    const detail = err.issues
-      .map((i) => {
-        const path = i.path.join(".");
-        return path ? `${path}: ${i.message}` : i.message;
-      })
-      .join("; ");
-    return `Invalid arguments — ${detail}`;
-  }
-  if (err instanceof DiscordAPIError) {
-    const code = Number(err.code);
-    const hint = DISCORD_ERROR_HINTS[code];
-    const base = `Discord API error ${err.code} (HTTP ${err.status}): ${err.message}`;
-    return hint ? `${base} — ${hint}` : base;
-  }
-  return err instanceof Error ? err.message : String(err);
-}
+import { discord } from "./client.js";
+import { createServer } from "./server.js";
 
 const pkg = JSON.parse(readFileSync(join(__dirname, "..", "package.json"), "utf-8"));
 const version: string = pkg.version;
 
-// ─── MCP Server ────────────────────────────────────────────────────────────────
-
-const server = new Server({ name: "discord-mcp", version }, { capabilities: { tools: {} } });
-
-// ─── Tool Definitions ──────────────────────────────────────────────────────────
-
-server.setRequestHandler(ListToolsRequestSchema, async (req) => {
-  if (req.params?.cursor !== undefined)
-    throw new McpError(ErrorCode.InvalidParams, "Invalid cursor: tools/list is not paginated.");
-  return { tools: getAllDefinitions() };
-});
-
-// ─── Tool Handler ───────────────────────────────────────────────────────────────
-
-server.setRequestHandler(CallToolRequestSchema, async (req) => {
-  const { name, arguments: args = {} } = req.params;
-  if (!hasTool(name)) throw new McpError(ErrorCode.InvalidParams, `Unknown tool: ${name}`);
-
-  try {
-    await ensureConnected();
-    return await handleTool(name, args);
-  } catch (err: unknown) {
-    return {
-      content: [{ type: "text", text: `❌ Error: ${formatToolError(err)}` }],
-      isError: true,
-    };
-  }
-});
-
-// ─── Start ─────────────────────────────────────────────────────────────────────
-
 async function main() {
   const transport = new StdioServerTransport();
-  await server.connect(transport);
+  await createServer(version).connect(transport);
   console.error(`Discord MCP Server v${version} running on stdio.`);
 }
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,0 +1,42 @@
+import { Server } from "@modelcontextprotocol/sdk/server/index.js";
+import {
+  CallToolRequestSchema,
+  ErrorCode,
+  ListToolsRequestSchema,
+  McpError,
+} from "@modelcontextprotocol/sdk/types.js";
+
+import { ensureConnected } from "./client.js";
+import { formatToolError } from "./errors.js";
+import { getAllDefinitions, handleTool, hasTool } from "./tools/index.js";
+
+/**
+ * Builds the MCP server with the tool list/call handlers wired in, leaving the
+ * transport to the caller — stdio in production, in-memory in tests.
+ */
+export function createServer(version: string): Server {
+  const server = new Server({ name: "discord-mcp", version }, { capabilities: { tools: {} } });
+
+  server.setRequestHandler(ListToolsRequestSchema, async (req) => {
+    if (req.params?.cursor !== undefined)
+      throw new McpError(ErrorCode.InvalidParams, "Invalid cursor: tools/list is not paginated.");
+    return { tools: getAllDefinitions() };
+  });
+
+  server.setRequestHandler(CallToolRequestSchema, async (req) => {
+    const { name, arguments: args = {} } = req.params;
+    if (!hasTool(name)) throw new McpError(ErrorCode.InvalidParams, `Unknown tool: ${name}`);
+
+    try {
+      await ensureConnected();
+      return await handleTool(name, args);
+    } catch (err: unknown) {
+      return {
+        content: [{ type: "text", text: `❌ Error: ${formatToolError(err)}` }],
+        isError: true,
+      };
+    }
+  });
+
+  return server;
+}

--- a/src/tools/channels.ts
+++ b/src/tools/channels.ts
@@ -38,7 +38,7 @@ const tools = [
         voice: ChannelType.GuildVoice,
         category: ChannelType.GuildCategory,
       };
-      const channelType = typeMap[type ?? "text"] ?? ChannelType.GuildText;
+      const channelType = typeMap[type ?? "text"];
       const created = await guild.channels.create({
         name,
         type: channelType as

--- a/src/tools/discovery.ts
+++ b/src/tools/discovery.ts
@@ -27,7 +27,10 @@ const tools = [
     outputSchema: z.object({ guilds: z.array(guildSummary) }),
     handle: async () => {
       const guilds = discord.guilds.cache.map((g) => ({
-        id: g.id, name: g.name, memberCount: g.memberCount, icon: g.iconURL(),
+        id: g.id,
+        name: g.name,
+        memberCount: g.memberCount,
+        icon: g.iconURL(),
       }));
       return structured({ guilds });
     },
@@ -55,10 +58,16 @@ const tools = [
     handle: async ({ guild_id }) => {
       const guild = await discord.guilds.fetch(guild_id);
       return structured({
-        id: guild.id, name: guild.name, description: guild.description,
-        memberCount: guild.memberCount, channelCount: guild.channels.cache.size,
-        roleCount: guild.roles.cache.size, boostLevel: guild.premiumTier,
-        boostCount: guild.premiumSubscriptionCount, createdAt: guild.createdAt.toISOString(), owner: guild.ownerId,
+        id: guild.id,
+        name: guild.name,
+        description: guild.description,
+        memberCount: guild.memberCount,
+        channelCount: guild.channels.cache.size,
+        roleCount: guild.roles.cache.size,
+        boostLevel: guild.premiumTier,
+        boostCount: guild.premiumSubscriptionCount,
+        createdAt: guild.createdAt.toISOString(),
+        owner: guild.ownerId,
       });
     },
   }),
@@ -79,7 +88,9 @@ const tools = [
         .sort((a, b) => (a as CategoryChannel).position - (b as CategoryChannel).position);
 
       const result: Record<string, unknown[]> = { "No Category": [] };
-      categories.forEach((cat) => { result[cat.name] = []; });
+      categories.forEach((cat) => {
+        result[cat.name] = [];
+      });
 
       guild.channels.cache
         .filter((c) => c.type !== ChannelType.GuildCategory)

--- a/src/tools/dm.ts
+++ b/src/tools/dm.ts
@@ -12,7 +12,13 @@ const tools = [
     name: "discord_send_dm",
     description:
       "Send a private direct message to a user by their user ID. Use discord_send_message to post in a server channel instead. Requires the bot to share at least one server with the user, and the user must allow DMs from server members (otherwise Discord rejects the send). Returns the new message ID.",
-    annotations: { title: "Send DM", readOnlyHint: false, destructiveHint: false, idempotentHint: false, openWorldHint: true },
+    annotations: {
+      title: "Send DM",
+      readOnlyHint: false,
+      destructiveHint: false,
+      idempotentHint: false,
+      openWorldHint: true,
+    },
     schema: z.object({
       user_id: userId,
       content: z.string().describe("Plain-text body of the DM (max 2000 characters)."),
@@ -20,14 +26,24 @@ const tools = [
     handle: async ({ user_id, content }) => {
       const user = await discord.users.fetch(user_id);
       const sent = await user.send(content);
-      return { content: [{ type: "text", text: `✅ DM sent to ${user.username} (message id: ${sent.id}).` }] };
+      return {
+        content: [
+          { type: "text", text: `✅ DM sent to ${user.username} (message id: ${sent.id}).` },
+        ],
+      };
     },
   }),
   defineTool({
     name: "discord_send_dm_embed",
     description:
       "Send a rich embed as a private direct message to a user. Use discord_send_dm for plain text, or discord_send_embed to post an embed in a channel. Requires the bot to share a server with the user, and the user must allow DMs from server members. Returns the new message ID.",
-    annotations: { title: "Send DM embed", readOnlyHint: false, destructiveHint: false, idempotentHint: false, openWorldHint: true },
+    annotations: {
+      title: "Send DM embed",
+      readOnlyHint: false,
+      destructiveHint: false,
+      idempotentHint: false,
+      openWorldHint: true,
+    },
     schema: z.object({
       user_id: userId,
       content: z.string().optional().describe("Optional plain text shown above the embed."),
@@ -39,33 +55,58 @@ const tools = [
         content: content || undefined,
         embeds: [buildEmbed(embedArgs)],
       });
-      return { content: [{ type: "text", text: `✅ DM embed sent to ${user.username} (message id: ${sent.id}).` }] };
+      return {
+        content: [
+          { type: "text", text: `✅ DM embed sent to ${user.username} (message id: ${sent.id}).` },
+        ],
+      };
     },
   }),
   defineTool({
     name: "discord_edit_dm",
     description:
       "Edit the text content of a DM message previously sent by this bot. Only the bot's own DM messages can be edited. Use discord_edit_dm_embed for embed messages. Returns a confirmation.",
-    annotations: { title: "Edit DM", readOnlyHint: false, destructiveHint: false, idempotentHint: true, openWorldHint: true },
+    annotations: {
+      title: "Edit DM",
+      readOnlyHint: false,
+      destructiveHint: false,
+      idempotentHint: true,
+      openWorldHint: true,
+    },
     schema: z.object({
       user_id: userId,
       message_id: messageId,
-      content: z.string().describe("New plain-text content that fully replaces the existing message (max 2000 characters)."),
+      content: z
+        .string()
+        .describe(
+          "New plain-text content that fully replaces the existing message (max 2000 characters).",
+        ),
     }),
     handle: async ({ user_id, message_id, content }) => {
       const user = await discord.users.fetch(user_id);
       const dm = await user.createDM();
       const msg = await dm.messages.fetch(message_id);
-      if (msg.author.id !== discord.user?.id) throw new Error("Can only edit messages sent by the bot.");
+      if (msg.author.id !== discord.user?.id)
+        throw new Error("Can only edit messages sent by the bot.");
       await msg.edit(content);
-      return { content: [{ type: "text", text: `✅ DM message ${message_id} edited for ${user.username}.` }] };
+      return {
+        content: [
+          { type: "text", text: `✅ DM message ${message_id} edited for ${user.username}.` },
+        ],
+      };
     },
   }),
   defineTool({
     name: "discord_edit_dm_embed",
     description:
       "Replace the embed on a DM message previously sent by this bot. Only the bot's own messages can be edited. Full replace, not merge: provided fields are applied and omitted fields are dropped. Returns a confirmation.",
-    annotations: { title: "Edit DM embed", readOnlyHint: false, destructiveHint: false, idempotentHint: true, openWorldHint: true },
+    annotations: {
+      title: "Edit DM embed",
+      readOnlyHint: false,
+      destructiveHint: false,
+      idempotentHint: true,
+      openWorldHint: true,
+    },
     schema: z.object({
       user_id: userId,
       message_id: messageId,
@@ -76,19 +117,33 @@ const tools = [
       const user = await discord.users.fetch(user_id);
       const dm = await user.createDM();
       const msg = await dm.messages.fetch(message_id);
-      if (msg.author.id !== discord.user?.id) throw new Error("Can only edit embeds sent by the bot.");
+      if (msg.author.id !== discord.user?.id)
+        throw new Error("Can only edit embeds sent by the bot.");
       await msg.edit({
         content: content || undefined,
         embeds: [buildEmbed(embedArgs)],
       });
-      return { content: [{ type: "text", text: `✅ DM embed edited on message ${message_id} for ${user.username}.` }] };
+      return {
+        content: [
+          {
+            type: "text",
+            text: `✅ DM embed edited on message ${message_id} for ${user.username}.`,
+          },
+        ],
+      };
     },
   }),
   defineTool({
     name: "discord_delete_dm",
     description:
       "Permanently delete a DM message previously sent by this bot. IRREVERSIBLE. The bot can only delete its own DM messages, not the recipient's. Returns a confirmation.",
-    annotations: { title: "Delete DM", readOnlyHint: false, destructiveHint: true, idempotentHint: false, openWorldHint: true },
+    annotations: {
+      title: "Delete DM",
+      readOnlyHint: false,
+      destructiveHint: true,
+      idempotentHint: false,
+      openWorldHint: true,
+    },
     schema: z.object({
       user_id: userId,
       message_id: messageId,
@@ -97,9 +152,14 @@ const tools = [
       const user = await discord.users.fetch(user_id);
       const dm = await user.createDM();
       const msg = await dm.messages.fetch(message_id);
-      if (msg.author.id !== discord.user?.id) throw new Error("Can only delete messages sent by the bot.");
+      if (msg.author.id !== discord.user?.id)
+        throw new Error("Can only delete messages sent by the bot.");
       await msg.delete();
-      return { content: [{ type: "text", text: `✅ DM message ${message_id} deleted for ${user.username}.` }] };
+      return {
+        content: [
+          { type: "text", text: `✅ DM message ${message_id} deleted for ${user.username}.` },
+        ],
+      };
     },
   }),
   defineTool({
@@ -109,7 +169,9 @@ const tools = [
     annotations: { title: "Read DMs", readOnlyHint: true, openWorldHint: true },
     schema: z.object({
       user_id: userId,
-      limit: intIn(1, 100).default(20).describe("How many recent messages to fetch (1–100). Default 20."),
+      limit: intIn(1, 100)
+        .default(20)
+        .describe("How many recent messages to fetch (1–100). Default 20."),
     }),
     outputSchema: z.object({
       messages: z.array(
@@ -142,7 +204,13 @@ const tools = [
     name: "discord_reply_dm",
     description:
       "Reply to a specific message in a DM, attaching a quoted reply reference. Unlike the edit/delete DM tools, this works on any message in the conversation (the bot's or the user's). Use discord_send_dm for a standalone DM with no reference. Returns the new reply's message ID.",
-    annotations: { title: "Reply to DM", readOnlyHint: false, destructiveHint: false, idempotentHint: false, openWorldHint: true },
+    annotations: {
+      title: "Reply to DM",
+      readOnlyHint: false,
+      destructiveHint: false,
+      idempotentHint: false,
+      openWorldHint: true,
+    },
     schema: z.object({
       user_id: userId,
       message_id: messageId,
@@ -153,7 +221,11 @@ const tools = [
       const dm = await user.createDM();
       const target = await dm.messages.fetch(message_id);
       const sent = await target.reply(content);
-      return { content: [{ type: "text", text: `✅ DM reply sent to ${user.username} (message id: ${sent.id}).` }] };
+      return {
+        content: [
+          { type: "text", text: `✅ DM reply sent to ${user.username} (message id: ${sent.id}).` },
+        ],
+      };
     },
   }),
 ];

--- a/src/tools/forums.ts
+++ b/src/tools/forums.ts
@@ -47,12 +47,14 @@ const tools = [
       guild_id: guildId,
     }),
     outputSchema: z.object({
-      channels: z.array(z.object({
-        id: z.string(),
-        name: z.string(),
-        topic: z.string().nullable(),
-        parentId: z.string().nullable(),
-      })),
+      channels: z.array(
+        z.object({
+          id: z.string(),
+          name: z.string(),
+          topic: z.string().nullable(),
+          parentId: z.string().nullable(),
+        }),
+      ),
     }),
     handle: async ({ guild_id }) => {
       const guild = await discord.guilds.fetch(guild_id);
@@ -72,12 +74,20 @@ const tools = [
     name: "discord_create_forum_channel",
     description:
       "Create a new forum channel in a server. A forum holds posts (threads) rather than a linear message feed. Requires the Manage Channels permission. Use discord_create_channel for text/voice channels instead. Returns the new channel's name and ID.",
-    annotations: { title: "Create forum channel", readOnlyHint: false, destructiveHint: false, idempotentHint: false, openWorldHint: true },
+    annotations: {
+      title: "Create forum channel",
+      readOnlyHint: false,
+      destructiveHint: false,
+      idempotentHint: false,
+      openWorldHint: true,
+    },
     schema: z.object({
       guild_id: guildId,
       name: z.string().describe("Name of the new forum channel (max 100 characters)."),
       topic: z.string().optional().describe("Guidelines/topic text shown at the top of the forum."),
-      category_id: snowflake.optional().describe("Optional category (snowflake) to nest the forum under."),
+      category_id: snowflake
+        .optional()
+        .describe("Optional category (snowflake) to nest the forum under."),
     }),
     handle: async ({ guild_id, name, topic, category_id }) => {
       const guild = await discord.guilds.fetch(guild_id);
@@ -87,19 +97,34 @@ const tools = [
         topic,
         parent: category_id,
       });
-      return { content: [{ type: "text", text: `✅ Forum channel #${created.name} created (id: ${created.id}).` }] };
+      return {
+        content: [
+          { type: "text", text: `✅ Forum channel #${created.name} created (id: ${created.id}).` },
+        ],
+      };
     },
   }),
   defineTool({
     name: "discord_create_forum_post",
     description:
       "Create a new post (a thread with a starter message) in a forum channel. Requires the Send Messages and Create Public Threads permissions. Use discord_reply_to_forum to add follow-up messages. Returns the new post's name and thread ID.",
-    annotations: { title: "Create forum post", readOnlyHint: false, destructiveHint: false, idempotentHint: false, openWorldHint: true },
+    annotations: {
+      title: "Create forum post",
+      readOnlyHint: false,
+      destructiveHint: false,
+      idempotentHint: false,
+      openWorldHint: true,
+    },
     schema: z.object({
       forum_channel_id: snowflake.describe("ID (snowflake) of the forum channel to post in."),
-      title: z.string().describe("Title of the post, used as the thread name (max 100 characters)."),
+      title: z
+        .string()
+        .describe("Title of the post, used as the thread name (max 100 characters)."),
       content: z.string().describe("Body of the post's starter message (max 2000 characters)."),
-      applied_tags: z.array(z.string()).optional().describe("Optional tag IDs to apply. Get valid IDs from discord_get_forum_tags."),
+      applied_tags: z
+        .array(z.string())
+        .optional()
+        .describe("Optional tag IDs to apply. Get valid IDs from discord_get_forum_tags."),
     }),
     handle: async ({ forum_channel_id, title, content, applied_tags }) => {
       const forum = await getForumChannel(forum_channel_id);
@@ -108,7 +133,14 @@ const tools = [
         message: { content },
         appliedTags: applied_tags ?? [],
       });
-      return { content: [{ type: "text", text: `✅ Forum post "${thread.name}" created (id: ${thread.id}) in #${forum.name}.` }] };
+      return {
+        content: [
+          {
+            type: "text",
+            text: `✅ Forum post "${thread.name}" created (id: ${thread.id}) in #${forum.name}.`,
+          },
+        ],
+      };
     },
   }),
   defineTool({
@@ -118,15 +150,19 @@ const tools = [
     annotations: { title: "Get forum post", readOnlyHint: true, openWorldHint: true },
     schema: z.object({
       thread_id: threadId,
-      limit: intIn(1, 100).default(20).describe("How many recent messages to include (1–100). Default 20."),
+      limit: intIn(1, 100)
+        .default(20)
+        .describe("How many recent messages to include (1–100). Default 20."),
     }),
     outputSchema: threadSummary.extend({
-      messages: z.array(z.object({
-        id: z.string(),
-        author: z.string(),
-        content: z.string(),
-        timestamp: z.string(),
-      })),
+      messages: z.array(
+        z.object({
+          id: z.string(),
+          author: z.string(),
+          content: z.string(),
+          timestamp: z.string(),
+        }),
+      ),
     }),
     handle: async ({ thread_id, limit }) => {
       const thread = await getThreadChannel(thread_id);
@@ -157,9 +193,18 @@ const tools = [
       "List posts in a forum channel. Returns { threads: [...], hasMore, nextBefore }. The first call (no `before`) includes all active posts plus the first page of archived posts; archived posts are paginated, so if hasMore is true pass nextBefore back as `before` to fetch older archived posts. Read-only. Use discord_get_forum_post to read one post's messages.",
     annotations: { title: "List forum threads", readOnlyHint: true, openWorldHint: true },
     schema: z.object({
-      forum_channel_id: snowflake.describe("ID (snowflake) of the forum channel to list posts from."),
-      limit: intIn(1, 100).default(100).describe("Max archived posts per page (1–100). Default 100."),
-      before: z.string().optional().describe("Pagination cursor: an ISO timestamp. Pass the previous response's nextBefore to fetch older archived posts. When set, active posts are omitted."),
+      forum_channel_id: snowflake.describe(
+        "ID (snowflake) of the forum channel to list posts from.",
+      ),
+      limit: intIn(1, 100)
+        .default(100)
+        .describe("Max archived posts per page (1–100). Default 100."),
+      before: z
+        .string()
+        .optional()
+        .describe(
+          "Pagination cursor: an ISO timestamp. Pass the previous response's nextBefore to fetch older archived posts. When set, active posts are omitted.",
+        ),
     }),
     outputSchema: z.object({
       threads: z.array(threadSummary),
@@ -186,7 +231,9 @@ const tools = [
         createdAt: t.createdAt?.toISOString() ?? null,
       }));
       const lastArchived = archived.threads.last();
-      const nextBefore = archived.hasMore ? lastArchived?.archivedAt?.toISOString() ?? null : null;
+      const nextBefore = archived.hasMore
+        ? (lastArchived?.archivedAt?.toISOString() ?? null)
+        : null;
       return structured({ threads, hasMore: archived.hasMore, nextBefore });
     },
   }),
@@ -194,7 +241,13 @@ const tools = [
     name: "discord_reply_to_forum",
     description:
       "Post a follow-up message inside an existing forum post (thread). Requires the Send Messages in Threads permission (shown as 'Send Messages in Posts' for forums). Use discord_create_forum_post to start a new post instead. Returns the new message ID.",
-    annotations: { title: "Reply to forum post", readOnlyHint: false, destructiveHint: false, idempotentHint: false, openWorldHint: true },
+    annotations: {
+      title: "Reply to forum post",
+      readOnlyHint: false,
+      destructiveHint: false,
+      idempotentHint: false,
+      openWorldHint: true,
+    },
     schema: z.object({
       thread_id: snowflake.describe("ID (snowflake) of the forum post (thread) to reply in."),
       content: z.string().describe("Plain-text body of the reply (max 2000 characters)."),
@@ -202,14 +255,24 @@ const tools = [
     handle: async ({ thread_id, content }) => {
       const thread = await getThreadChannel(thread_id);
       const sent = await thread.send(content);
-      return { content: [{ type: "text", text: `✅ Reply sent (id: ${sent.id}) in thread "${thread.name}".` }] };
+      return {
+        content: [
+          { type: "text", text: `✅ Reply sent (id: ${sent.id}) in thread "${thread.name}".` },
+        ],
+      };
     },
   }),
   defineTool({
     name: "discord_delete_forum_post",
     description:
       "Permanently delete a forum post (thread) and all its messages. IRREVERSIBLE. To merely close it without deleting, use discord_update_forum_post with archived:true. Requires the Manage Threads permission.",
-    annotations: { title: "Delete forum post", readOnlyHint: false, destructiveHint: true, idempotentHint: false, openWorldHint: true },
+    annotations: {
+      title: "Delete forum post",
+      readOnlyHint: false,
+      destructiveHint: true,
+      idempotentHint: false,
+      openWorldHint: true,
+    },
     schema: z.object({
       thread_id: snowflake.describe("ID (snowflake) of the forum post (thread) to delete."),
     }),
@@ -226,15 +289,19 @@ const tools = [
       "List the tags available on a forum channel (id, name, emoji, moderated flag). Read-only. Use these IDs with discord_create_forum_post or discord_update_forum_post; manage the tag set with discord_set_forum_tags.",
     annotations: { title: "Get forum tags", readOnlyHint: true, openWorldHint: true },
     schema: z.object({
-      forum_channel_id: snowflake.describe("ID (snowflake) of the forum channel to read tags from."),
+      forum_channel_id: snowflake.describe(
+        "ID (snowflake) of the forum channel to read tags from.",
+      ),
     }),
     outputSchema: z.object({
-      tags: z.array(z.object({
-        id: z.string(),
-        name: z.string(),
-        emoji: z.string().nullable(),
-        moderated: z.boolean(),
-      })),
+      tags: z.array(
+        z.object({
+          id: z.string(),
+          name: z.string(),
+          emoji: z.string().nullable(),
+          moderated: z.boolean(),
+        }),
+      ),
     }),
     handle: async ({ forum_channel_id }) => {
       const forum = await getForumChannel(forum_channel_id);
@@ -251,14 +318,29 @@ const tools = [
     name: "discord_set_forum_tags",
     description:
       "Replace the full set of available tags on a forum channel with the provided list. This overwrites existing tags, so include every tag you want to keep. Requires the Manage Channels permission. Returns a confirmation.",
-    annotations: { title: "Set forum tags", readOnlyHint: false, destructiveHint: true, idempotentHint: true, openWorldHint: true },
+    annotations: {
+      title: "Set forum tags",
+      readOnlyHint: false,
+      destructiveHint: true,
+      idempotentHint: true,
+      openWorldHint: true,
+    },
     schema: z.object({
       forum_channel_id: snowflake.describe("ID (snowflake) of the forum channel to set tags on."),
-      tags: z.array(z.object({
-        name: z.string().describe("Tag label (max 20 characters)."),
-        emoji_name: z.string().optional().describe("Optional unicode emoji shown on the tag."),
-        moderated: z.boolean().optional().describe("If true, only members with Manage Threads can apply this tag. Default false."),
-      })).describe("Complete list of tags to set (replaces all existing tags)."),
+      tags: z
+        .array(
+          z.object({
+            name: z.string().describe("Tag label (max 20 characters)."),
+            emoji_name: z.string().optional().describe("Optional unicode emoji shown on the tag."),
+            moderated: z
+              .boolean()
+              .optional()
+              .describe(
+                "If true, only members with Manage Threads can apply this tag. Default false.",
+              ),
+          }),
+        )
+        .describe("Complete list of tags to set (replaces all existing tags)."),
     }),
     handle: async ({ forum_channel_id, tags }) => {
       const forum = await getForumChannel(forum_channel_id);
@@ -268,20 +350,44 @@ const tools = [
         moderated: t.moderated ?? false,
       }));
       await forum.setAvailableTags(mapped);
-      return { content: [{ type: "text", text: `✅ Forum tags updated on #${forum.name} (${mapped.length} tags set).` }] };
+      return {
+        content: [
+          {
+            type: "text",
+            text: `✅ Forum tags updated on #${forum.name} (${mapped.length} tags set).`,
+          },
+        ],
+      };
     },
   }),
   defineTool({
     name: "discord_update_forum_post",
     description:
       "Update a forum post's title, archived/locked state, or applied tags. Only provided fields change; passing applied_tags replaces the post's tags. Set archived:true to close a post without deleting it. Requires the Manage Threads permission.",
-    annotations: { title: "Update forum post", readOnlyHint: false, destructiveHint: false, idempotentHint: true, openWorldHint: true },
+    annotations: {
+      title: "Update forum post",
+      readOnlyHint: false,
+      destructiveHint: false,
+      idempotentHint: true,
+      openWorldHint: true,
+    },
     schema: z.object({
       thread_id: snowflake.describe("ID (snowflake) of the forum post (thread) to update."),
       title: z.string().optional().describe("New title/thread name (max 100 characters)."),
-      archived: z.boolean().optional().describe("true to archive (close) the post, false to reopen it."),
-      locked: z.boolean().optional().describe("true to lock the post so only moderators can reply."),
-      applied_tags: z.array(z.string()).optional().describe("Tag IDs to apply; replaces the post's current tags. Get valid IDs from discord_get_forum_tags."),
+      archived: z
+        .boolean()
+        .optional()
+        .describe("true to archive (close) the post, false to reopen it."),
+      locked: z
+        .boolean()
+        .optional()
+        .describe("true to lock the post so only moderators can reply."),
+      applied_tags: z
+        .array(z.string())
+        .optional()
+        .describe(
+          "Tag IDs to apply; replaces the post's current tags. Get valid IDs from discord_get_forum_tags.",
+        ),
     }),
     handle: async ({ thread_id, title, archived, locked, applied_tags }) => {
       const thread = await getThreadChannel(thread_id);

--- a/src/tools/invites.ts
+++ b/src/tools/invites.ts
@@ -80,6 +80,7 @@ const tools = [
       const code = invite_code.replace(/^(https?:\/\/)?(discord\.gg\/)?/, "");
       if (!code) throw new Error("invite_code is required.");
       const invite = await discord.fetchInvite(code);
+      assertAllowedGuild(invite.guild?.id);
       return structured(serializeInvite(invite));
     },
   }),

--- a/src/tools/members.ts
+++ b/src/tools/members.ts
@@ -22,19 +22,29 @@ const tools = [
     annotations: { title: "List members", readOnlyHint: true, openWorldHint: true },
     schema: z.object({
       guild_id: guildId,
-      limit: intIn(1, DEFAULTS.MEMBERS_MAX).default(DEFAULTS.MEMBERS).describe("How many members per page (1–1000). Default 50."),
-      after: snowflake.optional().describe("Pagination cursor: a user ID (snowflake). Pass the previous response's nextCursor to fetch the next page."),
+      limit: intIn(1, DEFAULTS.MEMBERS_MAX)
+        .default(DEFAULTS.MEMBERS)
+        .describe("How many members per page (1–1000). Default 50."),
+      after: snowflake
+        .optional()
+        .describe(
+          "Pagination cursor: a user ID (snowflake). Pass the previous response's nextCursor to fetch the next page.",
+        ),
     }),
     outputSchema: z.object({ members: z.array(memberSummary), nextCursor: z.string().nullable() }),
     handle: async ({ guild_id, limit, after }) => {
       const guild = await discord.guilds.fetch(guild_id);
       const members = await guild.members.list({ limit, after });
       const result = [...members.values()].map((m: GuildMember) => ({
-        id: m.id, username: m.user.tag, nickname: m.nickname,
-        roles: m.roles.cache.filter((r) => r.name !== "@everyone").map((r) => ({ id: r.id, name: r.name })),
+        id: m.id,
+        username: m.user.tag,
+        nickname: m.nickname,
+        roles: m.roles.cache
+          .filter((r) => r.name !== "@everyone")
+          .map((r) => ({ id: r.id, name: r.name })),
         joinedAt: m.joinedAt?.toISOString() ?? null,
       }));
-      const nextCursor = members.size === limit ? members.lastKey() ?? null : null;
+      const nextCursor = members.size === limit ? (members.lastKey() ?? null) : null;
       return structured({ members: result, nextCursor });
     },
   }),
@@ -62,11 +72,17 @@ const tools = [
       const guild = await discord.guilds.fetch(guild_id);
       const member = await guild.members.fetch(user_id);
       return structured({
-        id: member.id, username: member.user.tag, nickname: member.nickname,
-        roles: member.roles.cache.filter((r) => r.name !== "@everyone").map((r) => ({ id: r.id, name: r.name })),
+        id: member.id,
+        username: member.user.tag,
+        nickname: member.nickname,
+        roles: member.roles.cache
+          .filter((r) => r.name !== "@everyone")
+          .map((r) => ({ id: r.id, name: r.name })),
         permissions: serializePermissions(member.permissions),
-        joinedAt: member.joinedAt?.toISOString() ?? null, createdAt: member.user.createdAt.toISOString(),
-        bot: member.user.bot, timedOutUntil: member.communicationDisabledUntil?.toISOString() ?? null,
+        joinedAt: member.joinedAt?.toISOString() ?? null,
+        createdAt: member.user.createdAt.toISOString(),
+        bot: member.user.bot,
+        timedOutUntil: member.communicationDisabledUntil?.toISOString() ?? null,
       });
     },
   }),
@@ -74,7 +90,13 @@ const tools = [
     name: "discord_kick_member",
     description:
       "Remove a member from the server. They can rejoin with a new invite (unlike a ban). Requires the Kick Members permission, and the bot's top role must be higher than the target's. Use discord_ban_member to block re-entry. The reason is recorded in the audit log.",
-    annotations: { title: "Kick member", readOnlyHint: false, destructiveHint: true, idempotentHint: false, openWorldHint: true },
+    annotations: {
+      title: "Kick member",
+      readOnlyHint: false,
+      destructiveHint: true,
+      idempotentHint: false,
+      openWorldHint: true,
+    },
     schema: z.object({
       guild_id: guildId,
       user_id: snowflake.describe("Discord user ID (snowflake) of the member to kick."),
@@ -91,12 +113,22 @@ const tools = [
     name: "discord_ban_member",
     description:
       "Ban a user from the server, blocking re-entry until unbanned. Optionally bulk-deletes their recent messages. Requires the Ban Members permission, and the bot's top role must outrank the target's. Use discord_unban_member to reverse, or discord_kick_member for a non-permanent removal. The reason is recorded in the audit log.",
-    annotations: { title: "Ban member", readOnlyHint: false, destructiveHint: true, idempotentHint: true, openWorldHint: true },
+    annotations: {
+      title: "Ban member",
+      readOnlyHint: false,
+      destructiveHint: true,
+      idempotentHint: true,
+      openWorldHint: true,
+    },
     schema: z.object({
       guild_id: guildId,
       user_id: snowflake.describe("Discord user ID (snowflake) of the user to ban."),
       reason: z.string().optional().describe("Optional reason recorded in the server audit log."),
-      delete_message_days: intIn(0, 7).default(0).describe("Also delete the user's messages from the last N days (0–7). Default 0 (delete nothing)."),
+      delete_message_days: intIn(0, 7)
+        .default(0)
+        .describe(
+          "Also delete the user's messages from the last N days (0–7). Default 0 (delete nothing).",
+        ),
     }),
     handle: async ({ guild_id, user_id, reason, delete_message_days }) => {
       const guild = await discord.guilds.fetch(guild_id);
@@ -111,7 +143,13 @@ const tools = [
     name: "discord_unban_member",
     description:
       "Lift a ban so the user may rejoin via a new invite. Requires the Ban Members permission. Reverses discord_ban_member. The reason is recorded in the audit log.",
-    annotations: { title: "Unban member", readOnlyHint: false, destructiveHint: false, idempotentHint: true, openWorldHint: true },
+    annotations: {
+      title: "Unban member",
+      readOnlyHint: false,
+      destructiveHint: false,
+      idempotentHint: true,
+      openWorldHint: true,
+    },
     schema: z.object({
       guild_id: guildId,
       user_id: snowflake.describe("Discord user ID (snowflake) of the banned user to unban."),
@@ -127,23 +165,37 @@ const tools = [
     name: "discord_timeout_member",
     description:
       "Mute a member for a set duration (Discord 'timeout'): they cannot send messages, react, or speak until it expires. Pass duration_minutes = 0 to remove an active timeout early. Max 28 days (40320 minutes). Requires the Moderate Members permission.",
-    annotations: { title: "Timeout member", readOnlyHint: false, destructiveHint: false, idempotentHint: true, openWorldHint: true },
+    annotations: {
+      title: "Timeout member",
+      readOnlyHint: false,
+      destructiveHint: false,
+      idempotentHint: true,
+      openWorldHint: true,
+    },
     schema: z.object({
       guild_id: guildId,
       user_id: snowflake.describe("Discord user ID (snowflake) of the member to time out."),
-      duration_minutes: intIn(0, 40320).describe("Timeout length in minutes (0–40320, i.e. up to 28 days). Use 0 to clear an existing timeout."),
+      duration_minutes: intIn(0, 40320).describe(
+        "Timeout length in minutes (0–40320, i.e. up to 28 days). Use 0 to clear an existing timeout.",
+      ),
       reason: z.string().optional().describe("Optional reason recorded in the server audit log."),
     }),
     handle: async ({ guild_id, user_id, duration_minutes, reason }) => {
       const guild = await discord.guilds.fetch(guild_id);
       const member = await guild.members.fetch(user_id);
-      const until = duration_minutes > 0 ? new Date(Date.now() + duration_minutes * 60 * 1000) : null;
+      const until =
+        duration_minutes > 0 ? new Date(Date.now() + duration_minutes * 60 * 1000) : null;
       await member.disableCommunicationUntil(until, reason);
       return {
-        content: [{
-          type: "text",
-          text: duration_minutes > 0 ? `✅ ${member.user.tag} is in timeout for ${duration_minutes} minutes.` : `✅ Timeout removed from ${member.user.tag}.`,
-        }],
+        content: [
+          {
+            type: "text",
+            text:
+              duration_minutes > 0
+                ? `✅ ${member.user.tag} is in timeout for ${duration_minutes} minutes.`
+                : `✅ Timeout removed from ${member.user.tag}.`,
+          },
+        ],
       };
     },
   }),
@@ -155,22 +207,30 @@ const tools = [
     schema: z.object({
       guild_id: guildId,
       query: z.string().describe("Prefix to match against usernames and nicknames."),
-      limit: intIn(1, MAX_FETCH_LIMIT).default(DEFAULTS.LIMIT).describe("Max members to return (1–100). Default 25."),
+      limit: intIn(1, MAX_FETCH_LIMIT)
+        .default(DEFAULTS.LIMIT)
+        .describe("Max members to return (1–100). Default 25."),
     }),
     outputSchema: z.object({
-      members: z.array(z.object({
-        id: z.string(),
-        username: z.string(),
-        nickname: z.string().nullable(),
-        roles: z.array(roleRef),
-      })),
+      members: z.array(
+        z.object({
+          id: z.string(),
+          username: z.string(),
+          nickname: z.string().nullable(),
+          roles: z.array(roleRef),
+        }),
+      ),
     }),
     handle: async ({ guild_id, query, limit }) => {
       const guild = await discord.guilds.fetch(guild_id);
       const members = await guild.members.search({ query, limit });
       const result = [...members.values()].map((m: GuildMember) => ({
-        id: m.id, username: m.user.tag, nickname: m.nickname,
-        roles: m.roles.cache.filter((r) => r.name !== "@everyone").map((r) => ({ id: r.id, name: r.name })),
+        id: m.id,
+        username: m.user.tag,
+        nickname: m.nickname,
+        roles: m.roles.cache
+          .filter((r) => r.name !== "@everyone")
+          .map((r) => ({ id: r.id, name: r.name })),
       }));
       return structured({ members: result });
     },
@@ -179,11 +239,21 @@ const tools = [
     name: "discord_set_nickname",
     description:
       "Set or clear a member's server nickname. Pass null (or the string 'null') to clear it. Requires the Manage Nicknames permission (or Change Nickname for the bot itself). The reason is recorded in the audit log.",
-    annotations: { title: "Set nickname", readOnlyHint: false, destructiveHint: false, idempotentHint: true, openWorldHint: true },
+    annotations: {
+      title: "Set nickname",
+      readOnlyHint: false,
+      destructiveHint: false,
+      idempotentHint: true,
+      openWorldHint: true,
+    },
     schema: z.object({
       guild_id: guildId,
       user_id: snowflake.describe("Discord user ID (snowflake) of the member."),
-      nickname: z.string().max(32).nullable().describe("New nickname (max 32 characters), or null to clear it."),
+      nickname: z
+        .string()
+        .max(32)
+        .nullable()
+        .describe("New nickname (max 32 characters), or null to clear it."),
       reason: z.string().optional().describe("Optional reason recorded in the server audit log."),
     }),
     handle: async ({ guild_id, user_id, nickname, reason }) => {
@@ -191,7 +261,16 @@ const tools = [
       const member = await guild.members.fetch(user_id);
       const nick = nickname === null || nickname === "null" ? null : nickname;
       await member.setNickname(nick, reason);
-      return { content: [{ type: "text", text: nick ? `✅ Nickname for ${member.user.tag} set to "${nick}".` : `✅ Nickname cleared for ${member.user.tag}.` }] };
+      return {
+        content: [
+          {
+            type: "text",
+            text: nick
+              ? `✅ Nickname for ${member.user.tag} set to "${nick}".`
+              : `✅ Nickname cleared for ${member.user.tag}.`,
+          },
+        ],
+      };
     },
   }),
   defineTool({
@@ -201,61 +280,120 @@ const tools = [
     annotations: { title: "List bans", readOnlyHint: true, openWorldHint: true },
     schema: z.object({
       guild_id: guildId,
-      limit: intIn(1, DEFAULTS.MEMBERS_MAX).default(DEFAULTS.MEMBERS_MAX).describe("Max bans per page (1–1000). Default 1000."),
-      after: snowflake.optional().describe("Pagination cursor: a user ID (snowflake). Pass the previous response's nextCursor to fetch the next page."),
+      limit: intIn(1, DEFAULTS.MEMBERS_MAX)
+        .default(DEFAULTS.MEMBERS_MAX)
+        .describe("Max bans per page (1–1000). Default 1000."),
+      after: snowflake
+        .optional()
+        .describe(
+          "Pagination cursor: a user ID (snowflake). Pass the previous response's nextCursor to fetch the next page.",
+        ),
     }),
     outputSchema: z.object({
-      bans: z.array(z.object({
-        user_id: z.string(),
-        username: z.string(),
-        reason: z.string().nullable(),
-      })),
+      bans: z.array(
+        z.object({
+          user_id: z.string(),
+          username: z.string(),
+          reason: z.string().nullable(),
+        }),
+      ),
       nextCursor: z.string().nullable(),
     }),
     handle: async ({ guild_id, limit, after }) => {
       const guild = await discord.guilds.fetch(guild_id);
       const bans = await guild.bans.fetch({ limit, after, cache: false });
       const result = [...bans.values()].map((ban) => ({
-        user_id: ban.user.id, username: ban.user.tag, reason: ban.reason ?? null,
+        user_id: ban.user.id,
+        username: ban.user.tag,
+        reason: ban.reason ?? null,
       }));
-      const nextCursor = bans.size === limit ? bans.lastKey() ?? null : null;
+      const nextCursor = bans.size === limit ? (bans.lastKey() ?? null) : null;
       return structured({ bans: result, nextCursor });
     },
   }),
   defineTool({
     name: "discord_bulk_ban",
     description:
-      "Ban many users in a single call, intended for raid mitigation. SAFE BY DEFAULT: dry_run is true unless explicitly set to false, so call it first to preview the exact list of user IDs that would be banned, then re-call with dry_run:false to actually ban them. Requires the Ban Members permission. Returns counts of banned vs failed users. Use discord_ban_member for a single ban with finer control.",
-    annotations: { title: "Bulk ban", readOnlyHint: false, destructiveHint: true, idempotentHint: false, openWorldHint: true },
+      "Ban many users in a single call, intended for raid mitigation. SAFE BY DEFAULT: dry_run is true unless explicitly set to false, so call it first to preview the exact list of user IDs that would be banned, then re-call with dry_run:false to actually ban them. Requires both the Ban Members and Manage Server permissions. Returns counts of banned vs failed users; Discord rejects the whole call with an error if no user could be banned. Use discord_ban_member for a single ban with finer control.",
+    annotations: {
+      title: "Bulk ban",
+      readOnlyHint: false,
+      destructiveHint: true,
+      idempotentHint: false,
+      openWorldHint: true,
+    },
     schema: z.object({
       guild_id: guildId,
-      user_ids: z.array(snowflake).min(1).max(200).describe("Array of user IDs (snowflakes) to ban (max 200 per call — Discord API limit)."),
-      delete_message_seconds: intIn(0, 604800).default(0).describe("Also delete each user's messages from the last N seconds (0–604800, i.e. up to 7 days). Default 0."),
-      dry_run: z.boolean().default(true).describe("If true (default), only returns the user IDs that would be banned without banning anyone. Set false to actually ban."),
+      user_ids: z
+        .array(snowflake)
+        .min(1)
+        .max(200)
+        .describe("Array of user IDs (snowflakes) to ban (max 200 per call — Discord API limit)."),
+      delete_message_seconds: intIn(0, 604800)
+        .default(0)
+        .describe(
+          "Also delete each user's messages from the last N seconds (0–604800, i.e. up to 7 days). Default 0.",
+        ),
+      dry_run: z
+        .boolean()
+        .default(true)
+        .describe(
+          "If true (default), only returns the user IDs that would be banned without banning anyone. Set false to actually ban.",
+        ),
       reason: z.string().optional().describe("Optional reason recorded in the server audit log."),
     }),
     handle: async ({ guild_id, user_ids, delete_message_seconds, dry_run, reason }) => {
       const guild = await discord.guilds.fetch(guild_id);
       if (dry_run) {
-        return { content: [{ type: "text", text: `🔍 Dry run: ${user_ids.length} users would be banned:\n${JSON.stringify(user_ids, null, 2)}` }] };
+        return {
+          content: [
+            {
+              type: "text",
+              text: `🔍 Dry run: ${user_ids.length} users would be banned:\n${JSON.stringify(user_ids, null, 2)}`,
+            },
+          ],
+        };
       }
       const result = await guild.members.bulkBan(user_ids, {
         deleteMessageSeconds: delete_message_seconds,
         reason,
       });
-      return { content: [{ type: "text", text: `✅ Bulk ban complete: ${result.bannedUsers.length} banned, ${result.failedUsers.length} failed.` }] };
+      return {
+        content: [
+          {
+            type: "text",
+            text: `✅ Bulk ban complete: ${result.bannedUsers.length} banned, ${result.failedUsers.length} failed.`,
+          },
+        ],
+      };
     },
   }),
   defineTool({
     name: "discord_prune_members",
     description:
       "Remove members who have been inactive (no roles, not seen) for a number of days. SAFE BY DEFAULT: dry_run is true unless explicitly set to false, so call it first to preview the count, then re-call with dry_run:false to actually remove them. Removal is irreversible (members must rejoin). Requires the Kick Members permission.",
-    annotations: { title: "Prune inactive members", readOnlyHint: false, destructiveHint: true, idempotentHint: false, openWorldHint: true },
+    annotations: {
+      title: "Prune inactive members",
+      readOnlyHint: false,
+      destructiveHint: true,
+      idempotentHint: false,
+      openWorldHint: true,
+    },
     schema: z.object({
       guild_id: guildId,
       days: intIn(1, 30).describe("Inactivity threshold in days (1–30)."),
-      roles: z.array(snowflake).optional().describe("Optional role IDs (snowflakes) to include; by default only members with no roles are counted."),
-      dry_run: z.boolean().default(true).describe("If true (default), only returns the count that would be pruned without removing anyone. Set false to actually prune."),
+      roles: z
+        .array(snowflake)
+        .optional()
+        .describe(
+          "Optional role IDs (snowflakes) to include; by default only members with no roles are counted.",
+        ),
+      dry_run: z
+        .boolean()
+        .default(true)
+        .describe(
+          "If true (default), only returns the count that would be pruned without removing anyone. Set false to actually prune.",
+        ),
       reason: z.string().optional().describe("Optional reason recorded in the server audit log."),
     }),
     handle: async ({ guild_id, days, roles, dry_run, reason }) => {
@@ -266,7 +404,16 @@ const tools = [
         roles: roles ?? undefined,
         reason,
       });
-      return { content: [{ type: "text", text: dry_run ? `🔍 Dry run: ${pruned} members would be pruned (${days} days inactive).` : `✅ ${pruned} members pruned (${days} days inactive).` }] };
+      return {
+        content: [
+          {
+            type: "text",
+            text: dry_run
+              ? `🔍 Dry run: ${pruned} members would be pruned (${days} days inactive).`
+              : `✅ ${pruned} members pruned (${days} days inactive).`,
+          },
+        ],
+      };
     },
   }),
 ];

--- a/src/tools/messages.ts
+++ b/src/tools/messages.ts
@@ -9,8 +9,8 @@ import {
 } from "discord.js";
 import { z } from "zod";
 import { discord, getTextChannel, fetchChannelChecked } from "../client.js";
-import { MAX_FETCH_LIMIT, DEFAULTS } from "../constants.js";
-import { buildEmbed, embedFieldsShape, embedObjectSchema } from "../embeds.js";
+import { MAX_FETCH_LIMIT, DEFAULTS, AUTO_ARCHIVE_DURATIONS } from "../constants.js";
+import { buildEmbed, embedFieldsShape, embedObjectSchema, embedArraySchema } from "../embeds.js";
 import { defineModule, defineTool, snowflake, intIn, structured } from "./define.js";
 
 const channelId = snowflake.describe("ID (snowflake) of the channel or thread.");
@@ -44,7 +44,9 @@ const tools = [
     annotations: { title: "Read messages", readOnlyHint: true, openWorldHint: true },
     schema: z.object({
       channel_id: snowflake.describe("ID (snowflake) of the channel or thread to read from."),
-      limit: intIn(1, MAX_FETCH_LIMIT).default(DEFAULTS.MESSAGES).describe("How many recent messages to fetch (1–100). Default 20."),
+      limit: intIn(1, MAX_FETCH_LIMIT)
+        .default(DEFAULTS.MESSAGES)
+        .describe("How many recent messages to fetch (1–100). Default 20."),
     }),
     outputSchema: z.object({
       messages: z.array(messageSummary.extend({ attachments: z.number(), pinned: z.boolean() })),
@@ -55,8 +57,12 @@ const tools = [
       const result = [...messages.values()]
         .sort((a, b) => a.createdTimestamp - b.createdTimestamp)
         .map((m) => ({
-          id: m.id, author: m.author.tag, content: m.content,
-          timestamp: m.createdAt.toISOString(), attachments: m.attachments.size, pinned: m.pinned,
+          id: m.id,
+          author: m.author.tag,
+          content: m.content,
+          timestamp: m.createdAt.toISOString(),
+          attachments: m.attachments.size,
+          pinned: m.pinned,
         }));
       return structured({ messages: result });
     },
@@ -65,7 +71,13 @@ const tools = [
     name: "discord_send_message",
     description:
       "Send a plain-text message to a channel or thread. For rich content (title, color, fields, images) use discord_send_embed; to attach a reply reference to an existing message use discord_reply_message. Requires the bot to have the Send Messages permission. Returns the new message ID.",
-    annotations: { title: "Send message", readOnlyHint: false, destructiveHint: false, idempotentHint: false, openWorldHint: true },
+    annotations: {
+      title: "Send message",
+      readOnlyHint: false,
+      destructiveHint: false,
+      idempotentHint: false,
+      openWorldHint: true,
+    },
     schema: z.object({
       channel_id: snowflake.describe("ID (snowflake) of the target channel or thread."),
       content: z.string().describe("Plain-text body of the message (max 2000 characters)."),
@@ -73,16 +85,26 @@ const tools = [
     handle: async ({ channel_id, content }) => {
       const channel = await getTextChannel(channel_id);
       const sent = await channel.send(content);
-      return { content: [{ type: "text", text: `✅ Message sent (id: ${sent.id}) in #${channel.name}.` }] };
+      return {
+        content: [{ type: "text", text: `✅ Message sent (id: ${sent.id}) in #${channel.name}.` }],
+      };
     },
   }),
   defineTool({
     name: "discord_reply_message",
     description:
       "Reply to a specific message, attaching a reply reference so clients show it as a threaded reply. Use discord_send_message for a standalone message with no reference. Requires the Send Messages permission. Returns the new reply's message ID.",
-    annotations: { title: "Reply to message", readOnlyHint: false, destructiveHint: false, idempotentHint: false, openWorldHint: true },
+    annotations: {
+      title: "Reply to message",
+      readOnlyHint: false,
+      destructiveHint: false,
+      idempotentHint: false,
+      openWorldHint: true,
+    },
     schema: z.object({
-      channel_id: channelId.describe("ID (snowflake) of the channel or thread containing the message."),
+      channel_id: channelId.describe(
+        "ID (snowflake) of the channel or thread containing the message.",
+      ),
       message_id: messageId.describe("ID of the message to reply to."),
       content: z.string().describe("Plain-text body of the reply (max 2000 characters)."),
     }),
@@ -90,57 +112,112 @@ const tools = [
       const channel = await getTextChannel(channel_id);
       const target = await channel.messages.fetch(message_id);
       const sent = await target.reply(content);
-      return { content: [{ type: "text", text: `✅ Reply sent (id: ${sent.id}) to message ${message_id} in #${channel.name}.` }] };
+      return {
+        content: [
+          {
+            type: "text",
+            text: `✅ Reply sent (id: ${sent.id}) to message ${message_id} in #${channel.name}.`,
+          },
+        ],
+      };
     },
   }),
   defineTool({
     name: "discord_edit_message",
     description:
       "Edit the text content of a message previously sent by this bot. Discord forbids editing other users' messages, so this fails for non-bot messages. Use discord_edit_embed for embed messages. Works in text channels and threads. Returns the edited message ID.",
-    annotations: { title: "Edit message", readOnlyHint: false, destructiveHint: false, idempotentHint: true, openWorldHint: true },
+    annotations: {
+      title: "Edit message",
+      readOnlyHint: false,
+      destructiveHint: false,
+      idempotentHint: true,
+      openWorldHint: true,
+    },
     schema: z.object({
-      channel_id: channelId.describe("ID (snowflake) of the channel or thread containing the message."),
-      message_id: messageId.describe("ID of the message to edit. Must be a message authored by this bot."),
-      content: z.string().describe("New plain-text content that fully replaces the existing content (max 2000 characters)."),
+      channel_id: channelId.describe(
+        "ID (snowflake) of the channel or thread containing the message.",
+      ),
+      message_id: messageId.describe(
+        "ID of the message to edit. Must be a message authored by this bot.",
+      ),
+      content: z
+        .string()
+        .describe(
+          "New plain-text content that fully replaces the existing content (max 2000 characters).",
+        ),
     }),
     handle: async ({ channel_id, message_id, content }) => {
       const channel = await getTextChannel(channel_id);
       const msg = await channel.messages.fetch(message_id);
-      if (msg.author.id !== discord.user?.id) throw new Error("Can only edit messages sent by the bot.");
+      if (msg.author.id !== discord.user?.id)
+        throw new Error("Can only edit messages sent by the bot.");
       const edited = await msg.edit(content);
-      return { content: [{ type: "text", text: `✅ Message ${edited.id} edited in #${channel.name}.` }] };
+      return {
+        content: [{ type: "text", text: `✅ Message ${edited.id} edited in #${channel.name}.` }],
+      };
     },
   }),
   defineTool({
     name: "discord_add_reaction",
     description:
       "Add a single emoji reaction to a message as the bot. Requires the Add Reactions and Read Message History permissions. Use discord_remove_reactions to undo. Idempotent: re-adding the bot's existing reaction has no effect.",
-    annotations: { title: "Add reaction", readOnlyHint: false, destructiveHint: false, idempotentHint: true, openWorldHint: true },
+    annotations: {
+      title: "Add reaction",
+      readOnlyHint: false,
+      destructiveHint: false,
+      idempotentHint: true,
+      openWorldHint: true,
+    },
     schema: z.object({
-      channel_id: channelId.describe("ID (snowflake) of the channel or thread containing the message."),
+      channel_id: channelId.describe(
+        "ID (snowflake) of the channel or thread containing the message.",
+      ),
       message_id: messageId.describe("ID of the message to react to."),
-      emoji: z.string().describe("Unicode emoji (e.g. '👍') or a custom emoji in 'name:id' format."),
+      emoji: z
+        .string()
+        .describe("Unicode emoji (e.g. '👍') or a custom emoji in 'name:id' format."),
     }),
     handle: async ({ channel_id, message_id, emoji }) => {
       const channel = await getTextChannel(channel_id);
       const msg = await channel.messages.fetch(message_id);
       await msg.react(emoji);
-      return { content: [{ type: "text", text: `✅ Reacted with ${emoji} to message ${msg.id} in #${channel.name}.` }] };
+      return {
+        content: [
+          {
+            type: "text",
+            text: `✅ Reacted with ${emoji} to message ${msg.id} in #${channel.name}.`,
+          },
+        ],
+      };
     },
   }),
   defineTool({
     name: "discord_create_thread",
     description:
       "Create a thread, either branching from an existing message (pass message_id) or as a standalone thread in a text channel (omit message_id). Standalone creation requires a parent text channel and fails if channel_id is itself a thread. Requires the Create Public Threads permission. Returns the new thread's ID.",
-    annotations: { title: "Create thread", readOnlyHint: false, destructiveHint: false, idempotentHint: false, openWorldHint: true },
+    annotations: {
+      title: "Create thread",
+      readOnlyHint: false,
+      destructiveHint: false,
+      idempotentHint: false,
+      openWorldHint: true,
+    },
     schema: z.object({
-      channel_id: snowflake.describe("ID (snowflake) of the parent text channel. For a message-based thread, the channel containing message_id."),
+      channel_id: snowflake.describe(
+        "ID (snowflake) of the parent text channel. For a message-based thread, the channel containing message_id.",
+      ),
       name: z.string().describe("Name of the thread to create (max 100 characters)."),
-      message_id: snowflake.optional().describe("Optional. Message to branch the thread from. If omitted, a standalone thread is created in the channel."),
+      message_id: snowflake
+        .optional()
+        .describe(
+          "Optional. Message to branch the thread from. If omitted, a standalone thread is created in the channel.",
+        ),
       auto_archive_duration: z
-        .union([z.literal(60), z.literal(1440), z.literal(4320), z.literal(10080)])
+        .literal([...AUTO_ARCHIVE_DURATIONS])
         .default(1440)
-        .describe("Minutes of inactivity before auto-archiving: 60, 1440, 4320, or 10080. Default 1440 (24h)."),
+        .describe(
+          "Minutes of inactivity before auto-archiving: 60, 1440, 4320, or 10080. Default 1440 (24h).",
+        ),
     }),
     handle: async ({ channel_id, name, message_id, auto_archive_duration }) => {
       const channel = await getTextChannel(channel_id);
@@ -148,24 +225,52 @@ const tools = [
       if (message_id) {
         const msg = await channel.messages.fetch(message_id);
         const thread = await msg.startThread({ name, autoArchiveDuration: duration });
-        return { content: [{ type: "text", text: `✅ Thread "${thread.name}" created from message (id: ${thread.id}).` }] };
+        return {
+          content: [
+            {
+              type: "text",
+              text: `✅ Thread "${thread.name}" created from message (id: ${thread.id}).`,
+            },
+          ],
+        };
       }
       if (!(channel instanceof TextChannel)) {
-        throw new Error(`Standalone thread creation requires a parent TextChannel; ${channel_id} is itself a thread. Pass a message_id to start a thread from a message instead.`);
+        throw new Error(
+          `Standalone thread creation requires a parent TextChannel; ${channel_id} is itself a thread. Pass a message_id to start a thread from a message instead.`,
+        );
       }
-      const thread = await channel.threads.create({ name, autoArchiveDuration: duration, type: ChannelType.PublicThread });
-      return { content: [{ type: "text", text: `✅ Thread "${thread.name}" created (id: ${thread.id}).` }] };
+      const thread = await channel.threads.create({
+        name,
+        autoArchiveDuration: duration,
+        type: ChannelType.PublicThread,
+      });
+      return {
+        content: [{ type: "text", text: `✅ Thread "${thread.name}" created (id: ${thread.id}).` }],
+      };
     },
   }),
   defineTool({
     name: "discord_bulk_delete_messages",
     description:
       "Permanently delete multiple recent messages in one call. IRREVERSIBLE. SAFE BY DEFAULT: dry_run is true unless explicitly set to false, so call it first to preview, then re-call with dry_run:false to actually delete. Discord only allows bulk-deleting messages younger than 14 days; older ones are skipped. Requires the Manage Messages permission. Returns the number deleted.",
-    annotations: { title: "Bulk delete messages", readOnlyHint: false, destructiveHint: true, idempotentHint: false, openWorldHint: true },
+    annotations: {
+      title: "Bulk delete messages",
+      readOnlyHint: false,
+      destructiveHint: true,
+      idempotentHint: false,
+      openWorldHint: true,
+    },
     schema: z.object({
-      channel_id: snowflake.describe("ID (snowflake) of the channel or thread to delete messages from."),
+      channel_id: snowflake.describe(
+        "ID (snowflake) of the channel or thread to delete messages from.",
+      ),
       count: intIn(2, MAX_FETCH_LIMIT).describe("Number of recent messages to delete (2–100)."),
-      dry_run: z.boolean().default(true).describe("If true (default), only reports how many would be deleted without deleting. Set false to actually delete."),
+      dry_run: z
+        .boolean()
+        .default(true)
+        .describe(
+          "If true (default), only reports how many would be deleted without deleting. Set false to actually delete.",
+        ),
     }),
     handle: async ({ channel_id, count, dry_run }) => {
       const channel = await getTextChannel(channel_id);
@@ -173,17 +278,34 @@ const tools = [
         const recent = await channel.messages.fetch({ limit: count, cache: false });
         const cutoff = Date.now() - 14 * 24 * 60 * 60 * 1000;
         const deletable = recent.filter((m) => m.createdTimestamp > cutoff).size;
-        return { content: [{ type: "text", text: `🔍 Dry run: ${deletable} of the ${recent.size} most recent messages in #${channel.name} would be deleted (${recent.size - deletable} older than 14 days are skipped). Re-call with dry_run:false to delete.` }] };
+        return {
+          content: [
+            {
+              type: "text",
+              text: `🔍 Dry run: ${deletable} of the ${recent.size} most recent messages in #${channel.name} would be deleted (${recent.size - deletable} older than 14 days are skipped). Re-call with dry_run:false to delete.`,
+            },
+          ],
+        };
       }
       const deleted = await channel.bulkDelete(count, true);
-      return { content: [{ type: "text", text: `✅ Deleted ${deleted.size} messages in #${channel.name}.` }] };
+      return {
+        content: [
+          { type: "text", text: `✅ Deleted ${deleted.size} messages in #${channel.name}.` },
+        ],
+      };
     },
   }),
   defineTool({
     name: "discord_send_embed",
     description:
       "Send a single rich embed (title, description, color, fields, author, footer, images, timestamp). Use discord_send_message for plain text, or discord_send_multiple_embeds to send several embeds at once. Requires the Send Messages and Embed Links permissions. Returns the new message ID.",
-    annotations: { title: "Send embed", readOnlyHint: false, destructiveHint: false, idempotentHint: false, openWorldHint: true },
+    annotations: {
+      title: "Send embed",
+      readOnlyHint: false,
+      destructiveHint: false,
+      idempotentHint: false,
+      openWorldHint: true,
+    },
     schema: z.object({
       channel_id: snowflake.describe("ID (snowflake) of the target channel or thread."),
       ...embedFieldsShape,
@@ -191,52 +313,89 @@ const tools = [
     handle: async ({ channel_id, ...embedArgs }) => {
       const channel = await getTextChannel(channel_id);
       const sent = await channel.send({ embeds: [buildEmbed(embedArgs)] });
-      return { content: [{ type: "text", text: `✅ Embed sent (id: ${sent.id}) in #${channel.name}.` }] };
+      return {
+        content: [{ type: "text", text: `✅ Embed sent (id: ${sent.id}) in #${channel.name}.` }],
+      };
     },
   }),
   defineTool({
     name: "discord_edit_embed",
     description:
       "Replace the embed on a message previously sent by this bot. Only this bot's messages can be edited. This is a full replace, not a merge: provided fields are applied and omitted fields are dropped from the embed. Returns a confirmation.",
-    annotations: { title: "Edit embed", readOnlyHint: false, destructiveHint: false, idempotentHint: true, openWorldHint: true },
+    annotations: {
+      title: "Edit embed",
+      readOnlyHint: false,
+      destructiveHint: false,
+      idempotentHint: true,
+      openWorldHint: true,
+    },
     schema: z.object({
-      channel_id: channelId.describe("ID (snowflake) of the channel or thread containing the message."),
-      message_id: messageId.describe("ID of the message to edit. Must be a message authored by this bot (an embed is added if it has none)."),
+      channel_id: channelId.describe(
+        "ID (snowflake) of the channel or thread containing the message.",
+      ),
+      message_id: messageId.describe(
+        "ID of the message to edit. Must be a message authored by this bot (an embed is added if it has none).",
+      ),
       ...embedFieldsShape,
     }),
     handle: async ({ channel_id, message_id, ...embedArgs }) => {
       const channel = await getTextChannel(channel_id);
       const msg = await channel.messages.fetch(message_id);
-      if (msg.author.id !== discord.user?.id) throw new Error("Can only edit embeds sent by the bot.");
+      if (msg.author.id !== discord.user?.id)
+        throw new Error("Can only edit embeds sent by the bot.");
       await msg.edit({ embeds: [buildEmbed(embedArgs)] });
-      return { content: [{ type: "text", text: `✅ Embed edited on message ${message_id} in #${channel.name}.` }] };
+      return {
+        content: [
+          { type: "text", text: `✅ Embed edited on message ${message_id} in #${channel.name}.` },
+        ],
+      };
     },
   }),
   defineTool({
     name: "discord_send_multiple_embeds",
     description:
       "Send up to 10 embeds in a single message, with optional text above them. Use discord_send_embed for a single embed. Requires the Send Messages and Embed Links permissions. Returns the new message ID.",
-    annotations: { title: "Send multiple embeds", readOnlyHint: false, destructiveHint: false, idempotentHint: false, openWorldHint: true },
+    annotations: {
+      title: "Send multiple embeds",
+      readOnlyHint: false,
+      destructiveHint: false,
+      idempotentHint: false,
+      openWorldHint: true,
+    },
     schema: z.object({
       channel_id: snowflake.describe("ID (snowflake) of the target channel or thread."),
       content: z.string().optional().describe("Optional plain text shown above the embeds."),
-      embeds: z.array(embedObjectSchema).describe("Array of embed objects to send (max 10)."),
+      embeds: embedArraySchema.describe("Array of embed objects to send (max 10)."),
     }),
     handle: async ({ channel_id, content, embeds }) => {
       const channel = await getTextChannel(channel_id);
-      if (embeds.length > 10) throw new Error("Discord allows a maximum of 10 embeds per message.");
       const built = embeds.map((e) => buildEmbed(e));
       const sent = await channel.send({ content: content || undefined, embeds: built });
-      return { content: [{ type: "text", text: `✅ ${built.length} embeds sent (id: ${sent.id}) in #${channel.name}.` }] };
+      return {
+        content: [
+          {
+            type: "text",
+            text: `✅ ${built.length} embeds sent (id: ${sent.id}) in #${channel.name}.`,
+          },
+        ],
+      };
     },
   }),
   defineTool({
     name: "discord_delete_message",
     description:
       "Permanently delete one specific message. IRREVERSIBLE. The bot can always delete its own messages; deleting another user's message requires the Manage Messages permission. Use discord_bulk_delete_messages to remove many at once. An optional reason is recorded in the audit log.",
-    annotations: { title: "Delete message", readOnlyHint: false, destructiveHint: true, idempotentHint: false, openWorldHint: true },
+    annotations: {
+      title: "Delete message",
+      readOnlyHint: false,
+      destructiveHint: true,
+      idempotentHint: false,
+      openWorldHint: true,
+    },
     schema: z.object({
-      channel_id: channelId.describe("ID (snowflake) of the channel or thread containing the message."),
+      channel_id: channelId.describe(
+        "ID (snowflake) of the channel or thread containing the message.",
+      ),
       message_id: messageId.describe("ID of the message to delete."),
       reason: z.string().optional().describe("Optional reason recorded in the server audit log."),
     }),
@@ -252,16 +411,28 @@ const tools = [
     name: "discord_pin_message",
     description:
       "Pin or unpin a message in a channel, controlled by the pin flag. Requires the Pin Messages permission (a dedicated permission since early 2026, separate from Manage Messages). A channel holds at most 50 pins. Idempotent: pinning an already-pinned message (or unpinning an unpinned one) has no additional effect.",
-    annotations: { title: "Pin or unpin message", readOnlyHint: false, destructiveHint: false, idempotentHint: true, openWorldHint: true },
+    annotations: {
+      title: "Pin or unpin message",
+      readOnlyHint: false,
+      destructiveHint: false,
+      idempotentHint: true,
+      openWorldHint: true,
+    },
     schema: z.object({
-      channel_id: channelId.describe("ID (snowflake) of the channel or thread containing the message."),
+      channel_id: channelId.describe(
+        "ID (snowflake) of the channel or thread containing the message.",
+      ),
       message_id: messageId.describe("ID of the message to pin or unpin."),
       pin: z.boolean().describe("true to pin the message, false to unpin it."),
     }),
     handle: async ({ channel_id, message_id, pin }) => {
       const channel = await getTextChannel(channel_id);
       const msg = await channel.messages.fetch(message_id);
-      if (pin) { await msg.pin(); } else { await msg.unpin(); }
+      if (pin) {
+        await msg.pin();
+      } else {
+        await msg.unpin();
+      }
       return { content: [{ type: "text", text: `✅ Message ${pin ? "pinned" : "unpinned"}.` }] };
     },
   }),
@@ -273,7 +444,9 @@ const tools = [
     schema: z.object({
       channel_id: snowflake.describe("ID (snowflake) of the channel or thread to search."),
       keyword: z.string().describe("Case-insensitive substring to match within message content."),
-      limit: intIn(1, MAX_FETCH_LIMIT).default(MAX_FETCH_LIMIT).describe("Max number of recent messages to scan (1–100). Default 100."),
+      limit: intIn(1, MAX_FETCH_LIMIT)
+        .default(MAX_FETCH_LIMIT)
+        .describe("Max number of recent messages to scan (1–100). Default 100."),
     }),
     outputSchema: z.object({ matches: z.array(messageSummary) }),
     handle: async ({ channel_id, keyword, limit }) => {
@@ -283,7 +456,12 @@ const tools = [
       const matches = [...messages.values()]
         .filter((m) => m.content.toLowerCase().includes(needle))
         .sort((a, b) => a.createdTimestamp - b.createdTimestamp)
-        .map((m) => ({ id: m.id, author: m.author.tag, content: m.content, timestamp: m.createdAt.toISOString() }));
+        .map((m) => ({
+          id: m.id,
+          author: m.author.tag,
+          content: m.content,
+          timestamp: m.createdAt.toISOString(),
+        }));
       return structured({ matches });
     },
   }),
@@ -291,46 +469,94 @@ const tools = [
     name: "discord_crosspost_message",
     description:
       "Publish (crosspost) a message from an Announcement channel to every server that follows it. Only works in announcement channels on a message that has not already been published. Requires the Send Messages permission (and Manage Messages for messages authored by others). Returns a confirmation.",
-    annotations: { title: "Crosspost message", readOnlyHint: false, destructiveHint: false, idempotentHint: true, openWorldHint: true },
+    annotations: {
+      title: "Crosspost message",
+      readOnlyHint: false,
+      destructiveHint: false,
+      idempotentHint: true,
+      openWorldHint: true,
+    },
     schema: z.object({
-      channel_id: snowflake.describe("ID (snowflake) of the announcement channel containing the message."),
+      channel_id: snowflake.describe(
+        "ID (snowflake) of the announcement channel containing the message.",
+      ),
       message_id: messageId.describe("ID of the message to publish to followers."),
     }),
     handle: async ({ channel_id, message_id }) => {
       const channel = await fetchChannelChecked(channel_id);
       if (!channel || channel.type !== ChannelType.GuildAnnouncement)
-        throw new Error("Channel is not an announcement channel — only announcement-channel messages can be published.");
+        throw new Error(
+          "Channel is not an announcement channel — only announcement-channel messages can be published.",
+        );
       const msg = await channel.messages.fetch(message_id);
       await msg.crosspost();
-      return { content: [{ type: "text", text: `✅ Message ${msg.id} published to all followers of #${channel.name}.` }] };
+      return {
+        content: [
+          {
+            type: "text",
+            text: `✅ Message ${msg.id} published to all followers of #${channel.name}.`,
+          },
+        ],
+      };
     },
   }),
   defineTool({
     name: "discord_remove_reactions",
     description:
       "Remove reactions from a message. With no emoji: removes ALL reactions. With emoji only: removes every reaction of that emoji. With emoji and user_id: removes that one user's reaction. Removing all reactions or another user's reaction requires the Manage Messages permission. Use discord_add_reaction to add.",
-    annotations: { title: "Remove reactions", readOnlyHint: false, destructiveHint: true, idempotentHint: true, openWorldHint: true },
+    annotations: {
+      title: "Remove reactions",
+      readOnlyHint: false,
+      destructiveHint: true,
+      idempotentHint: true,
+      openWorldHint: true,
+    },
     schema: z.object({
-      channel_id: channelId.describe("ID (snowflake) of the channel or thread containing the message."),
+      channel_id: channelId.describe(
+        "ID (snowflake) of the channel or thread containing the message.",
+      ),
       message_id: messageId.describe("ID of the message to remove reactions from."),
-      emoji: z.string().optional().describe("Unicode emoji or custom emoji 'name:id'. Omit to remove ALL reactions on the message."),
-      user_id: snowflake.optional().describe("Remove only this user's reaction for the given emoji. Requires emoji to be set."),
+      emoji: z
+        .string()
+        .optional()
+        .describe(
+          "Unicode emoji or custom emoji 'name:id'. Omit to remove ALL reactions on the message.",
+        ),
+      user_id: snowflake
+        .optional()
+        .describe(
+          "Remove only this user's reaction for the given emoji. Requires emoji to be set.",
+        ),
     }),
     handle: async ({ channel_id, message_id, emoji, user_id }) => {
       const channel = await getTextChannel(channel_id);
       const msg = await channel.messages.fetch(message_id);
       if (!emoji) {
         await msg.reactions.removeAll();
-        return { content: [{ type: "text", text: `✅ All reactions removed from message ${msg.id}.` }] };
+        return {
+          content: [{ type: "text", text: `✅ All reactions removed from message ${msg.id}.` }],
+        };
       }
       const reaction = findReaction(msg, emoji);
-      if (!reaction) throw new Error(`No reaction found for emoji "${emoji}" on message ${msg.id}.`);
+      if (!reaction)
+        throw new Error(`No reaction found for emoji "${emoji}" on message ${msg.id}.`);
       if (user_id) {
         await reaction.users.remove(user_id);
-        return { content: [{ type: "text", text: `✅ Removed ${emoji} reaction from user ${user_id} on message ${msg.id}.` }] };
+        return {
+          content: [
+            {
+              type: "text",
+              text: `✅ Removed ${emoji} reaction from user ${user_id} on message ${msg.id}.`,
+            },
+          ],
+        };
       }
       await reaction.remove();
-      return { content: [{ type: "text", text: `✅ All ${emoji} reactions removed from message ${msg.id}.` }] };
+      return {
+        content: [
+          { type: "text", text: `✅ All ${emoji} reactions removed from message ${msg.id}.` },
+        ],
+      };
     },
   }),
   defineTool({
@@ -339,25 +565,36 @@ const tools = [
       "List the users who reacted to a message with a specific emoji. Returns { reactions: [...] } with id, username, bot flag. Read-only.",
     annotations: { title: "Get reactions", readOnlyHint: true, openWorldHint: true },
     schema: z.object({
-      channel_id: channelId.describe("ID (snowflake) of the channel or thread containing the message."),
+      channel_id: channelId.describe(
+        "ID (snowflake) of the channel or thread containing the message.",
+      ),
       message_id: messageId.describe("ID of the message to inspect."),
       emoji: z.string().describe("Unicode emoji or custom emoji 'name:id' to list reactors for."),
-      limit: intIn(1, MAX_FETCH_LIMIT).default(DEFAULTS.LIMIT).describe("Max users to return (1–100). Default 25."),
+      limit: intIn(1, MAX_FETCH_LIMIT)
+        .default(DEFAULTS.LIMIT)
+        .describe("Max users to return (1–100). Default 25."),
     }),
     outputSchema: z.object({
-      reactions: z.array(z.object({
-        id: z.string(),
-        username: z.string(),
-        bot: z.boolean(),
-      })),
+      reactions: z.array(
+        z.object({
+          id: z.string(),
+          username: z.string(),
+          bot: z.boolean(),
+        }),
+      ),
     }),
     handle: async ({ channel_id, message_id, emoji, limit }) => {
       const channel = await getTextChannel(channel_id);
       const msg = await channel.messages.fetch(message_id);
       const reaction = findReaction(msg, emoji);
-      if (!reaction) throw new Error(`No reaction found for emoji "${emoji}" on message ${msg.id}.`);
+      if (!reaction)
+        throw new Error(`No reaction found for emoji "${emoji}" on message ${msg.id}.`);
       const users = await reaction.users.fetch({ limit });
-      const result = [...users.values()].map((u) => ({ id: u.id, username: u.username, bot: u.bot }));
+      const result = [...users.values()].map((u) => ({
+        id: u.id,
+        username: u.username,
+        bot: u.bot,
+      }));
       return structured({ reactions: result });
     },
   }),
@@ -376,8 +613,11 @@ const tools = [
       const channel = await getTextChannel(channel_id);
       const pinned = await channel.messages.fetchPins();
       const result = pinned.items.map(({ message: m, pinnedAt }) => ({
-        id: m.id, author: m.author.tag, content: m.content,
-        timestamp: m.createdAt.toISOString(), pinnedAt: pinnedAt.toISOString(),
+        id: m.id,
+        author: m.author.tag,
+        content: m.content,
+        timestamp: m.createdAt.toISOString(),
+        pinnedAt: pinnedAt.toISOString(),
       }));
       return structured({ messages: result });
     },
@@ -386,9 +626,17 @@ const tools = [
     name: "discord_forward_message",
     description:
       "Forward an existing message to another channel using Discord's native forward, which preserves the original attribution. Works across text channels and threads. Use discord_send_message to compose new content instead. Requires the Send Messages permission in the target channel. Returns a confirmation.",
-    annotations: { title: "Forward message", readOnlyHint: false, destructiveHint: false, idempotentHint: false, openWorldHint: true },
+    annotations: {
+      title: "Forward message",
+      readOnlyHint: false,
+      destructiveHint: false,
+      idempotentHint: false,
+      openWorldHint: true,
+    },
     schema: z.object({
-      channel_id: channelId.describe("ID (snowflake) of the channel or thread containing the source message."),
+      channel_id: channelId.describe(
+        "ID (snowflake) of the channel or thread containing the source message.",
+      ),
       message_id: messageId.describe("ID of the message to forward."),
       target_channel_id: snowflake.describe("ID (snowflake) of the destination channel or thread."),
     }),
@@ -398,8 +646,14 @@ const tools = [
       const targetChannel = await getTextChannel(target_channel_id);
       // ThreadChannel<boolean> is the abstract base for PublicThreadChannel / PrivateThreadChannel;
       // any runtime instance is one of them, but the type narrowing can't be expressed without a cast.
-      await msg.forward(targetChannel as TextChannel | PublicThreadChannel<boolean> | PrivateThreadChannel);
-      return { content: [{ type: "text", text: `✅ Message ${msg.id} forwarded to #${targetChannel.name}.` }] };
+      await msg.forward(
+        targetChannel as TextChannel | PublicThreadChannel<boolean> | PrivateThreadChannel,
+      );
+      return {
+        content: [
+          { type: "text", text: `✅ Message ${msg.id} forwarded to #${targetChannel.name}.` },
+        ],
+      };
     },
   }),
 ];

--- a/src/tools/permissions.ts
+++ b/src/tools/permissions.ts
@@ -1,17 +1,7 @@
 import { PermissionOverwriteOptions, GuildChannel } from "discord.js";
 import { z } from "zod";
-import { discord, getGuildChannel, serializePermissions } from "../client.js";
+import { discord, getGuildChannel, serializePermissions, parsePermissionNames } from "../client.js";
 import { defineTool, defineModule, snowflake, guildId, structured } from "./define.js";
-
-/**
- * Parses a permission array from tool arguments.
- * Accepts an array directly or a JSON-encoded string.
- */
-function parsePermArray(value: string[] | string | undefined): string[] {
-  if (Array.isArray(value)) return value;
-  if (typeof value === "string") return JSON.parse(value);
-  return [];
-}
 
 /** Flag names as an array, or a JSON-encoded array string (some clients serialize arrays). */
 const permFlags = z.union([z.array(z.string()), z.string()]).optional();
@@ -58,77 +48,145 @@ const tools = [
     name: "discord_set_role_permission",
     description:
       "Add or update a per-channel permission overwrite for a role, allowing and/or denying specific permissions. Merges with the role's existing overwrite (does not reset it). Requires the Manage Roles permission. Use discord_set_member_permission to target a single member instead.",
-    annotations: { title: "Set role channel permission", readOnlyHint: false, destructiveHint: false, idempotentHint: true, openWorldHint: true },
+    annotations: {
+      title: "Set role channel permission",
+      readOnlyHint: false,
+      destructiveHint: false,
+      idempotentHint: true,
+      openWorldHint: true,
+    },
     schema: z.object({
       channel_id: snowflake.describe("ID (snowflake) of the channel to set the overwrite on."),
       role_id: snowflake.describe("ID (snowflake) of the role to grant/deny permissions for."),
-      allow: permFlags.describe("Permission flag names to allow, e.g. ['SendMessages','ViewChannel'] (or the same array JSON-encoded as a string). Uses Discord PermissionsBitField flag names."),
-      deny: permFlags.describe("Permission flag names to deny, e.g. ['SendMessages'] (or the same array JSON-encoded as a string)."),
+      allow: permFlags.describe(
+        "Permission flag names to allow, e.g. ['SendMessages','ViewChannel'] (or the same array JSON-encoded as a string). Uses Discord PermissionsBitField flag names.",
+      ),
+      deny: permFlags.describe(
+        "Permission flag names to deny, e.g. ['SendMessages'] (or the same array JSON-encoded as a string).",
+      ),
       reason: z.string().optional().describe("Optional reason recorded in the server audit log."),
     }),
     handle: async ({ channel_id, role_id, allow, deny, reason }) => {
       const channel = await getGuildChannel(channel_id);
       const options: PermissionOverwriteOptions = {};
-      parsePermArray(allow).forEach((p) => { (options as Record<string, boolean>)[p] = true; });
-      parsePermArray(deny).forEach((p) => { (options as Record<string, boolean>)[p] = false; });
+      parsePermissionNames(allow).forEach((p) => {
+        (options as Record<string, boolean>)[p] = true;
+      });
+      parsePermissionNames(deny).forEach((p) => {
+        (options as Record<string, boolean>)[p] = false;
+      });
       await channel.permissionOverwrites.edit(role_id, options, { reason });
-      return { content: [{ type: "text", text: `✅ Permissions updated for role ${role_id} on #${channel.name}.` }] };
+      return {
+        content: [
+          { type: "text", text: `✅ Permissions updated for role ${role_id} on #${channel.name}.` },
+        ],
+      };
     },
   }),
   defineTool({
     name: "discord_set_member_permission",
     description:
       "Add or update a per-channel permission overwrite for a single member, allowing and/or denying specific permissions. Merges with the member's existing overwrite. Requires the Manage Roles permission. Use discord_set_role_permission to target a whole role instead.",
-    annotations: { title: "Set member channel permission", readOnlyHint: false, destructiveHint: false, idempotentHint: true, openWorldHint: true },
+    annotations: {
+      title: "Set member channel permission",
+      readOnlyHint: false,
+      destructiveHint: false,
+      idempotentHint: true,
+      openWorldHint: true,
+    },
     schema: z.object({
       channel_id: snowflake.describe("ID (snowflake) of the channel to set the overwrite on."),
       user_id: snowflake.describe("ID (snowflake) of the member to grant/deny permissions for."),
-      allow: permFlags.describe("Permission flag names to allow, e.g. ['ViewChannel'] (or the same array JSON-encoded as a string). Uses Discord PermissionsBitField flag names."),
-      deny: permFlags.describe("Permission flag names to deny (array, or JSON-encoded array string)."),
+      allow: permFlags.describe(
+        "Permission flag names to allow, e.g. ['ViewChannel'] (or the same array JSON-encoded as a string). Uses Discord PermissionsBitField flag names.",
+      ),
+      deny: permFlags.describe(
+        "Permission flag names to deny (array, or JSON-encoded array string).",
+      ),
       reason: z.string().optional().describe("Optional reason recorded in the server audit log."),
     }),
     handle: async ({ channel_id, user_id, allow, deny, reason }) => {
       const channel = await getGuildChannel(channel_id);
       const options: PermissionOverwriteOptions = {};
-      parsePermArray(allow).forEach((p) => { (options as Record<string, boolean>)[p] = true; });
-      parsePermArray(deny).forEach((p) => { (options as Record<string, boolean>)[p] = false; });
+      parsePermissionNames(allow).forEach((p) => {
+        (options as Record<string, boolean>)[p] = true;
+      });
+      parsePermissionNames(deny).forEach((p) => {
+        (options as Record<string, boolean>)[p] = false;
+      });
       await channel.permissionOverwrites.edit(user_id, options, { reason });
-      return { content: [{ type: "text", text: `✅ Permissions updated for member ${user_id} on #${channel.name}.` }] };
+      return {
+        content: [
+          {
+            type: "text",
+            text: `✅ Permissions updated for member ${user_id} on #${channel.name}.`,
+          },
+        ],
+      };
     },
   }),
   defineTool({
     name: "discord_reset_channel_permissions",
     description:
       "Remove ALL permission overwrites on a channel, so only role/server-level permissions apply. Does NOT re-sync with the category — use discord_lock_channel_permissions for that. IRREVERSIBLE — the cleared overwrites cannot be recovered. Requires the Manage Roles permission.",
-    annotations: { title: "Reset channel permissions", readOnlyHint: false, destructiveHint: true, idempotentHint: true, openWorldHint: true },
+    annotations: {
+      title: "Reset channel permissions",
+      readOnlyHint: false,
+      destructiveHint: true,
+      idempotentHint: true,
+      openWorldHint: true,
+    },
     schema: z.object({
-      channel_id: snowflake.describe("ID (snowflake) of the channel whose overwrites will be cleared."),
+      channel_id: snowflake.describe(
+        "ID (snowflake) of the channel whose overwrites will be cleared.",
+      ),
       reason: z.string().optional().describe("Optional reason recorded in the server audit log."),
     }),
     handle: async ({ channel_id, reason }) => {
       const channel = await getGuildChannel(channel_id);
       await channel.permissionOverwrites.set([], reason);
-      return { content: [{ type: "text", text: `✅ All permission overwrites cleared on #${channel.name}.` }] };
+      return {
+        content: [
+          { type: "text", text: `✅ All permission overwrites cleared on #${channel.name}.` },
+        ],
+      };
     },
   }),
   defineTool({
     name: "discord_copy_permissions",
     description:
       "Replace the target channel's permission overwrites with a copy of the source channel's. The target's existing overwrites are overwritten. Requires the Manage Roles permission. Returns a confirmation.",
-    annotations: { title: "Copy channel permissions", readOnlyHint: false, destructiveHint: true, idempotentHint: true, openWorldHint: true },
+    annotations: {
+      title: "Copy channel permissions",
+      readOnlyHint: false,
+      destructiveHint: true,
+      idempotentHint: true,
+      openWorldHint: true,
+    },
     schema: z.object({
-      source_channel_id: snowflake.describe("ID (snowflake) of the channel to copy overwrites from."),
-      target_channel_id: snowflake.describe("ID (snowflake) of the channel whose overwrites will be replaced."),
+      source_channel_id: snowflake.describe(
+        "ID (snowflake) of the channel to copy overwrites from.",
+      ),
+      target_channel_id: snowflake.describe(
+        "ID (snowflake) of the channel whose overwrites will be replaced.",
+      ),
       reason: z.string().optional().describe("Optional reason recorded in the server audit log."),
     }),
     handle: async ({ source_channel_id, target_channel_id, reason }) => {
       const source = await getGuildChannel(source_channel_id);
       const target = await getGuildChannel(target_channel_id);
       const overwrites = source.permissionOverwrites.cache.map((ow) => ({
-        id: ow.id, type: ow.type, allow: ow.allow, deny: ow.deny,
+        id: ow.id,
+        type: ow.type,
+        allow: ow.allow,
+        deny: ow.deny,
       }));
       await target.permissionOverwrites.set(overwrites, reason);
-      return { content: [{ type: "text", text: `✅ Permissions copied from #${source.name} to #${target.name}.` }] };
+      return {
+        content: [
+          { type: "text", text: `✅ Permissions copied from #${source.name} to #${target.name}.` },
+        ],
+      };
     },
   }),
   defineTool({
@@ -140,11 +198,13 @@ const tools = [
       guild_id: guildId,
     }),
     outputSchema: z.object({
-      channels: z.array(z.object({
-        channel: z.string(),
-        channelId: z.string(),
-        overwrites: z.array(auditOverwriteSummary),
-      })),
+      channels: z.array(
+        z.object({
+          channel: z.string(),
+          channelId: z.string(),
+          overwrites: z.array(auditOverwriteSummary),
+        }),
+      ),
     }),
     handle: async ({ guild_id }) => {
       const guild = await discord.guilds.fetch(guild_id);
@@ -158,7 +218,9 @@ const tools = [
           });
         }
       });
-      await Promise.all([...memberIdsNeeded].map((id) => guild.members.fetch(id).catch(() => null)));
+      await Promise.all(
+        [...memberIdsNeeded].map((id) => guild.members.fetch(id).catch(() => null)),
+      );
       const report: Record<string, unknown>[] = [];
       guild.channels.cache
         .filter((c) => c instanceof GuildChannel)
@@ -167,11 +229,17 @@ const tools = [
           const overwrites = gch.permissionOverwrites.cache.map((ow) => {
             const isRole = ow.type === 0;
             const entity = isRole
-              ? guild.roles.cache.get(ow.id)?.name ?? ow.id
-              : guild.members.cache.get(ow.id)?.user.tag ?? ow.id;
-            return { entity, type: isRole ? "role" : "member", allow: serializePermissions(ow.allow), deny: serializePermissions(ow.deny) };
+              ? (guild.roles.cache.get(ow.id)?.name ?? ow.id)
+              : (guild.members.cache.get(ow.id)?.user.tag ?? ow.id);
+            return {
+              entity,
+              type: isRole ? "role" : "member",
+              allow: serializePermissions(ow.allow),
+              deny: serializePermissions(ow.deny),
+            };
           });
-          if (overwrites.length > 0) report.push({ channel: gch.name, channelId: gch.id, overwrites });
+          if (overwrites.length > 0)
+            report.push({ channel: gch.name, channelId: gch.id, overwrites });
         });
       return structured({ channels: report });
     },

--- a/src/tools/roles.ts
+++ b/src/tools/roles.ts
@@ -1,6 +1,11 @@
 import { ColorResolvable, Role, Guild } from "discord.js";
 import { z } from "zod";
-import { discord, serializePermissions, deserializePermissions } from "../client.js";
+import {
+  discord,
+  serializePermissions,
+  deserializePermissions,
+  parsePermissionNames,
+} from "../client.js";
 import { defineTool, defineModule, snowflake, guildId, structured, httpUrl } from "./define.js";
 
 const roleId = snowflake.describe("ID (snowflake) of the role to edit.");
@@ -26,12 +31,6 @@ const roleMember = z.object({
  * Parses a permission array from tool arguments.
  * Accepts an array, a JSON string, or returns undefined if absent.
  */
-function parsePerms(raw: string[] | string | undefined): string[] | undefined {
-  if (Array.isArray(raw)) return raw;
-  if (typeof raw === "string") return JSON.parse(raw);
-  return undefined;
-}
-
 /** Fetches a role by ID, throwing a clear error if it does not exist in the guild. */
 async function fetchRole(guild: Guild, rawId: string): Promise<Role> {
   const role = await guild.roles.fetch(rawId);
@@ -102,13 +101,13 @@ const tools = [
     }),
     handle: async ({ guild_id, name, color, hoist, mentionable, permissions }) => {
       const guild = await discord.guilds.fetch(guild_id);
-      const perms = parsePerms(permissions);
+      const perms = permissions === undefined ? undefined : parsePermissionNames(permissions);
       const role = await guild.roles.create({
         name,
         color: color as ColorResolvable | undefined,
         hoist,
         mentionable,
-        permissions: perms ? deserializePermissions(perms) : undefined,
+        permissions: perms !== undefined ? deserializePermissions(perms) : undefined,
       });
       return {
         content: [{ type: "text", text: `✅ Role "${role.name}" created (id: ${role.id}).` }],
@@ -150,13 +149,13 @@ const tools = [
     handle: async ({ guild_id, role_id, name, color, hoist, mentionable, permissions }) => {
       const guild = await discord.guilds.fetch(guild_id);
       const role = await fetchRole(guild, role_id);
-      const perms = parsePerms(permissions);
+      const perms = permissions === undefined ? undefined : parsePermissionNames(permissions);
       await role.edit({
         name,
         color: color as ColorResolvable | undefined,
         hoist,
         mentionable,
-        permissions: perms ? deserializePermissions(perms) : undefined,
+        permissions: perms !== undefined ? deserializePermissions(perms) : undefined,
       });
       return { content: [{ type: "text", text: `✅ Role "${role.name}" updated.` }] };
     },
@@ -301,6 +300,11 @@ const tools = [
     handle: async ({ guild_id, role_id, position }) => {
       const guild = await discord.guilds.fetch(guild_id);
       const role = await fetchRole(guild, role_id);
+      const maxPosition = guild.roles.cache.size - 1;
+      if (position > maxPosition)
+        throw new Error(
+          `position ${position} is out of range — this server's highest role position is ${maxPosition}.`,
+        );
       await role.setPosition(position);
       return {
         content: [{ type: "text", text: `✅ Role "${role.name}" moved to position ${position}.` }],
@@ -318,20 +322,25 @@ const tools = [
       idempotentHint: true,
       openWorldHint: true,
     },
-    schema: z.object({
-      guild_id: guildId,
-      role_id: snowflake.describe("ID (snowflake) of the role to set the icon on."),
-      icon: z
-        .union([httpUrl, z.literal("null")])
-        .nullable()
-        .optional()
-        .describe("Image URL for the role icon, or null to remove it."),
-      unicode_emoji: z
-        .string()
-        .nullable()
-        .optional()
-        .describe("Unicode emoji to use as the role icon, or null to remove it."),
-    }),
+    schema: z
+      .object({
+        guild_id: guildId,
+        role_id: snowflake.describe("ID (snowflake) of the role to set the icon on."),
+        icon: z
+          .union([httpUrl, z.literal("null")])
+          .nullable()
+          .optional()
+          .describe("Image URL for the role icon, or null to remove it."),
+        unicode_emoji: z
+          .string()
+          .nullable()
+          .optional()
+          .describe("Unicode emoji to use as the role icon, or null to remove it."),
+      })
+      .refine(
+        (a) => a.icon !== undefined || a.unicode_emoji !== undefined,
+        "Provide icon or unicode_emoji.",
+      ),
     handle: async ({ guild_id, role_id, icon, unicode_emoji }) => {
       const guild = await discord.guilds.fetch(guild_id);
       const role = await fetchRole(guild, role_id);

--- a/src/tools/scheduledEvents.ts
+++ b/src/tools/scheduledEvents.ts
@@ -179,10 +179,6 @@ const tools = [
       const guild = await discord.guilds.fetch(guild_id);
 
       const entityType = ENTITY_TYPE_MAP[entity_type];
-      if (!entityType)
-        throw new Error(
-          `Invalid entity_type: "${entity_type}". Must be VOICE, STAGE_INSTANCE, or EXTERNAL.`,
-        );
 
       if (
         (entityType === GuildScheduledEventEntityType.Voice ||
@@ -393,6 +389,10 @@ const tools = [
       if (event.entityType === GuildScheduledEventEntityType.External && !channel_id)
         throw new Error(
           "channel_id is required for EXTERNAL events (they have no channel of their own).",
+        );
+      if (event.entityType !== GuildScheduledEventEntityType.External && channel_id)
+        throw new Error(
+          "channel_id is only honored for EXTERNAL events — VOICE/STAGE invites always point at the event's own channel; omit channel_id.",
         );
       const url = await event.createInviteURL({
         channel: channel_id,

--- a/src/tools/webhooks.ts
+++ b/src/tools/webhooks.ts
@@ -1,7 +1,7 @@
 import { WebhookClient } from "discord.js";
 import { z } from "zod";
 import { discord, fetchChannelChecked, assertAllowedGuild, allowListActive } from "../client.js";
-import { buildEmbed, embedObjectSchema } from "../embeds.js";
+import { buildEmbed, embedArraySchema } from "../embeds.js";
 import { defineTool, defineModule, snowflake, guildId, httpUrl, structured } from "./define.js";
 
 const webhookId = snowflake.describe("ID (snowflake) of the webhook.");
@@ -79,8 +79,7 @@ const tools = [
       avatar_url: httpUrl
         .optional()
         .describe("Override the webhook's default avatar for this message."),
-      embeds: z
-        .array(embedObjectSchema)
+      embeds: embedArraySchema
         .optional()
         .describe("Up to 10 embed objects to attach to the webhook message."),
     }),
@@ -94,11 +93,7 @@ const tools = [
         if (content) sendOptions.content = content;
         if (username) sendOptions.username = username;
         if (avatar_url) sendOptions.avatarURL = avatar_url;
-        if (embeds) {
-          if (embeds.length > 10)
-            throw new Error("Discord allows a maximum of 10 embeds per message.");
-          sendOptions.embeds = embeds.map((e) => buildEmbed(e));
-        }
+        if (embeds) sendOptions.embeds = embeds.map((e) => buildEmbed(e));
         if (!sendOptions.content && !sendOptions.embeds) {
           throw new Error("At least one of content or embeds is required.");
         }
@@ -240,8 +235,7 @@ const tools = [
         .string()
         .optional()
         .describe("New plain-text content for the message (max 2000 characters)."),
-      embeds: z
-        .array(embedObjectSchema)
+      embeds: embedArraySchema
         .optional()
         .describe("Up to 10 embed objects to attach to the webhook message."),
     }),

--- a/test/allowlist.test.ts
+++ b/test/allowlist.test.ts
@@ -1,0 +1,53 @@
+import { test, mock, afterEach } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync, readdirSync } from "node:fs";
+import { join } from "node:path";
+import { discord, fetchChannelChecked } from "../src/client.js";
+import webhooks from "../src/tools/webhooks.js";
+
+const ALLOWED = "111111111111111111";
+const FOREIGN = "222222222222222222";
+
+afterEach(() => {
+  mock.restoreAll();
+  delete process.env.DISCORD_ALLOWED_GUILDS;
+});
+
+test("fetchChannelChecked rejects a channel whose guild is outside the allow-list", async () => {
+  process.env.DISCORD_ALLOWED_GUILDS = ALLOWED;
+  mock.method(discord.channels, "fetch", async () => ({ guildId: FOREIGN }) as never);
+  await assert.rejects(() => fetchChannelChecked("333333333333333333"), /allow-list/);
+});
+
+test("fetchChannelChecked passes an allowed channel and guild-less objects through", async () => {
+  process.env.DISCORD_ALLOWED_GUILDS = ALLOWED;
+  mock.method(discord.channels, "fetch", async () => ({ guildId: ALLOWED }) as never);
+  assert.ok(await fetchChannelChecked("333333333333333333"));
+  mock.method(discord.channels, "fetch", async () => ({}) as never);
+  assert.ok(await fetchChannelChecked("333333333333333333"));
+});
+
+test("token-webhook flows are gated when the allow-list is active", async () => {
+  process.env.DISCORD_ALLOWED_GUILDS = ALLOWED;
+  mock.method(discord, "fetchWebhook", async () => ({ guildId: FOREIGN }) as never);
+  await assert.rejects(
+    () =>
+      webhooks.handlers.get("discord_send_webhook_message")!({
+        webhook_id: "333333333333333333",
+        webhook_token: "tok",
+        content: "x",
+      }),
+    /allow-list/,
+  );
+});
+
+test("no tool module bypasses the checked channel fetch", () => {
+  const dir = join(__dirname, "..", "src", "tools");
+  for (const file of readdirSync(dir).filter((f) => f.endsWith(".ts"))) {
+    const src = readFileSync(join(dir, file), "utf-8");
+    assert.ok(
+      !/discord\.channels\.fetch/.test(src),
+      `${file} calls discord.channels.fetch directly — use fetchChannelChecked/getTextChannel/getGuildChannel`,
+    );
+  }
+});

--- a/test/bug-classes.test.ts
+++ b/test/bug-classes.test.ts
@@ -1,0 +1,77 @@
+import { test, mock, afterEach } from "node:test";
+import assert from "node:assert/strict";
+import { ChannelType } from "discord.js";
+import { discord } from "../src/client.js";
+import { parsePermissionNames } from "../src/client.js";
+import messages from "../src/tools/messages.js";
+import scheduledEvents from "../src/tools/scheduledEvents.js";
+
+const CHANNEL = "111111111111111111";
+const MESSAGE = "222222222222222222";
+
+afterEach(() => mock.restoreAll());
+
+test("crosspost rejects non-announcement channels with an actionable error", async () => {
+  mock.method(
+    discord.channels,
+    "fetch",
+    async () => ({ type: ChannelType.GuildText, guildId: CHANNEL }) as never,
+  );
+  await assert.rejects(
+    () =>
+      messages.handlers.get("discord_crosspost_message")!({
+        channel_id: CHANNEL,
+        message_id: MESSAGE,
+      }),
+    /announcement channel/,
+  );
+});
+
+test("delete_message sends the audit-log reason through the raw REST route", async () => {
+  const fakeChannel = {
+    id: CHANNEL,
+    isDMBased: () => false,
+    isTextBased: () => true,
+    messages: { fetch: async () => ({}) },
+  };
+  mock.method(discord.channels, "fetch", async () => fakeChannel as never);
+  const restCalls: unknown[][] = [];
+  mock.method(discord.rest, "delete", (async (...args: unknown[]) => {
+    restCalls.push(args);
+    return {};
+  }) as never);
+  await messages.handlers.get("discord_delete_message")!({
+    channel_id: CHANNEL,
+    message_id: MESSAGE,
+    reason: "spam cleanup",
+  });
+  assert.equal(restCalls.length, 1);
+  assert.deepEqual(restCalls[0][1], { reason: "spam cleanup" });
+});
+
+test("scheduled events reject non-ISO datetimes before any API call", async () => {
+  await assert.rejects(
+    () =>
+      scheduledEvents.handlers.get("discord_create_scheduled_event")!({
+        guild_id: CHANNEL,
+        name: "x",
+        entity_type: "EXTERNAL",
+        location: "here",
+        scheduled_start_time: "tomorrow",
+        scheduled_end_time: "2030-01-01T10:00:00Z",
+      }),
+    /scheduled_start_time/,
+  );
+});
+
+test("parsePermissionNames validates shape and flag names with the culprit named", () => {
+  assert.deepEqual(parsePermissionNames(["SendMessages"]), ["SendMessages"]);
+  assert.deepEqual(parsePermissionNames('["SendMessages","ViewChannel"]'), [
+    "SendMessages",
+    "ViewChannel",
+  ]);
+  assert.deepEqual(parsePermissionNames(undefined), []);
+  assert.throws(() => parsePermissionNames("SendMessages"), /not a JSON array/);
+  assert.throws(() => parsePermissionNames('"SendMessages"'), /array of permission flag names/);
+  assert.throws(() => parsePermissionNames(["NotARealFlag"]), /NotARealFlag/);
+});

--- a/test/define.test.ts
+++ b/test/define.test.ts
@@ -28,7 +28,7 @@ test("field descriptions propagate from .describe() into the inputSchema", () =>
   const send = messages.definitions.find((d) => d.name === "discord_send_message");
   const props = (send!.inputSchema as { properties: Record<string, { description?: string }> })
     .properties;
-  assert.match(props.content.description ?? "", /Plain-text body/);
+  assert.ok((props.content.description ?? "").length > 0, "field description must propagate");
 });
 
 test("handle rejects invalid args before reaching the Discord API", async () => {

--- a/test/helpers.test.ts
+++ b/test/helpers.test.ts
@@ -1,11 +1,7 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
 import { PermissionsBitField } from "discord.js";
-import {
-  validateId,
-  serializePermissions,
-  deserializePermissions,
-} from "../src/client.js";
+import { validateId, serializePermissions, deserializePermissions } from "../src/client.js";
 
 test("validateId accepts a valid snowflake", () => {
   assert.equal(validateId("123456789012345678", "id"), "123456789012345678");

--- a/test/mass-op-safety.test.ts
+++ b/test/mass-op-safety.test.ts
@@ -1,0 +1,73 @@
+import { test, mock, afterEach } from "node:test";
+import assert from "node:assert/strict";
+import { discord } from "../src/client.js";
+import messages from "../src/tools/messages.js";
+import channels from "../src/tools/channels.js";
+import members from "../src/tools/members.js";
+
+const GUILD = "111111111111111111";
+const USER = "222222222222222222";
+
+afterEach(() => mock.restoreAll());
+
+function def(mod: { definitions: { name: string }[] }, name: string) {
+  const d = mod.definitions.find((t) => t.name === name) as unknown as {
+    inputSchema: { properties: Record<string, Record<string, unknown>>; required?: string[] };
+  };
+  assert.ok(d, `${name} not found`);
+  return d;
+}
+
+test("destructive mass-op tools advertise dry_run default:true and keep it optional", () => {
+  for (const [mod, name] of [
+    [messages, "discord_bulk_delete_messages"],
+    [channels, "discord_delete_channel"],
+    [members, "discord_bulk_ban"],
+    [members, "discord_prune_members"],
+  ] as const) {
+    const d = def(mod, name);
+    assert.equal(d.inputSchema.properties.dry_run.default, true, `${name} dry_run default`);
+    assert.ok(!d.inputSchema.required?.includes("dry_run"), `${name} dry_run must stay optional`);
+  }
+});
+
+test("bulk_ban advertises and enforces the 200-ID Discord cap", async () => {
+  const d = def(members, "discord_bulk_ban");
+  const userIds = d.inputSchema.properties.user_ids;
+  assert.equal(userIds.maxItems, 200);
+  assert.equal(userIds.minItems, 1);
+  await assert.rejects(
+    () =>
+      members.handlers.get("discord_bulk_ban")!({
+        guild_id: GUILD,
+        user_ids: Array.from({ length: 201 }, () => USER),
+      }),
+    /200/,
+  );
+});
+
+test("set_nickname requires the nickname field — omission no longer silently clears", async () => {
+  const d = def(members, "discord_set_nickname");
+  assert.ok(d.inputSchema.required?.includes("nickname"));
+  await assert.rejects(
+    () => members.handlers.get("discord_set_nickname")!({ guild_id: GUILD, user_id: USER }),
+    /nickname/,
+  );
+});
+
+test("set_nickname treats null and the string 'null' as an explicit clear", async () => {
+  const calls: unknown[] = [];
+  const fakeMember = {
+    user: { tag: "user#0" },
+    setNickname: async (nick: unknown) => void calls.push(nick),
+  };
+  mock.method(
+    discord.guilds,
+    "fetch",
+    async () => ({ members: { fetch: async () => fakeMember } }) as never,
+  );
+  const handler = members.handlers.get("discord_set_nickname")!;
+  await handler({ guild_id: GUILD, user_id: USER, nickname: null });
+  await handler({ guild_id: GUILD, user_id: USER, nickname: "null" });
+  assert.deepEqual(calls, [null, null]);
+});

--- a/test/registry.test.ts
+++ b/test/registry.test.ts
@@ -11,10 +11,15 @@ test("selectModules exposes everything when unset or `all`", () => {
   delete process.env.DISCORD_MCP_TOOLSETS;
 });
 
-test("selectModules picks listed toolsets, case-insensitive", () => {
+test("selectModules picks exactly the listed toolsets, case-insensitive", () => {
   process.env.DISCORD_MCP_TOOLSETS = "Discovery, MESSAGES";
   try {
-    assert.equal(selectModules().length, 2);
+    const selected = selectModules();
+    assert.equal(selected.length, 2);
+    const names = selected.flatMap((m) => m.definitions.map((d) => d.name));
+    assert.ok(names.includes("discord_list_guilds"), "discovery toolset selected");
+    assert.ok(names.includes("discord_read_messages"), "messages toolset selected");
+    assert.ok(!names.includes("discord_ban_member"), "destructive member tools must be gated off");
   } finally {
     delete process.env.DISCORD_MCP_TOOLSETS;
   }

--- a/test/server.test.ts
+++ b/test/server.test.ts
@@ -1,0 +1,58 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
+import { McpError, ErrorCode } from "@modelcontextprotocol/sdk/types.js";
+import { ZodError, z } from "zod";
+import { DiscordAPIError } from "discord.js";
+import { createServer } from "../src/server.js";
+import { formatToolError } from "../src/errors.js";
+
+async function connectedClient() {
+  const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+  const server = createServer("0.0.0-test");
+  const client = new Client({ name: "test", version: "0.0.0" });
+  await Promise.all([server.connect(serverTransport), client.connect(clientTransport)]);
+  return client;
+}
+
+test("unknown tool is a JSON-RPC InvalidParams protocol error, not a tool result", async () => {
+  const client = await connectedClient();
+  await assert.rejects(
+    () => client.callTool({ name: "discord_nonexistent", arguments: {} }),
+    (err: unknown) => err instanceof McpError && err.code === ErrorCode.InvalidParams,
+  );
+  await client.close();
+});
+
+test("tools/list serves every definition and rejects unexpected cursors", async () => {
+  const client = await connectedClient();
+  const { tools } = await client.listTools();
+  assert.ok(tools.length >= 95);
+  await assert.rejects(
+    () => client.listTools({ cursor: "bogus" }),
+    (err: unknown) => err instanceof McpError && err.code === ErrorCode.InvalidParams,
+  );
+  await client.close();
+});
+
+test("formatToolError flattens ZodError paths and surfaces Discord hints", () => {
+  const zerr = z.object({ channel_id: z.string() }).safeParse({ channel_id: 1 });
+  assert.ok(!zerr.success);
+  const msg = formatToolError(zerr.error as ZodError);
+  assert.match(msg, /^Invalid arguments — channel_id: /);
+
+  const derr = new DiscordAPIError(
+    { code: 50013, message: "Missing Permissions" },
+    50013,
+    403,
+    "DELETE",
+    "https://discord.com/api/v10/x",
+    {},
+  );
+  const dmsg = formatToolError(derr);
+  assert.match(dmsg, /50013/);
+  assert.match(dmsg, /Missing permissions — the bot lacks/);
+
+  assert.equal(formatToolError(new Error("boom")), "boom");
+});


### PR DESCRIPTION
Fifth audit round (6 dimensions, adversarial web verification): 22 confirmed findings, all implemented except the Node-20 engines decision (left for the maintainer).

Highs:
- npm audit: 8 vulns (2 high incl. ws on the gateway hot path) → 0, lockfile-only
- release.yml: publish-docker now needs publish-npm (an image could ship even with failing tests/version mismatch) + least-privilege permissions
- Test debt: the suite would have caught 0 of today's 5 real bugs. 15 new tests across 4 suites now pin: central allow-list enforcement (fetchChannelChecked, webhook-token gate, grep invariant), mass-op safety contract (dry_run default:true advertised ×4, bulk_ban 200 cap, set_nickname required-nullable), the day's bug classes (crosspost channel type, REST delete reason, ISO datetime), and the MCP protocol via InMemoryTransport (unknown tool → McpError InvalidParams, cursor rejection) after extracting createServer()/errors.ts

Robustness/API:
- ensureConnected wedge on late READY fixed (isReady fast-path)
- getTextChannel widened to all message-capable guild channels — delete/pin/read now work in announcement channels (was inconsistent with crosspost)
- Shared validated parsePermissionNames (replaces two diverged JSON.parse copies; names the offending flag)
- get_invite allow-list assert; set_role_position upper-bound check; set_role_icon no-op guard; event-invite channel_id guard; embeds maxItems:10 shared schema; dead code removed
- bulk_ban description: Ban Members AND Manage Server
- Dockerfile pinned to node:24 LTS (was node:26 Current, untested by CI)

Chore: repo fully prettier-formatted, format:check enforced in CI, scratch files in .prettierignore.

36/36 tests.