### PR TITLE
chore!: drop Node 20 (EOL) — engines >=22

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [20, 22, 24]
+        node-version: [22, 24]
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-node@v6

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - `discord_set_nickname` now requires the `nickname` field (string or null) — omitting it used to silently clear the nickname; `discord_bulk_ban` caps `user_ids` at 200 (Discord API limit) and `discord_set_role_position` requires `position >= 1` (and rejects positions above the server's highest role instead of silently doing nothing)
 - `discord_set_role_icon` requires at least one of `icon`/`unicode_emoji` (both omitted used to report success without doing anything); `discord_create_event_invite` rejects `channel_id` on non-EXTERNAL events (it was silently ignored); embed arrays advertise and enforce `maxItems: 10`; invalid permission flag names are rejected with the culprit named instead of crashing with an opaque internal error
 - The `events` toolset is renamed `scheduled_events`
+- Node 20 support dropped (`engines: ">=22.0.0"`) — Node 20 reached end-of-life on 2026-04-30 and no longer receives security fixes
 
 ### Added
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 [![npm](https://img.shields.io/npm/v/@pasympa/discord-mcp)](https://www.npmjs.com/package/@pasympa/discord-mcp)
 [![License](https://img.shields.io/github/license/PaSympa/discord-mcp)](LICENSE)
-[![Node](https://img.shields.io/badge/node-%3E%3D20-green)](https://nodejs.org)
+[![Node](https://img.shields.io/badge/node-%3E%3D22-green)](https://nodejs.org)
 [![Discord.js](https://img.shields.io/badge/discord.js-v14-5865F2)](https://discord.js.org)
 [![MCP](https://img.shields.io/badge/MCP-compatible-purple)](https://modelcontextprotocol.io)
 

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "url": "https://github.com/PaSympa/discord-mcp/issues"
   },
   "engines": {
-    "node": ">=20.0.0"
+    "node": ">=22.0.0"
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.29.0",


### PR DESCRIPTION
Maintainer decision from the round-5 audit: Node 20 is EOL since 2026-04-30 (no more security fixes). engines bumped to >=22.0.0, CI matrix [22, 24], README badge updated, breaking-changes entry added to the 2.0.0 changelog section.