### PR TITLE
fix: audit round 6 — CI gap, behavioral tests, supply chain (19 findings)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: CI
 
 on:
   push:
-    branches: [main]
+    branches: [main, "release/**"]
   pull_request:
-    branches: [main]
+    branches: [main, "release/**"]
 
 permissions:
   contents: read

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,7 +9,8 @@ jobs:
   publish-npm:
     runs-on: ubuntu-latest
     permissions:
-      contents: write
+      contents: read
+      id-token: write
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-node@v6
@@ -29,7 +30,7 @@ jobs:
       - run: npm run lint
       - run: npm run build
       - run: npm test
-      - run: npm publish --access public
+      - run: npm publish --access public --provenance
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
@@ -41,9 +42,11 @@ jobs:
       contents: read
     steps:
       - uses: actions/checkout@v6
-      - name: Install mcp-publisher
+      - name: Install mcp-publisher (pinned + checksum-verified)
         run: |
-          curl -L "https://github.com/modelcontextprotocol/registry/releases/latest/download/mcp-publisher_$(uname -s | tr '[:upper:]' '[:lower:]')_$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/').tar.gz" | tar xz mcp-publisher
+          curl -fsSLo mcp-publisher.tar.gz "https://github.com/modelcontextprotocol/registry/releases/download/v1.7.9/mcp-publisher_linux_amd64.tar.gz"
+          echo "ab128162b0616090b47cf245afe0a23f3ef08936fdce19074f5ba0a4469281ac  mcp-publisher.tar.gz" | sha256sum -c -
+          tar xzf mcp-publisher.tar.gz mcp-publisher
       - name: Authenticate to MCP Registry
         run: ./mcp-publisher login github-oidc
       - name: Publish server to MCP Registry
@@ -59,6 +62,8 @@ jobs:
       - name: Extract version from tag
         id: version
         run: echo "VERSION=${GITHUB_REF#refs/tags/v}" >> $GITHUB_OUTPUT
+      - uses: docker/setup-qemu-action@v3
+      - uses: docker/setup-buildx-action@v3
       - uses: docker/login-action@v4
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
@@ -66,6 +71,7 @@ jobs:
       - uses: docker/build-push-action@v7
         with:
           push: true
+          platforms: linux/amd64,linux/arm64
           tags: |
             pasympa/discord-mcp:${{ steps.version.outputs.VERSION }}
             pasympa/discord-mcp:latest

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -3,7 +3,7 @@ import tseslint from "typescript-eslint";
 import prettier from "eslint-config-prettier";
 
 export default tseslint.config(
-  { ignores: ["dist/", "node_modules/"] },
+  { ignores: ["dist/", "node_modules/", "live-test*.mjs"] },
   js.configs.recommended,
   ...tseslint.configs.recommended,
   prettier,

--- a/src/client.ts
+++ b/src/client.ts
@@ -3,8 +3,6 @@ import {
   Client,
   Events,
   GatewayIntentBits,
-  TextChannel,
-  ThreadChannel,
   GuildChannel,
   PermissionsBitField,
   type GuildTextBasedChannel,

--- a/src/tools/discovery.ts
+++ b/src/tools/discovery.ts
@@ -1,6 +1,6 @@
 import { ChannelType, CategoryChannel, GuildChannel } from "discord.js";
 import { z } from "zod";
-import { discord } from "../client.js";
+import { discord, isGuildAllowed } from "../client.js";
 import { defineTool, defineModule, guildId, structured } from "./define.js";
 
 const guildSummary = z.object({
@@ -26,12 +26,14 @@ const tools = [
     schema: z.object({}),
     outputSchema: z.object({ guilds: z.array(guildSummary) }),
     handle: async () => {
-      const guilds = discord.guilds.cache.map((g) => ({
-        id: g.id,
-        name: g.name,
-        memberCount: g.memberCount,
-        icon: g.iconURL(),
-      }));
+      const guilds = discord.guilds.cache
+        .filter((g) => isGuildAllowed(g.id))
+        .map((g) => ({
+          id: g.id,
+          name: g.name,
+          memberCount: g.memberCount,
+          icon: g.iconURL(),
+        }));
       return structured({ guilds });
     },
   }),

--- a/src/tools/forums.ts
+++ b/src/tools/forums.ts
@@ -199,8 +199,8 @@ const tools = [
       limit: intIn(1, 100)
         .default(100)
         .describe("Max archived posts per page (1–100). Default 100."),
-      before: z
-        .string()
+      before: z.iso
+        .datetime({ offset: true })
         .optional()
         .describe(
           "Pagination cursor: an ISO timestamp. Pass the previous response's nextBefore to fetch older archived posts. When set, active posts are omitted.",

--- a/src/tools/messages.ts
+++ b/src/tools/messages.ts
@@ -6,11 +6,12 @@ import {
   Message,
   MessageReaction,
   Routes,
+  DiscordAPIError,
 } from "discord.js";
 import { z } from "zod";
 import { discord, getTextChannel, fetchChannelChecked } from "../client.js";
 import { MAX_FETCH_LIMIT, DEFAULTS, AUTO_ARCHIVE_DURATIONS } from "../constants.js";
-import { buildEmbed, embedFieldsShape, embedObjectSchema, embedArraySchema } from "../embeds.js";
+import { buildEmbed, embedFieldsShape, embedArraySchema } from "../embeds.js";
 import { defineModule, defineTool, snowflake, intIn, structured } from "./define.js";
 
 const channelId = snowflake.describe("ID (snowflake) of the channel or thread.");
@@ -489,7 +490,17 @@ const tools = [
           "Channel is not an announcement channel — only announcement-channel messages can be published.",
         );
       const msg = await channel.messages.fetch(message_id);
-      await msg.crosspost();
+      try {
+        await msg.crosspost();
+      } catch (err) {
+        // 40033 = already crossposted: treat as success so the tool is truly idempotent.
+        if (err instanceof DiscordAPIError && Number(err.code) === 40033) {
+          return {
+            content: [{ type: "text", text: `✅ Message ${message_id} was already published.` }],
+          };
+        }
+        throw err;
+      }
       return {
         content: [
           {

--- a/src/tools/roles.ts
+++ b/src/tools/roles.ts
@@ -27,10 +27,6 @@ const roleMember = z.object({
   nickname: z.string().nullable(),
 });
 
-/**
- * Parses a permission array from tool arguments.
- * Accepts an array, a JSON string, or returns undefined if absent.
- */
 /** Fetches a role by ID, throwing a clear error if it does not exist in the guild. */
 async function fetchRole(guild: Guild, rawId: string): Promise<Role> {
   const role = await guild.roles.fetch(rawId);

--- a/src/tools/scheduledEvents.ts
+++ b/src/tools/scheduledEvents.ts
@@ -26,12 +26,11 @@ const ENTITY_TYPE_MAP: Record<string, GuildScheduledEventEntityType> = {
   EXTERNAL: GuildScheduledEventEntityType.External,
 };
 
-const STATUS_MAP: Record<string, GuildScheduledEventStatus> = {
-  SCHEDULED: GuildScheduledEventStatus.Scheduled,
+const STATUS_MAP = {
   ACTIVE: GuildScheduledEventStatus.Active,
   COMPLETED: GuildScheduledEventStatus.Completed,
   CANCELED: GuildScheduledEventStatus.Canceled,
-};
+} as const;
 
 const ENTITY_TYPE_NAMES: Record<number, string> = {
   [GuildScheduledEventEntityType.StageInstance]: "STAGE_INSTANCE",
@@ -194,21 +193,19 @@ const tools = [
         throw new Error("scheduled_end_time is required for EXTERNAL events.");
       }
 
-      const options: Record<string, unknown> = {
+      const options: GuildScheduledEventCreateOptions = {
         name,
         scheduledStartTime: scheduled_start_time,
         entityType,
         privacyLevel: GuildScheduledEventPrivacyLevel.GuildOnly,
+        description,
+        scheduledEndTime: scheduled_end_time,
+        channel: channel_id,
+        entityMetadata: location !== undefined ? { location } : undefined,
+        image,
       };
-      if (description) options.description = description;
-      if (scheduled_end_time) options.scheduledEndTime = scheduled_end_time;
-      if (channel_id) options.channel = channel_id;
-      if (location) options.entityMetadata = { location };
-      if (image) options.image = image;
 
-      const event = await guild.scheduledEvents.create(
-        options as unknown as GuildScheduledEventCreateOptions,
-      );
+      const event = await guild.scheduledEvents.create(options);
       return {
         content: [
           { type: "text", text: `✅ Scheduled event "${event.name}" created (id: ${event.id}).` },
@@ -267,24 +264,23 @@ const tools = [
       const guild = await discord.guilds.fetch(guild_id);
       const event = await guild.scheduledEvents.fetch(event_id);
 
-      const options: Record<string, unknown> = {};
-      if (name) options.name = name;
-      if (description !== undefined) options.description = description;
-      if (scheduled_start_time) options.scheduledStartTime = scheduled_start_time;
-      if (scheduled_end_time) options.scheduledEndTime = scheduled_end_time;
-      if (channel_id) options.channel = channel_id;
-      if (location) options.entityMetadata = { location };
-      if (image) options.image = image;
-      if (status) options.status = STATUS_MAP[status];
+      const options: GuildScheduledEventEditOptions<
+        GuildScheduledEventStatus,
+        | GuildScheduledEventStatus.Active
+        | GuildScheduledEventStatus.Completed
+        | GuildScheduledEventStatus.Canceled
+      > = {
+        name,
+        description,
+        scheduledStartTime: scheduled_start_time,
+        scheduledEndTime: scheduled_end_time,
+        channel: channel_id,
+        entityMetadata: location !== undefined ? { location } : undefined,
+        image,
+        status: status !== undefined ? STATUS_MAP[status] : undefined,
+      };
 
-      const updated = await event.edit(
-        options as unknown as GuildScheduledEventEditOptions<
-          GuildScheduledEventStatus,
-          | GuildScheduledEventStatus.Active
-          | GuildScheduledEventStatus.Completed
-          | GuildScheduledEventStatus.Canceled
-        >,
-      );
+      const updated = await event.edit(options);
       return {
         content: [
           {

--- a/src/tools/webhooks.ts
+++ b/src/tools/webhooks.ts
@@ -85,8 +85,14 @@ const tools = [
     }),
     handle: async ({ webhook_id, webhook_token, content, username, avatar_url, embeds }) => {
       if (!webhook_token) throw new Error("webhook_token is required.");
-      if (allowListActive())
-        assertAllowedGuild((await discord.fetchWebhook(webhook_id, webhook_token)).guildId);
+      if (allowListActive()) {
+        const guildOfWebhook = (await discord.fetchWebhook(webhook_id, webhook_token)).guildId;
+        if (!guildOfWebhook)
+          throw new Error(
+            "Webhook has no resolvable guild — refused while DISCORD_ALLOWED_GUILDS is active.",
+          );
+        assertAllowedGuild(guildOfWebhook);
+      }
       const client = new WebhookClient({ id: webhook_id, token: webhook_token });
       try {
         const sendOptions: Record<string, unknown> = {};
@@ -241,8 +247,14 @@ const tools = [
     }),
     handle: async ({ webhook_id, webhook_token, message_id, content, embeds }) => {
       if (!webhook_token) throw new Error("webhook_token is required.");
-      if (allowListActive())
-        assertAllowedGuild((await discord.fetchWebhook(webhook_id, webhook_token)).guildId);
+      if (allowListActive()) {
+        const guildOfWebhook = (await discord.fetchWebhook(webhook_id, webhook_token)).guildId;
+        if (!guildOfWebhook)
+          throw new Error(
+            "Webhook has no resolvable guild — refused while DISCORD_ALLOWED_GUILDS is active.",
+          );
+        assertAllowedGuild(guildOfWebhook);
+      }
       const client = new WebhookClient({ id: webhook_id, token: webhook_token });
       try {
         const editOptions: Record<string, unknown> = {};
@@ -274,8 +286,14 @@ const tools = [
     }),
     handle: async ({ webhook_id, webhook_token, message_id }) => {
       if (!webhook_token) throw new Error("webhook_token is required.");
-      if (allowListActive())
-        assertAllowedGuild((await discord.fetchWebhook(webhook_id, webhook_token)).guildId);
+      if (allowListActive()) {
+        const guildOfWebhook = (await discord.fetchWebhook(webhook_id, webhook_token)).guildId;
+        if (!guildOfWebhook)
+          throw new Error(
+            "Webhook has no resolvable guild — refused while DISCORD_ALLOWED_GUILDS is active.",
+          );
+        assertAllowedGuild(guildOfWebhook);
+      }
       const client = new WebhookClient({ id: webhook_id, token: webhook_token });
       try {
         await client.deleteMessage(message_id);
@@ -304,8 +322,14 @@ const tools = [
     }),
     handle: async ({ webhook_id, webhook_token, message_id }) => {
       if (!webhook_token) throw new Error("webhook_token is required.");
-      if (allowListActive())
-        assertAllowedGuild((await discord.fetchWebhook(webhook_id, webhook_token)).guildId);
+      if (allowListActive()) {
+        const guildOfWebhook = (await discord.fetchWebhook(webhook_id, webhook_token)).guildId;
+        if (!guildOfWebhook)
+          throw new Error(
+            "Webhook has no resolvable guild — refused while DISCORD_ALLOWED_GUILDS is active.",
+          );
+        assertAllowedGuild(guildOfWebhook);
+      }
       const client = new WebhookClient({ id: webhook_id, token: webhook_token });
       try {
         const msg = await client.fetchMessage(message_id);

--- a/test/allowlist.test.ts
+++ b/test/allowlist.test.ts
@@ -27,19 +27,42 @@ test("fetchChannelChecked passes an allowed channel and guild-less objects throu
   assert.ok(await fetchChannelChecked("333333333333333333"));
 });
 
-test("token-webhook flows are gated when the allow-list is active", async () => {
-  process.env.DISCORD_ALLOWED_GUILDS = ALLOWED;
-  mock.method(discord, "fetchWebhook", async () => ({ guildId: FOREIGN }) as never);
-  await assert.rejects(
-    () =>
-      webhooks.handlers.get("discord_send_webhook_message")!({
-        webhook_id: "333333333333333333",
-        webhook_token: "tok",
-        content: "x",
-      }),
-    /allow-list/,
-  );
-});
+const TOKEN_WEBHOOK_CALLS: [string, Record<string, unknown>][] = [
+  ["discord_send_webhook_message", { content: "x" }],
+  ["discord_edit_webhook_message", { message_id: "444444444444444444", content: "x" }],
+  ["discord_delete_webhook_message", { message_id: "444444444444444444" }],
+  ["discord_fetch_webhook_message", { message_id: "444444444444444444" }],
+];
+
+for (const [tool, extra] of TOKEN_WEBHOOK_CALLS) {
+  test(`${tool} is gated when the allow-list is active`, async () => {
+    process.env.DISCORD_ALLOWED_GUILDS = ALLOWED;
+    mock.method(discord, "fetchWebhook", async () => ({ guildId: FOREIGN }) as never);
+    await assert.rejects(
+      () =>
+        webhooks.handlers.get(tool)!({
+          webhook_id: "333333333333333333",
+          webhook_token: "tok",
+          ...extra,
+        }),
+      /allow-list/,
+    );
+  });
+
+  test(`${tool} fails closed when the webhook has no resolvable guild`, async () => {
+    process.env.DISCORD_ALLOWED_GUILDS = ALLOWED;
+    mock.method(discord, "fetchWebhook", async () => ({}) as never);
+    await assert.rejects(
+      () =>
+        webhooks.handlers.get(tool)!({
+          webhook_id: "333333333333333333",
+          webhook_token: "tok",
+          ...extra,
+        }),
+      /no resolvable guild/,
+    );
+  });
+}
 
 test("no tool module bypasses the checked channel fetch", () => {
   const dir = join(__dirname, "..", "src", "tools");
@@ -48,6 +71,10 @@ test("no tool module bypasses the checked channel fetch", () => {
     assert.ok(
       !/discord\.channels\.fetch/.test(src),
       `${file} calls discord.channels.fetch directly — use fetchChannelChecked/getTextChannel/getGuildChannel`,
+    );
+    assert.ok(
+      !/guild_id:\s*snowflake\b/.test(src),
+      `${file} declares a raw guild_id: snowflake input — use the allow-list-enforcing guildId fragment`,
     );
   }
 });

--- a/test/bug-classes.test.ts
+++ b/test/bug-classes.test.ts
@@ -1,6 +1,6 @@
 import { test, mock, afterEach } from "node:test";
 import assert from "node:assert/strict";
-import { ChannelType } from "discord.js";
+import { ChannelType, Routes } from "discord.js";
 import { discord } from "../src/client.js";
 import { parsePermissionNames } from "../src/client.js";
 import messages from "../src/tools/messages.js";
@@ -46,6 +46,7 @@ test("delete_message sends the audit-log reason through the raw REST route", asy
     reason: "spam cleanup",
   });
   assert.equal(restCalls.length, 1);
+  assert.equal(restCalls[0][0], Routes.channelMessage(CHANNEL, MESSAGE));
   assert.deepEqual(restCalls[0][1], { reason: "spam cleanup" });
 });
 

--- a/test/dry-run.test.ts
+++ b/test/dry-run.test.ts
@@ -1,0 +1,128 @@
+import { test, mock, afterEach } from "node:test";
+import assert from "node:assert/strict";
+import { discord } from "../src/client.js";
+import messages from "../src/tools/messages.js";
+import channels from "../src/tools/channels.js";
+import members from "../src/tools/members.js";
+
+const GUILD = "111111111111111111";
+const CHANNEL = "333333333333333333";
+const USER = "222222222222222222";
+
+afterEach(() => mock.restoreAll());
+
+function textOf(res: { content: { text?: string }[] }): string {
+  return res.content[0]?.text ?? "";
+}
+
+test("delete_channel: default previews and never deletes; dry_run:false deletes with the reason", async () => {
+  const deletions: unknown[] = [];
+  const fakeChannel = {
+    name: "victim",
+    guildId: GUILD,
+    delete: async (reason: unknown) => void deletions.push(reason),
+  };
+  mock.method(discord.channels, "fetch", async () => fakeChannel as never);
+  const handler = channels.handlers.get("discord_delete_channel")!;
+
+  const preview = await handler({ channel_id: CHANNEL });
+  assert.match(textOf(preview), /Dry run/);
+  assert.equal(deletions.length, 0, "dry run must not delete");
+
+  await handler({ channel_id: CHANNEL, dry_run: false, reason: "cleanup" });
+  assert.deepEqual(deletions, ["cleanup"]);
+});
+
+test("bulk_delete_messages: default previews via fetch; dry_run:false calls bulkDelete once", async () => {
+  const bulkCalls: unknown[][] = [];
+  const fakeChannel = {
+    name: "chan",
+    guildId: GUILD,
+    isDMBased: () => false,
+    isTextBased: () => true,
+    messages: { fetch: async () => ({ filter: () => ({ size: 1 }), size: 3 }) },
+    bulkDelete: async (...args: unknown[]) => {
+      bulkCalls.push(args);
+      return { size: 3 };
+    },
+  };
+  mock.method(discord.channels, "fetch", async () => fakeChannel as never);
+  const handler = messages.handlers.get("discord_bulk_delete_messages")!;
+
+  const preview = await handler({ channel_id: CHANNEL, count: 3 });
+  assert.match(textOf(preview), /Dry run/);
+  assert.equal(bulkCalls.length, 0, "dry run must not bulk-delete");
+
+  await handler({ channel_id: CHANNEL, count: 3, dry_run: false });
+  assert.equal(bulkCalls.length, 1);
+});
+
+test("bulk_ban: default previews the exact IDs; dry_run:false calls bulkBan with the reason", async () => {
+  const banCalls: unknown[][] = [];
+  const fakeGuild = {
+    members: {
+      bulkBan: async (...args: unknown[]) => {
+        banCalls.push(args);
+        return { bannedUsers: [USER], failedUsers: [] };
+      },
+    },
+  };
+  mock.method(discord.guilds, "fetch", async () => fakeGuild as never);
+  const handler = members.handlers.get("discord_bulk_ban")!;
+
+  const preview = await handler({ guild_id: GUILD, user_ids: [USER] });
+  assert.match(textOf(preview), /Dry run/);
+  assert.match(textOf(preview), new RegExp(USER), "preview lists the exact IDs");
+  assert.equal(banCalls.length, 0, "dry run must not ban");
+
+  await handler({ guild_id: GUILD, user_ids: [USER], dry_run: false, reason: "raid" });
+  assert.equal(banCalls.length, 1);
+  assert.deepEqual(banCalls[0][0], [USER]);
+  assert.match(JSON.stringify(banCalls[0][1]), /raid/);
+});
+
+test("prune_members: dry_run flips Discord's native dry flag", async () => {
+  const pruneCalls: { dry?: boolean }[] = [];
+  const fakeGuild = {
+    members: {
+      prune: async (opts: { dry?: boolean }) => {
+        pruneCalls.push(opts);
+        return 4;
+      },
+    },
+  };
+  mock.method(discord.guilds, "fetch", async () => fakeGuild as never);
+  const handler = members.handlers.get("discord_prune_members")!;
+
+  await handler({ guild_id: GUILD, days: 30 });
+  await handler({ guild_id: GUILD, days: 30, dry_run: false });
+  assert.equal(pruneCalls[0].dry, true);
+  assert.equal(pruneCalls[1].dry, false);
+});
+
+test("ban and kick propagate the audit-log reason to the terminal discord.js call", async () => {
+  const bans: unknown[][] = [];
+  const kicks: unknown[] = [];
+  const fakeMember = { user: { tag: "u#0" }, kick: async (r: unknown) => void kicks.push(r) };
+  const fakeGuild = {
+    members: {
+      ban: async (...args: unknown[]) => void bans.push(args),
+      fetch: async () => fakeMember,
+    },
+  };
+  mock.method(discord.guilds, "fetch", async () => fakeGuild as never);
+
+  await members.handlers.get("discord_ban_member")!({
+    guild_id: GUILD,
+    user_id: USER,
+    reason: "ban reason",
+  });
+  assert.match(JSON.stringify(bans[0][1]), /ban reason/);
+
+  await members.handlers.get("discord_kick_member")!({
+    guild_id: GUILD,
+    user_id: USER,
+    reason: "kick reason",
+  });
+  assert.deepEqual(kicks, ["kick reason"]);
+});

--- a/test/server.test.ts
+++ b/test/server.test.ts
@@ -28,12 +28,30 @@ test("unknown tool is a JSON-RPC InvalidParams protocol error, not a tool result
 test("tools/list serves every definition and rejects unexpected cursors", async () => {
   const client = await connectedClient();
   const { tools } = await client.listTools();
-  assert.ok(tools.length >= 95);
+  assert.equal(tools.length, 97, "update this pin when adding/removing tools");
   await assert.rejects(
     () => client.listTools({ cursor: "bogus" }),
     (err: unknown) => err instanceof McpError && err.code === ErrorCode.InvalidParams,
   );
   await client.close();
+});
+
+test("a handler failure surfaces as an isError result, not a protocol error", async () => {
+  const { discord } = await import("../src/client.js");
+  const { mock } = await import("node:test");
+  mock.method(discord, "isReady", () => false as never);
+  mock.method(discord, "login", async () => {
+    throw new Error("login refused (test)");
+  });
+  const client = await connectedClient();
+  const res = (await client.callTool({
+    name: "discord_list_guilds",
+    arguments: {},
+  })) as { isError?: boolean; content: { text?: string }[] };
+  assert.equal(res.isError, true);
+  assert.match(res.content[0].text ?? "", /login refused \(test\)|DISCORD_TOKEN/);
+  await client.close();
+  mock.restoreAll();
 });
 
 test("formatToolError flattens ZodError paths and surfaces Discord hints", () => {


### PR DESCRIPTION
Sixth audit round (convergence run): 19 unique findings — 2 high, both OUTSIDE the shipped code (CI trigger + test depth), confirming the source converged (1 security low, 1 discord-api low).

Highs:
- ci.yml only triggered on main: every release/2.0 PR today merged with ZERO checks — and 3 unused imports (lint errors on HEAD) survived 4 PRs as living proof, masked locally by piping lint through tail. Now triggers on main + release/**; lint fixed
- dry_run had schema-only coverage: new behavioral tests prove the default path never calls the destructive API (spied) and dry_run:false calls it exactly once with the audit reason — for delete_channel, bulk_delete, bulk_ban, prune + reason propagation for ban/kick

Meds: webhook-token allow-list gate now tested on all 4 tools AND fails closed when the webhook has no resolvable guild; delete-reason regression test asserts the exact REST route; grep-guard extended to ban raw `guild_id: snowflake` inputs; in-memory test for the isError wiring; mcp-publisher pinned to v1.7.9 + sha256-verified (was unpinned latest with id-token:write); publish-npm least-privilege + --provenance.

Lows: crosspost made truly idempotent (40033 → success, decision (b)); list_guilds honors the allow-list; webhook fail-closed; forums `before` cursor validated; double casts replaced by typed event options (which immediately caught the stale SCHEDULED entry in STATUS_MAP); truthy/undefined checks unified in edit_scheduled_event; orphan docblock removed; Docker multi-arch (amd64+arm64 — Apple Silicon decision taken).

49/49 tests.