### PR TITLE
release: 1.7.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.7.3] - 2026-06-11
+
+### Fixed
+
+- Security: refreshed the dependency lockfile (8 npm audit findings → 0, including `ws` — the websocket library on the gateway hot path). npm consumers always resolved fresh in-range dependencies and were unaffected; the Docker image embeds the lockfile, so this release rebuilds it with the patched versions
+- Release pipeline: the Docker publish job now requires the npm job (lint, tests, tag↔version guard) instead of publishing unconditionally on any tag
+
 ## [1.7.2] - 2026-06-10
 
 ### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@pasympa/discord-mcp",
-  "version": "1.7.2",
+  "version": "1.7.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@pasympa/discord-mcp",
-      "version": "1.7.2",
+      "version": "1.7.3",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.27.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pasympa/discord-mcp",
-  "version": "1.7.2",
+  "version": "1.7.3",
   "mcpName": "io.github.PaSympa/discord-mcp",
   "description": "A lightweight, multi-guild Discord MCP server with 95+ tools",
   "main": "dist/index.js",

--- a/server.json
+++ b/server.json
@@ -6,12 +6,12 @@
     "url": "https://github.com/PaSympa/discord-mcp",
     "source": "github"
   },
-  "version": "1.7.2",
+  "version": "1.7.3",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "@pasympa/discord-mcp",
-      "version": "1.7.2",
+      "version": "1.7.3",
       "transport": {
         "type": "stdio"
       },


### PR DESCRIPTION
Security patch release: lockfile refreshed (8 npm audit findings → 0, incl. ws on the gateway hot path — the fix itself landed in #57; this release rebuilds the Docker image with it) and the gated Docker publish job.

Version bump via `npm version patch` (package.json, package-lock.json, server.json aligned at 1.7.3 — tag v1.7.3 points at the bump commit). CHANGELOG entry included.

Merge with a **merge commit**, then the tag push triggers npm + Docker + GitHub Release + MCP Registry.