### PR TITLE
docs: complete the OAuth permission list (live-campaign findings)

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,7 +206,7 @@ Data access is governed by the **portal toggles**, not by these flags: this serv
 
 5. **OAuth2 > URL Generator**:
    - Scopes: `bot`
-   - Permissions: `Send Messages`, `Read Message History`, `Manage Channels`, `Manage Roles`, `Kick Members`, `Ban Members`, `Moderate Members`, `View Audit Log`, `Manage Messages`, `Manage Threads`, `Add Reactions`, `Manage Guild`, `Manage Webhooks`, `Manage Events`, `Create Instant Invite`, `Manage Nicknames`, `Pin Messages`, `Embed Links`, `Create Public Threads`
+   - Permissions: `Send Messages`, `Read Message History`, `Manage Channels`, `Manage Roles`, `Kick Members`, `Ban Members`, `Moderate Members`, `View Audit Log`, `Manage Messages`, `Manage Threads`, `Add Reactions`, `Manage Guild`, `Manage Webhooks`, `Manage Events`, `Create Events`, `Create Instant Invite`, `Manage Nicknames`, `Pin Messages`, `Embed Links`, `Create Public Threads`, `Send Messages in Threads`
 6. Copy the generated URL and invite the bot to your server
 
 ---


### PR DESCRIPTION
Two gaps proven live by exercising all 97 tools against a bot invited with the README's exact permission list:

- `Create Events`: Discord split it from `Manage Events` (2024) — `discord_create_scheduled_event` hard-fails with 50013 without it
- `Send Messages in Threads`: `discord_reply_to_forum` and any message into a thread hard-fail with 50001 without it (the requirement was already documented on the forum tool's description in round 4, but the invite list was never updated)

With these two, the documented invite URL yields a bot that can use all 97 tools.