### PR TITLE
feat: strict tool inputs, OCI registry manifest, scanner-visible packaging

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,6 +26,16 @@ jobs:
             echo "Version mismatch: tag=$TAG_VERSION package.json=$PKG_VERSION server.json=$SRV_VERSION"
             exit 1
           fi
+          node -e '
+            const tag = process.argv[1];
+            for (const pkg of require("./server.json").packages ?? []) {
+              const v = pkg.registryType === "oci" ? pkg.identifier.split(":").pop() : pkg.version;
+              if (v !== tag) {
+                console.error(`Version mismatch in server.json package ${pkg.identifier}: ${v} != ${tag}`);
+                process.exit(1);
+              }
+            }
+          ' "$TAG_VERSION"
       - run: npm ci
       - run: npm run lint
       - run: npm run build
@@ -36,7 +46,7 @@ jobs:
 
   publish-mcp-registry:
     runs-on: ubuntu-latest
-    needs: [publish-npm]
+    needs: [publish-npm, publish-docker]
     permissions:
       id-token: write
       contents: read

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## [Unreleased]
+
+### Changed
+
+- Tool inputs reject unknown argument keys instead of silently stripping them, and every `inputSchema` advertises `additionalProperties: false`. Callers passing extra keys now get `Invalid arguments — Unrecognized key: "…"`
+
+### Added
+
+- The Docker image is declared in the MCP Registry manifest (`server.json` OCI package) and carries the `io.modelcontextprotocol.server.name` label the registry requires; the registry publish job now waits for the Docker push
+- The npm tarball ships `SECURITY.md` and the `Dockerfile`, so tarball-based security scanners see the security policy and the container option
+
 ## [2.0.0] - 2026-06-21
 
 ### Breaking

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -113,7 +113,8 @@ The tag triggers `.github/workflows/release.yml`, which does everything else aut
 
 1. Fails fast if the tag does not match `package.json` / `server.json`
 2. Lints, builds, tests, then publishes to npm (`NPM_TOKEN` secret)
-3. Publishes to the official MCP Registry via GitHub OIDC (no secret needed) — the [GitHub MCP Registry](https://github.com/mcp) picks it up automatically
-4. Pushes the Docker images and creates the GitHub Release
+3. Pushes the Docker images
+4. Publishes to the official MCP Registry via GitHub OIDC (no secret needed) — the registry pulls the tagged Docker image to validate the `server.json` OCI entry, and the [GitHub MCP Registry](https://github.com/mcp) picks it up automatically
+5. Creates the GitHub Release
 
 No manual `npm publish` — local publishes are blocked by npm's 2FA policy anyway.

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,7 @@ RUN npm run build
 # Stage 2: Run
 FROM node:24-alpine
 
+LABEL io.modelcontextprotocol.server.name="io.github.PaSympa/discord-mcp"
 LABEL org.opencontainers.image.title="Discord MCP Server"
 LABEL org.opencontainers.image.description="A lightweight, multi-guild Discord MCP server with 97 tools"
 LABEL org.opencontainers.image.source="https://github.com/PaSympa/discord-mcp"

--- a/package.json
+++ b/package.json
@@ -9,7 +9,9 @@
     "discord-mcp": "dist/index.js"
   },
   "files": [
-    "dist"
+    "dist",
+    "SECURITY.md",
+    "Dockerfile"
   ],
   "scripts": {
     "build": "tsc",

--- a/scripts/sync-version.js
+++ b/scripts/sync-version.js
@@ -10,7 +10,12 @@ const serverJsonPath = path.join(__dirname, "..", "server.json");
 const server = JSON.parse(fs.readFileSync(serverJsonPath, "utf8"));
 server.version = version;
 for (const pkg of server.packages ?? []) {
-  pkg.version = version;
+  // The registry rejects a `version` field on OCI packages; the identifier's tag carries it.
+  if (pkg.registryType === "oci") {
+    pkg.identifier = pkg.identifier.slice(0, pkg.identifier.lastIndexOf(":") + 1) + version;
+  } else {
+    pkg.version = version;
+  }
 }
 fs.writeFileSync(serverJsonPath, JSON.stringify(server, null, 2) + "\n");
 console.log(`server.json synced to ${version}`);

--- a/server.json
+++ b/server.json
@@ -24,6 +24,22 @@
           "format": "string"
         }
       ]
+    },
+    {
+      "registryType": "oci",
+      "identifier": "docker.io/pasympa/discord-mcp:2.0.0",
+      "transport": {
+        "type": "stdio"
+      },
+      "environmentVariables": [
+        {
+          "name": "DISCORD_TOKEN",
+          "description": "Discord bot token",
+          "isRequired": true,
+          "isSecret": true,
+          "format": "string"
+        }
+      ]
     }
   ]
 }

--- a/src/embeds.ts
+++ b/src/embeds.ts
@@ -17,7 +17,7 @@ export const embedFieldsShape = {
     .describe("Side-bar color as a hex string, e.g. '#5865F2'."),
   fields: z
     .array(
-      z.object({
+      z.strictObject({
         name: z.string().describe("Field heading."),
         value: z.string().describe("Field body text."),
         inline: z
@@ -31,7 +31,7 @@ export const embedFieldsShape = {
       "Up to 25 name/value field blocks. Set inline:true on a field to render it side-by-side with adjacent inline fields (up to 3 per row).",
     ),
   author: z
-    .object({
+    .strictObject({
       name: z.string().describe("Author display name."),
       icon_url: httpUrl.optional().describe("Small icon shown next to the author name."),
       url: httpUrl.optional().describe("URL the author name links to."),
@@ -45,7 +45,7 @@ export const embedFieldsShape = {
 } as const;
 
 /** Schema for a single embed object (e.g. an item of `discord_send_multiple_embeds`). */
-export const embedObjectSchema = z.object(embedFieldsShape);
+export const embedObjectSchema = z.strictObject(embedFieldsShape);
 
 /** Up to 10 embeds — Discord's per-message cap, enforced at parse time and advertised as maxItems. */
 export const embedArraySchema = z

--- a/src/tools/define.ts
+++ b/src/tools/define.ts
@@ -78,9 +78,19 @@ interface RegisteredTool {
 }
 
 /**
+ * Rejects unknown argument keys instead of silently stripping them, and the
+ * derived JSON Schema advertises it (`additionalProperties: false`). `.strict()`
+ * preserves the shape and object-level checks, so the cast keeps S's inference.
+ */
+function strictInput<S extends z.ZodType>(schema: S): S {
+  return schema instanceof z.ZodObject ? (schema.strict() as unknown as S) : schema;
+}
+
+/**
  * Declares one tool from a single source of truth: the zod `schema` derives the
  * client-facing `inputSchema` and validates incoming args, so `handle` receives
  * values already typed and checked — no `as` casts, no schema/handler drift.
+ * Unknown argument keys are rejected (`additionalProperties: false`).
  * An optional `outputSchema` (a `z.object`) derives the advertised `outputSchema`
  * and checks the handler's `structuredContent` against it on the way out: a
  * conforming result is normalised (unknown keys dropped, text block regenerated to
@@ -97,14 +107,15 @@ export function defineTool<S extends z.ZodType>(tool: {
   handle(args: z.infer<S>): Promise<ToolResult>;
 }): RegisteredTool {
   const { outputSchema } = tool;
+  const schema = strictInput(tool.schema);
   return {
     name: tool.name,
     description: tool.description,
     annotations: tool.annotations,
-    inputSchema: toInputSchema(tool.schema),
+    inputSchema: toInputSchema(schema),
     outputSchema: outputSchema ? toOutputSchema(outputSchema) : undefined,
     run: async (args) => {
-      const result = await tool.handle(tool.schema.parse(args));
+      const result = await tool.handle(schema.parse(args));
       if (outputSchema && result.structuredContent !== undefined) {
         const parsed = outputSchema.safeParse(result.structuredContent);
         if (parsed.success) {

--- a/src/tools/forums.ts
+++ b/src/tools/forums.ts
@@ -329,7 +329,7 @@ const tools = [
       forum_channel_id: snowflake.describe("ID (snowflake) of the forum channel to set tags on."),
       tags: z
         .array(
-          z.object({
+          z.strictObject({
             name: z.string().describe("Tag label (max 20 characters)."),
             emoji_name: z.string().optional().describe("Optional unicode emoji shown on the tag."),
             moderated: z

--- a/src/tools/screening.ts
+++ b/src/tools/screening.ts
@@ -69,7 +69,7 @@ const tools = [
         .describe("Welcome message shown at the top of the screening form."),
       form_fields: z
         .array(
-          z.object({
+          z.strictObject({
             label: z.string().describe("Title of this rules block."),
             values: z.array(z.string()).describe("Individual rule lines shown under the label."),
             required: z

--- a/test/define.test.ts
+++ b/test/define.test.ts
@@ -116,6 +116,20 @@ test("non-conforming structuredContent becomes an isError result, never ships", 
   assert.equal(res.structuredContent, undefined);
 });
 
+test("unknown argument keys are rejected and advertised via additionalProperties: false", async () => {
+  const mod = defineModule([
+    defineTool({
+      name: "t_strict",
+      description: "x",
+      schema: z.object({ a: z.string() }),
+      handle: async () => ({ content: [{ type: "text" as const, text: "ok" }] }),
+    }),
+  ]);
+  const schema = mod.definitions[0].inputSchema as Record<string, unknown>;
+  assert.equal(schema.additionalProperties, false);
+  await assert.rejects(() => mod.handlers.get("t_strict")!({ a: "x", extra: 1 }), ZodError);
+});
+
 test("defineModule throws on duplicate tool names within a module", () => {
   const dup = () =>
     defineTool({

--- a/test/registry.test.ts
+++ b/test/registry.test.ts
@@ -36,6 +36,39 @@ test("selectModules fails fast on unknown or empty selections", () => {
   }
 });
 
+function assertStrictObjectSchemas(node: unknown, tool: string, path: string): void {
+  if (Array.isArray(node)) {
+    node.forEach((v, i) => assertStrictObjectSchemas(v, tool, `${path}[${i}]`));
+    return;
+  }
+  if (typeof node !== "object" || node === null) return;
+  const schema = node as Record<string, unknown>;
+  if (schema.type === "object" && schema.properties !== undefined) {
+    assert.equal(
+      schema.additionalProperties,
+      false,
+      `${tool} at ${path}: object schema must advertise additionalProperties: false`,
+    );
+  }
+  for (const [key, value] of Object.entries(schema)) {
+    assertStrictObjectSchemas(value, tool, `${path}.${key}`);
+  }
+}
+
+test("every tool's inputSchema forbids unknown keys at every nesting level", () => {
+  delete process.env.DISCORD_MCP_TOOLSETS;
+  for (const mod of selectModules()) {
+    for (const def of mod.definitions) {
+      assert.equal(
+        (def.inputSchema as Record<string, unknown>).additionalProperties,
+        false,
+        `${def.name} root must advertise additionalProperties: false`,
+      );
+      assertStrictObjectSchemas(def.inputSchema, def.name, "inputSchema");
+    }
+  }
+});
+
 test("hasTool reflects the registry", () => {
   assert.ok(hasTool("discord_list_guilds"));
   assert.ok(!hasTool("discord_nonexistent"));


### PR DESCRIPTION
## Motivation

An analysis of the Canopii Trust Index scan of v2.0.0 surfaced one legitimate weakness (input schemas not strict) plus two visibility gaps caused by scanners that only see the npm tarball or the registry manifest. This PR fixes what is actionable on our side without touching any tool description (description changes re-trigger Canopii's version-diff guard).

## Changes

- **Strict inputs**: `defineTool` applies `.strict()` to every root schema, and the shared nested shapes (embed `fields[]`/`author`, `embeds[]` items, forum `tags[]` items, screening `form_fields[]` items) are `z.strictObject`. Every `inputSchema` now advertises `additionalProperties: false` at every nesting level, and unknown keys are rejected with `Invalid arguments — Unrecognized key: "…"` instead of being silently stripped.
- **MCP Registry OCI package**: `server.json` declares `docker.io/pasympa/discord-mcp:<tag>` (canonical form — the registry validator rejects `version`/`registryBaseUrl` fields on OCI entries). The Dockerfile gains the `io.modelcontextprotocol.server.name` label the registry checks for ownership, `sync-version.js` rewrites the identifier tag on `npm version`, `publish-mcp-registry` now waits for `publish-docker` (the registry pulls the tagged image during validation), and the version guard also asserts every `server.json` package version, including the OCI tag.
- **Packaging**: the npm tarball ships `SECURITY.md` and the `Dockerfile` so tarball-based scanners see the security policy and container option.

## Verification

- 51/51 unit tests (new: recursive additionalProperties check over all 97 tools; unknown-key rejection)
- 14/14 live tests against the real test guild; live checks confirm root and nested unknown keys are rejected end-to-end while clean calls succeed
- `server.json` validates against the official 2025-12-11 schema (ajv); `npm version` simulation confirms the OCI tag rewrite; `npm pack` confirms tarball contents; guard simulation fails on a stale OCI tag as intended
- Adversarial multi-agent review of the diff: both confirmed findings (shallow `.strict()` on nested objects, unguarded OCI tag) are fixed in this PR

## Release note

Rejecting unknown keys is a behavior change for callers that sent extra arguments — worth a minor bump. First release after merge publishes the labeled Docker image before registry validation runs, so the new OCI entry validates on its first use.