### PR TITLE
release: 2.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,11 @@
 # Changelog
 
-## [Unreleased]
+## [2.1.0] - 2026-07-13
 
 ### Changed
 
 - Tool inputs reject unknown argument keys instead of silently stripping them, and every `inputSchema` advertises `additionalProperties: false`. Callers passing extra keys now get `Invalid arguments — Unrecognized key: "…"`
+- The Docker image runs on Node 26 (was Node 24)
 
 ### Added
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@pasympa/discord-mcp",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@pasympa/discord-mcp",
-      "version": "2.0.0",
+      "version": "2.1.0",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pasympa/discord-mcp",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "mcpName": "io.github.PaSympa/discord-mcp",
   "description": "A lightweight, multi-guild Discord MCP server with 95+ tools",
   "main": "dist/index.js",

--- a/server.json
+++ b/server.json
@@ -6,12 +6,12 @@
     "url": "https://github.com/PaSympa/discord-mcp",
     "source": "github"
   },
-  "version": "2.0.0",
+  "version": "2.1.0",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "@pasympa/discord-mcp",
-      "version": "2.0.0",
+      "version": "2.1.0",
       "transport": {
         "type": "stdio"
       },
@@ -27,7 +27,7 @@
     },
     {
       "registryType": "oci",
-      "identifier": "docker.io/pasympa/discord-mcp:2.0.0",
+      "identifier": "docker.io/pasympa/discord-mcp:2.1.0",
       "transport": {
         "type": "stdio"
       },


### PR DESCRIPTION
Version bump to 2.1.0 and CHANGELOG finalization.

Ships (already merged on main): strict tool inputs (unknown argument keys rejected, `additionalProperties: false` at every nesting level), MCP Registry OCI package + labeled Docker image + reordered release pipeline with extended version guard, npm tarball with SECURITY.md and Dockerfile, Docker image on Node 26, dependency bumps.

Merge with a MERGE COMMIT (the tagged commit must reach main's history). Tag push follows after merge.