### PR TITLE
fix: exit on stdin EOF so a dead client cannot orphan the server

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -18,19 +18,31 @@ async function main() {
   console.error(`Discord MCP Server v${version} running on stdio.`);
 }
 
-function shutdown() {
+let shuttingDown = false;
+
+function shutdown(code = 0) {
+  if (shuttingDown) return;
+  shuttingDown = true;
   console.error("Shutting down Discord MCP Server...");
   discord.destroy();
-  process.exit(0);
+  process.exit(code);
 }
 
-process.on("SIGINT", shutdown);
-process.on("SIGTERM", shutdown);
+process.on("SIGINT", () => shutdown());
+process.on("SIGTERM", () => shutdown());
+
+// A stdio server must not outlive its client: stdin EOF means the session is over.
+// StdioServerTransport only subscribes to stdin's 'data'/'error', so EOF never
+// surfaces, and the Discord gateway socket keeps the event loop alive — leaving
+// the process running long after its client has gone. ('end' is followed by
+// 'close'; shutdown() is guarded so the pair is harmless.)
+process.stdin.on("end", () => shutdown());
+process.stdin.on("close", () => shutdown());
+
 process.on("unhandledRejection", (reason) => console.error("Unhandled rejection:", reason));
 process.on("uncaughtException", (err) => console.error("Uncaught exception:", err));
 
 main().catch((err) => {
   console.error("Fatal:", err);
-  discord.destroy();
-  process.exit(1);
+  shutdown(1);
 });

--- a/test/fixtures/keepalive.mjs
+++ b/test/fixtures/keepalive.mjs
@@ -1,0 +1,6 @@
+// Stands in for discord.js's gateway socket: a referenced handle that keeps the
+// event loop alive, which is what turns a missed stdin EOF into a lingering
+// orphan process. A timer needs no network permissions, unlike a listening socket.
+import { setInterval } from "node:timers";
+
+setInterval(() => {}, 60_000);

--- a/test/lifecycle.test.ts
+++ b/test/lifecycle.test.ts
@@ -1,0 +1,80 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { spawn, type ChildProcess } from "node:child_process";
+import { join } from "node:path";
+
+const ROOT = join(__dirname, "..");
+const ENTRY = join(ROOT, "src", "index.ts");
+const KEEPALIVE = join(__dirname, "fixtures", "keepalive.mjs");
+const STARTUP_MS = 5_000;
+const EXIT_MS = 5_000;
+
+/**
+ * Boots the stdio entry point, resolving once it reports itself as running.
+ *
+ * The keepalive preload stands in for discord.js's gateway socket: a referenced
+ * handle that keeps the event loop alive. Without it the process would drain and
+ * exit on its own once stdin ends, masking the bug these tests cover — login is
+ * lazy, so no real gateway opens here.
+ */
+function startServer(): Promise<ChildProcess> {
+  const child = spawn(process.execPath, ["--import", KEEPALIVE, "--import", "tsx", ENTRY], {
+    cwd: ROOT,
+    stdio: ["pipe", "pipe", "pipe"],
+    env: { ...process.env, DISCORD_TOKEN: "placeholder.not.used" },
+  });
+  return new Promise((resolve, reject) => {
+    const timer = setTimeout(() => {
+      child.kill("SIGKILL");
+      reject(new Error("server never reported itself running"));
+    }, STARTUP_MS);
+    child.stderr!.on("data", (chunk: Buffer) => {
+      if (chunk.toString().includes("running on stdio")) {
+        clearTimeout(timer);
+        resolve(child);
+      }
+    });
+    child.once("error", reject);
+  });
+}
+
+/** Waits for exit and reports how; rejects if the child is still alive at the deadline. */
+function waitForExit(
+  child: ChildProcess,
+  ms: number,
+): Promise<{ code: number | null; signal: NodeJS.Signals | null }> {
+  if (child.exitCode !== null || child.signalCode !== null) {
+    return Promise.resolve({ code: child.exitCode, signal: child.signalCode });
+  }
+  return new Promise((resolve, reject) => {
+    const timer = setTimeout(() => {
+      child.kill("SIGKILL");
+      reject(new Error("server still alive at the deadline"));
+    }, ms);
+    child.once("exit", (code, signal) => {
+      clearTimeout(timer);
+      resolve({ code, signal });
+    });
+  });
+}
+
+// Regression: StdioServerTransport subscribes only to stdin's 'data'/'error', so EOF
+// went unnoticed, and any active handle (the gateway socket in production) kept the
+// event loop alive — a dead client left the server running indefinitely.
+test("exits cleanly when stdin reaches EOF, even with an active handle open", async () => {
+  const child = await startServer();
+  child.stdin!.end();
+
+  const { code, signal } = await waitForExit(child, EXIT_MS);
+  assert.equal(signal, null, "expected a self-initiated exit, not a signal kill");
+  assert.equal(code, 0, "expected the clean-shutdown exit code");
+});
+
+test("exits cleanly on SIGTERM", async () => {
+  const child = await startServer();
+  child.kill("SIGTERM");
+
+  const { code, signal } = await waitForExit(child, EXIT_MS);
+  assert.equal(signal, null, "expected the SIGTERM handler to exit, not a signal kill");
+  assert.equal(code, 0, "expected the clean-shutdown exit code");
+});


### PR DESCRIPTION
## Problem

When the MCP client that spawned `discord-mcp` exits, the server process can keep running indefinitely: `StdioServerTransport` subscribes only to stdin's `data`/`error` events, so EOF is never surfaced — and once any active handle exists (in practice the Discord gateway WebSocket, once a tool call has logged in), the event loop never drains.

Field report: I found 12 orphaned `discord-mcp` processes on one machine, accumulated over ~3 weeks, each spawned by an MCP client that had long since exited, holding 0.8–2.1 GB RSS between them. (Those long-lived orphans also showed sustained high CPU and did not respond to SIGTERM. I could **not** reproduce those two symptoms in a controlled setting, so this PR claims to fix only the lingering-process defect — the CPU/RSS/SIGTERM observations are reported for context, not explained by this patch.)

## Repro

```bash
DISCORD_TOKEN=placeholder node --import ./test/fixtures/keepalive.mjs --import tsx src/index.ts < /dev/null
```

`< /dev/null` delivers immediate stdin EOF; the preload stands in for the gateway handle. On `master` the process stays alive until killed; with this patch it exits 0 immediately.

## Fix

`src/index.ts`: listen for stdin `end`/`close` and shut down cleanly. `shutdown()` is guarded since EOF delivers `end` followed by `close`.

## Tests

`test/lifecycle.test.ts` boots the real entry point with the keepalive preload (a referenced timer — login is lazy, so no real gateway opens in tests, and a timer needs no network permissions):

- **exits cleanly when stdin reaches EOF, even with an active handle open** — fails on `master` (child still alive at deadline), passes with the fix; asserts `code === 0` and no signal kill
- **exits cleanly on SIGTERM** — guards the existing handler (passes on `master` too)

Full suite (56 tests), `tsc`, `eslint`, and `prettier --check` all pass.

## Note on the SDK

Arguably the root defect lives in `@modelcontextprotocol/typescript-sdk`: the `Transport` contract documents `onclose` as firing when the connection closes "for any reason", yet `StdioServerTransport` never surfaces stdin EOF (checked against current `main`). This entry-point guard is worth having regardless of an eventual SDK fix; happy to file the SDK issue separately if useful.
