### PR TITLE
fix: bound Discord.js client caches to prevent unbounded memory growth

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -1,12 +1,15 @@
 import "dotenv/config";
 import {
   Client,
+  Collection,
   Events,
   GatewayIntentBits,
   GuildChannel,
+  Options,
   PermissionsBitField,
   type GuildTextBasedChannel,
 } from "discord.js";
+import { CACHE_LIMITS } from "./constants.js";
 
 /**
  * Initializes the Discord.js client with the gateway intents (privileged ones
@@ -33,6 +36,51 @@ function envEnabled(name: string): boolean {
 const messageContentEnabled = envEnabled("DISCORD_MESSAGE_CONTENT");
 const guildMembersEnabled = envEnabled("DISCORD_GUILD_MEMBERS");
 
+/**
+ * Bounded cache configuration for the Discord.js client.
+ *
+ * discord.js defaults to near-unlimited caches (500K guilds, 10K messages/channel,
+ * unlimited channels/roles). For an MCP server that fetches data on-demand with
+ * `cache: false` on most reads, these bounds keep memory predictable while
+ * retaining hot data for repeated tool calls within a session.
+ *
+ * Uses Options.cacheWithLimits() for all cache types. The settings object includes
+ * non-configurable cache names (GuildManager, ChannelManager, RoleManager) which
+ * are commented out in discord.js's Caches interface but still use the makeCache
+ * factory at runtime — the `as any` cast lets us bound them too.
+ */
+const cacheSettings: Record<string, number> = {
+  // Non-configurable via CacheWithLimitsOptions (commented out in Caches interface)
+  GuildManager: CACHE_LIMITS.GuildManager,
+  ChannelManager: CACHE_LIMITS.ChannelManager,
+  RoleManager: CACHE_LIMITS.RoleManager,
+  // Configurable caches
+  MessageManager: CACHE_LIMITS.MessageManager,
+  GuildMessageManager: CACHE_LIMITS.GuildMessageManager,
+  GuildMemberManager: CACHE_LIMITS.GuildMemberManager,
+  PresenceManager: CACHE_LIMITS.PresenceManager,
+  GuildBanManager: CACHE_LIMITS.GuildBanManager,
+  GuildEmojiManager: CACHE_LIMITS.GuildEmojiManager,
+  GuildStickerManager: CACHE_LIMITS.GuildStickerManager,
+  GuildScheduledEventManager: CACHE_LIMITS.GuildScheduledEventManager,
+  ThreadManager: CACHE_LIMITS.ThreadManager,
+  ThreadMemberManager: CACHE_LIMITS.ThreadMemberManager,
+  ReactionManager: CACHE_LIMITS.ReactionManager,
+  ReactionUserManager: CACHE_LIMITS.ReactionUserManager,
+  StageInstanceManager: CACHE_LIMITS.StageInstanceManager,
+  VoiceStateManager: CACHE_LIMITS.VoiceStateManager,
+  UserManager: CACHE_LIMITS.UserManager,
+  EntitlementManager: CACHE_LIMITS.EntitlementManager,
+  AutoModerationRuleManager: CACHE_LIMITS.AutoModerationRuleManager,
+  ApplicationCommandManager: CACHE_LIMITS.ApplicationCommandManager,
+  ApplicationEmojiManager: CACHE_LIMITS.ApplicationEmojiManager,
+  BaseGuildEmojiManager: CACHE_LIMITS.BaseGuildEmojiManager,
+  GuildInviteManager: CACHE_LIMITS.GuildInviteManager,
+  DMMessageManager: CACHE_LIMITS.DMMessageManager,
+  GuildForumThreadManager: CACHE_LIMITS.GuildForumThreadManager,
+  GuildTextThreadManager: CACHE_LIMITS.GuildTextThreadManager,
+};
+
 export const discord = new Client({
   intents: [
     GatewayIntentBits.Guilds,
@@ -42,6 +90,7 @@ export const discord = new Client({
     ...(guildMembersEnabled ? [GatewayIntentBits.GuildMembers] : []),
   ],
   rest: { retries: 3, timeout: 15_000 },
+  makeCache: Options.cacheWithLimits(cacheSettings as any),
 });
 
 let discordReady = false;

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -13,3 +13,51 @@ export const DEFAULTS = {
 
 /** Valid auto-archive durations in minutes. */
 export const AUTO_ARCHIVE_DURATIONS = [60, 1440, 4320, 10080] as const;
+
+/**
+ * Bounded cache sizes for the Discord.js client.
+ *
+ * discord.js defaults to near-unlimited caches (500K guilds, 10K messages/channel,
+ * unlimited channels/roles). For an MCP server that fetches data on-demand with
+ * `cache: false` on most reads, these bounds keep memory predictable while
+ * retaining hot data for repeated tool calls within a session.
+ *
+ * Keys match the cache manager names used by Options.cacheWithLimits().
+ * Non-configurable caches (GuildManager, ChannelManager, RoleManager) are
+ * commented out in discord.js's Caches interface but still use the makeCache
+ * factory at runtime — they are included here and cast at the call site.
+ *
+ * Sizes are intentionally tight — the MCP request/response cycle is stateless,
+ * so cache hits across calls are rare. LRU eviction handles the rest.
+ */
+export const CACHE_LIMITS = {
+  // Non-configurable via CacheWithLimitsOptions (commented out in Caches interface)
+  GuildManager: 100,
+  ChannelManager: 100,
+  RoleManager: 200,
+  // Configurable caches
+  MessageManager: 1000,
+  GuildMessageManager: 1000,
+  GuildMemberManager: 500,
+  PresenceManager: 0,
+  GuildBanManager: 100,
+  GuildEmojiManager: 100,
+  GuildStickerManager: 100,
+  GuildScheduledEventManager: 100,
+  ThreadManager: 100,
+  ThreadMemberManager: 100,
+  ReactionManager: 0,
+  ReactionUserManager: 0,
+  StageInstanceManager: 100,
+  VoiceStateManager: 100,
+  UserManager: 100,
+  EntitlementManager: 100,
+  AutoModerationRuleManager: 0,
+  ApplicationCommandManager: 100,
+  ApplicationEmojiManager: 100,
+  BaseGuildEmojiManager: 100,
+  GuildInviteManager: 100,
+  DMMessageManager: 100,
+  GuildForumThreadManager: 100,
+  GuildTextThreadManager: 100,
+} as const;

--- a/src/tools/messages.ts
+++ b/src/tools/messages.ts
@@ -111,7 +111,7 @@ const tools = [
     }),
     handle: async ({ channel_id, message_id, content }) => {
       const channel = await getTextChannel(channel_id);
-      const target = await channel.messages.fetch(message_id);
+      const target = await channel.messages.fetch({ message: message_id, cache: false });
       const sent = await target.reply(content);
       return {
         content: [
@@ -149,7 +149,7 @@ const tools = [
     }),
     handle: async ({ channel_id, message_id, content }) => {
       const channel = await getTextChannel(channel_id);
-      const msg = await channel.messages.fetch(message_id);
+      const msg = await channel.messages.fetch({ message: message_id, cache: false });
       if (msg.author.id !== discord.user?.id)
         throw new Error("Can only edit messages sent by the bot.");
       const edited = await msg.edit(content);
@@ -180,7 +180,7 @@ const tools = [
     }),
     handle: async ({ channel_id, message_id, emoji }) => {
       const channel = await getTextChannel(channel_id);
-      const msg = await channel.messages.fetch(message_id);
+      const msg = await channel.messages.fetch({ message: message_id, cache: false });
       await msg.react(emoji);
       return {
         content: [
@@ -224,7 +224,7 @@ const tools = [
       const channel = await getTextChannel(channel_id);
       const duration = auto_archive_duration;
       if (message_id) {
-        const msg = await channel.messages.fetch(message_id);
+        const msg = await channel.messages.fetch({ message: message_id, cache: false });
         const thread = await msg.startThread({ name, autoArchiveDuration: duration });
         return {
           content: [
@@ -341,7 +341,7 @@ const tools = [
     }),
     handle: async ({ channel_id, message_id, ...embedArgs }) => {
       const channel = await getTextChannel(channel_id);
-      const msg = await channel.messages.fetch(message_id);
+      const msg = await channel.messages.fetch({ message: message_id, cache: false });
       if (msg.author.id !== discord.user?.id)
         throw new Error("Can only edit embeds sent by the bot.");
       await msg.edit({ embeds: [buildEmbed(embedArgs)] });
@@ -402,8 +402,7 @@ const tools = [
     }),
     handle: async ({ channel_id, message_id, reason }) => {
       const channel = await getTextChannel(channel_id);
-      await channel.messages.fetch(message_id);
-      // msg.delete() cannot carry an audit-log reason; the raw REST call sets X-Audit-Log-Reason.
+      const msg = await channel.messages.fetch({ message: message_id, cache: false });
       await discord.rest.delete(Routes.channelMessage(channel.id, message_id), { reason });
       return { content: [{ type: "text", text: `✅ Message ${message_id} deleted.` }] };
     },
@@ -428,7 +427,7 @@ const tools = [
     }),
     handle: async ({ channel_id, message_id, pin }) => {
       const channel = await getTextChannel(channel_id);
-      const msg = await channel.messages.fetch(message_id);
+      const msg = await channel.messages.fetch({ message: message_id, cache: false });
       if (pin) {
         await msg.pin();
       } else {
@@ -489,7 +488,7 @@ const tools = [
         throw new Error(
           "Channel is not an announcement channel — only announcement-channel messages can be published.",
         );
-      const msg = await channel.messages.fetch(message_id);
+      const msg = await channel.messages.fetch({ message: message_id, cache: false });
       try {
         await msg.crosspost();
       } catch (err) {
@@ -541,7 +540,7 @@ const tools = [
     }),
     handle: async ({ channel_id, message_id, emoji, user_id }) => {
       const channel = await getTextChannel(channel_id);
-      const msg = await channel.messages.fetch(message_id);
+      const msg = await channel.messages.fetch({ message: message_id, cache: false });
       if (!emoji) {
         await msg.reactions.removeAll();
         return {
@@ -596,7 +595,7 @@ const tools = [
     }),
     handle: async ({ channel_id, message_id, emoji, limit }) => {
       const channel = await getTextChannel(channel_id);
-      const msg = await channel.messages.fetch(message_id);
+      const msg = await channel.messages.fetch({ message: message_id, cache: false });
       const reaction = findReaction(msg, emoji);
       if (!reaction)
         throw new Error(`No reaction found for emoji "${emoji}" on message ${msg.id}.`);
@@ -653,7 +652,7 @@ const tools = [
     }),
     handle: async ({ channel_id, message_id, target_channel_id }) => {
       const channel = await getTextChannel(channel_id);
-      const msg = await channel.messages.fetch(message_id);
+      const msg = await channel.messages.fetch({ message: message_id, cache: false });
       const targetChannel = await getTextChannel(target_channel_id);
       // ThreadChannel<boolean> is the abstract base for PublicThreadChannel / PrivateThreadChannel;
       // any runtime instance is one of them, but the type narrowing can't be expressed without a cast.


### PR DESCRIPTION
## Problem

The Discord.js Client in `src/client.ts` was instantiated with default cache settings. discord.js v14's `UnlimitedClientCache` uses near-unlimited caches: 500K guilds, 10K messages/channel, unlimited channels/roles/members. Combined with tools that call `guild.channels.fetch()` and `guild.members.list()` without `cache: false`, this caused ~52 GB/day growth per container — both containers exhausted 176GB RAM + swap and were killed.

## Root Cause

`client.ts` line 36-45:

```ts
export const discord = new Client({
  intents: [...],
  rest: { retries: 3, timeout: 15_000 },
  // no makeCache option — defaults to UnlimitedClientCache
});
```

Six cache offenders across four tool modules:
- `discovery.ts` — `discord_list_channels` calls `guild.channels.fetch()` (caches ALL channels)
- `discovery.ts` — `discord_find_channel_by_name` calls `guild.channels.fetch()`
- `members.ts` — `discord_list_members` calls `guild.members.list()` (caches ALL members)
- `members.ts` — `discord_search_members` calls `guild.members.search()`
- `channels.ts` — multiple tools call `discord.guilds.fetch()` (caches guilds)
- `messages.ts` — 11 single-message `fetch(message_id)` calls cache every message

## Fix

### 1. Bounded LRU caches (client.ts + constants.ts)

Added `CACHE_LIMITS` with tight bounds for all 27 cache manager types and configured them via `Options.cacheWithLimits()`:

| Cache | Max | Rationale |
|-------|-----|-----------|
| GuildManager | 100 | Most bots are in <100 servers |
| ChannelManager | 100 | Tight bound; channels fetched on-demand |
| MessageManager | 1000 | MCP fetches with cache:false; hot data only |
| GuildMemberManager | 500 | Pagination used for large member lists |
| RoleManager | 200 | Typical server has <200 roles |
| ThreadManager | 100 | Threads are ephemeral |
| PresenceManager | 0 | Disabled — not needed for MCP |
| ReactionManager | 0 | Disabled — not needed for MCP |
| AutoModerationRuleManager | 0 | Disabled — not needed for MCP |

All other caches: 100. LRU eviction handles overflow.

**Non-configurable caches**: `GuildManager`, `ChannelManager`, `RoleManager` are commented out in discord.js's `Caches` interface but still use the `makeCache` factory at runtime. Included via `as any` cast.

### 2. cache: false on single-message fetches (messages.ts)

All 11 `channel.messages.fetch(message_id)` calls changed to `channel.messages.fetch({ message: message_id, cache: false })`.

### 3. Dockerfile.discord-mcp

Updated to build from fork source (`git clone` + `npx tsc` + symlink) instead of `npm install -g @pasympa/discord-mcp` from npm.

## Verification

- TypeScript compiles cleanly (`npx tsc --noEmit` — zero errors)
- Both containers running at ~40MB each (well under 1GB `mem_limit` safety net)
- No EPIPE errors, no crash loops

## Upstream PR

Fixes the memory leak described in the issue. Once merged, the local Dockerfile can switch back to `npm install -g @pasympa/discord-mcp`.

```diff
- new Client({ intents: [...], rest: {...} })
+ new Client({ intents: [...], rest: {...}, makeCache: Options.cacheWithLimits(cacheSettings) })
```