### PR TITLE
fix: stop unbounded cache growth in long-running servers

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -4,9 +4,11 @@ import {
   Events,
   GatewayIntentBits,
   GuildChannel,
+  Options,
   PermissionsBitField,
   type GuildTextBasedChannel,
 } from "discord.js";
+import { SWEEP } from "./constants.js";
 
 /**
  * Initializes the Discord.js client with the gateway intents (privileged ones
@@ -34,14 +36,30 @@ const messageContentEnabled = envEnabled("DISCORD_MESSAGE_CONTENT");
 const guildMembersEnabled = envEnabled("DISCORD_GUILD_MEMBERS");
 
 export const discord = new Client({
+  // No GuildMessages: nothing consumes MessageCreate, yet it caches every message plus
+  // its author. GuildMembers must stay — GUILD_MEMBER_REMOVE is the only eviction event.
   intents: [
     GatewayIntentBits.Guilds,
-    GatewayIntentBits.GuildMessages,
     GatewayIntentBits.GuildScheduledEvents,
     ...(messageContentEnabled ? [GatewayIntentBits.MessageContent] : []),
     ...(guildMembersEnabled ? [GatewayIntentBits.GuildMembers] : []),
   ],
   rest: { retries: 3, timeout: 15_000 },
+  sweepers: {
+    ...Options.DefaultSweeperSettings,
+    messages: SWEEP.messages,
+    threads: SWEEP.threads,
+    users: {
+      interval: SWEEP.users.interval,
+      filter: () => (user) => user.id !== user.client.user?.id,
+    },
+    guildMembers: {
+      interval: SWEEP.guildMembers.interval,
+      filter: () => (member) => member.id !== member.client.user?.id,
+    },
+    // Nothing reads guild.invites.cache back, and fetch() never clears stale entries.
+    invites: { interval: SWEEP.invites.interval, filter: () => () => true },
+  },
 });
 
 let discordReady = false;
@@ -77,30 +95,41 @@ export async function ensureConnected(): Promise<void> {
     throw new Error("DISCORD_TOKEN is required. Set it in your MCP client config or a .env file.");
   }
 
+  // Cleared only once the attempt settles: a second login replays every guild into the caches.
   if (!loginPromise) {
-    loginPromise = new Promise<void>((resolve, reject) => {
-      const onReady = () => {
-        clearTimeout(timer);
-        discordReady = true;
-        console.error(`✅  Discord bot connected as ${discord.user?.tag}`);
-        resolve();
-      };
-      const timer = setTimeout(() => {
-        discord.off(Events.ClientReady, onReady);
-        loginPromise = null;
-        reject(
-          new Error(
-            `Discord did not reach READY within ${LOGIN_TIMEOUT_MS / 1000}s. Check the token and that the Server Members / Message Content privileged intents are enabled in the Developer Portal, or disable them via DISCORD_GUILD_MEMBERS=false / DISCORD_MESSAGE_CONTENT=false.`,
-          ),
-        );
-      }, LOGIN_TIMEOUT_MS);
-      discord.once(Events.ClientReady, onReady);
-      discord.login(DISCORD_TOKEN).catch((err) => {
-        clearTimeout(timer);
-        discord.off(Events.ClientReady, onReady);
-        loginPromise = null;
-        reject(new Error(`Discord login failed: ${err.message}`));
+    loginPromise = (async () => {
+      let timer: NodeJS.Timeout | undefined;
+      let onReady!: () => void;
+      const ready = new Promise<void>((resolve, reject) => {
+        onReady = () => {
+          clearTimeout(timer);
+          resolve();
+        };
+        timer = setTimeout(() => {
+          discord.off(Events.ClientReady, onReady);
+          reject(
+            new Error(
+              `Discord did not reach READY within ${LOGIN_TIMEOUT_MS / 1000}s. Check the token and that the Server Members / Message Content privileged intents are enabled in the Developer Portal, or disable them via DISCORD_GUILD_MEMBERS=false / DISCORD_MESSAGE_CONTENT=false.`,
+            ),
+          );
+        }, LOGIN_TIMEOUT_MS);
+        discord.once(Events.ClientReady, onReady);
       });
+      ready.catch(() => {});
+
+      try {
+        await discord.login(DISCORD_TOKEN);
+      } catch (err) {
+        clearTimeout(timer);
+        discord.off(Events.ClientReady, onReady);
+        throw new Error(`Discord login failed: ${(err as Error).message}`, { cause: err });
+      }
+      await ready;
+      discordReady = true;
+      console.error(`✅  Discord bot connected as ${discord.user?.tag}`);
+    })();
+    loginPromise.catch(() => {
+      loginPromise = null;
     });
   }
 
@@ -136,8 +165,8 @@ export function assertAllowedGuild(guildId: string | null | undefined): void {
 }
 
 /** Fetches a channel and enforces the guild allow-list before returning it. */
-export async function fetchChannelChecked(channelId: string) {
-  const channel = await discord.channels.fetch(channelId);
+export async function fetchChannelChecked(channelId: string, force = false) {
+  const channel = await discord.channels.fetch(channelId, { force });
   if (channel && "guildId" in channel) assertAllowedGuild(channel.guildId);
   return channel;
 }

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -13,3 +13,16 @@ export const DEFAULTS = {
 
 /** Valid auto-archive durations in minutes. */
 export const AUTO_ARCHIVE_DURATIONS = [60, 1440, 4320, 10080] as const;
+
+/**
+ * Sweep intervals and lifetimes, in seconds. Sweepers rather than `makeCache` limits:
+ * bounding GuildManager, ChannelManager, GuildChannelManager, RoleManager or
+ * PermissionOverwriteManager breaks them (UnsupportedCacheOverwriteWarning).
+ */
+export const SWEEP = {
+  messages: { interval: 300, lifetime: 900 },
+  users: { interval: 600 },
+  guildMembers: { interval: 900 },
+  threads: { interval: 600, lifetime: 3600 },
+  invites: { interval: 900 },
+} as const;

--- a/src/tools/forums.ts
+++ b/src/tools/forums.ts
@@ -30,7 +30,8 @@ async function getForumChannel(channelId: string): Promise<ForumChannel> {
  * Fetches a channel by ID and guarantees it is a thread channel.
  */
 async function getThreadChannel(id: string): Promise<ThreadChannel> {
-  const channel = await fetchChannelChecked(id);
+  // Forced: messageCount is gateway bookkeeping, and GuildMessages is no longer requested.
+  const channel = await fetchChannelChecked(id, true);
   if (!channel || !channel.isThread())
     throw new Error(`Channel ${id} is not a thread or doesn't exist.`);
   return channel as ThreadChannel;

--- a/src/tools/permissions.ts
+++ b/src/tools/permissions.ts
@@ -218,9 +218,11 @@ const tools = [
           });
         }
       });
-      await Promise.all(
+      // From the fetch results, not the cache: a sweep can fire before the read-back.
+      const fetched = await Promise.all(
         [...memberIdsNeeded].map((id) => guild.members.fetch(id).catch(() => null)),
       );
+      const memberTags = new Map(fetched.filter((m) => m !== null).map((m) => [m.id, m.user.tag]));
       const report: Record<string, unknown>[] = [];
       guild.channels.cache
         .filter((c) => c instanceof GuildChannel)
@@ -230,7 +232,7 @@ const tools = [
             const isRole = ow.type === 0;
             const entity = isRole
               ? (guild.roles.cache.get(ow.id)?.name ?? ow.id)
-              : (guild.members.cache.get(ow.id)?.user.tag ?? ow.id);
+              : (memberTags.get(ow.id) ?? ow.id);
             return {
               entity,
               type: isRole ? "role" : "member",

--- a/src/tools/roles.ts
+++ b/src/tools/roles.ts
@@ -48,6 +48,7 @@ const tools = [
     handle: async ({ guild_id }) => {
       const guild = await discord.guilds.fetch(guild_id);
       const roles = await guild.roles.fetch();
+      const counts = await guild.roles.fetchMemberCounts();
       const result = [...roles.values()]
         .filter((r) => r.name !== "@everyone")
         .sort((a, b) => b.position - a.position)
@@ -56,7 +57,7 @@ const tools = [
           name: r.name,
           color: r.hexColor,
           position: r.position,
-          memberCount: r.members.size,
+          memberCount: counts.get(r.id) ?? 0,
           permissions: serializePermissions(r.permissions),
           hoist: r.hoist,
           mentionable: r.mentionable,
@@ -246,23 +247,24 @@ const tools = [
     handle: async ({ guild_id, role_id }) => {
       const guild = await discord.guilds.fetch(guild_id);
       const role = await fetchRole(guild, role_id);
-      // No "members of a role" endpoint exists, so populate the cache then filter (1000/page max).
+      // No "members of a role" endpoint exists, so page the member list and filter
+      // (1000/page max), accumulating per page — a sweep can empty the cache mid-loop.
       const MAX_PAGES = 20;
       let after: string | undefined;
       let truncated = true;
+      const members: { id: string; username: string; nickname: string | null }[] = [];
       for (let i = 0; i < MAX_PAGES; i++) {
         const page = await guild.members.list({ limit: 1000, after });
+        for (const m of page.values()) {
+          if (m.roles.cache.has(role.id))
+            members.push({ id: m.id, username: m.user.tag, nickname: m.nickname });
+        }
         if (page.size < 1000) {
           truncated = false;
           break;
         }
         after = page.lastKey();
       }
-      const members = role.members.map((m) => ({
-        id: m.id,
-        username: m.user.tag,
-        nickname: m.nickname,
-      }));
       return structured({
         members,
         truncated,

--- a/test/cache-growth.test.ts
+++ b/test/cache-growth.test.ts
@@ -1,0 +1,120 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import "./env-setup.js";
+import { discord } from "../src/client.js";
+
+/** Assertions are on cache sizes, never heap bytes: GC timing makes byte counts flaky. */
+
+type Adder = { _add: (...args: unknown[]) => unknown };
+const asAdder = (manager: unknown) => manager as unknown as Adder;
+
+const GUILD_ID = "100000000000000001";
+const rawGuild = {
+  id: GUILD_ID,
+  name: "test-guild",
+  owner_id: "1",
+  afk_timeout: 300,
+  verification_level: 0,
+  default_message_notifications: 0,
+  explicit_content_filter: 0,
+  roles: [
+    {
+      id: GUILD_ID,
+      name: "@everyone",
+      color: 0,
+      hoist: false,
+      position: 0,
+      permissions: "0",
+      managed: false,
+      mentionable: false,
+      flags: 0,
+    },
+  ],
+  emojis: [],
+  features: [],
+  mfa_level: 0,
+  system_channel_flags: 0,
+  joined_at: new Date(0).toISOString(),
+  large: false,
+  unavailable: false,
+  member_count: 1,
+  voice_states: [],
+  members: [],
+  channels: [],
+  threads: [],
+  presences: [],
+  stage_instances: [],
+  guild_scheduled_events: [],
+  stickers: [],
+  premium_tier: 0,
+  preferred_locale: "en-US",
+  nsfw_level: 0,
+};
+
+const rawUser = (n: number) => ({
+  id: String(1700000000000000000n + BigInt(n)),
+  username: `user_${n}`,
+  discriminator: "0",
+  global_name: null,
+  avatar: null,
+  bot: false,
+});
+
+const guild = asAdder(discord.guilds)._add(rawGuild) as {
+  members: unknown;
+  id: string;
+};
+
+test("the caches tool calls fill are fully reclaimed by the configured sweepers", () => {
+  const N = 5000;
+  for (let i = 0; i < N; i++) {
+    asAdder(discord.users)._add(rawUser(i));
+    asAdder(guild.members)._add({
+      user: rawUser(i),
+      roles: [],
+      joined_at: new Date(0).toISOString(),
+      deaf: false,
+      mute: false,
+      flags: 0,
+    });
+  }
+
+  const members = guild.members as { cache: { size: number } };
+  assert.ok(discord.users.cache.size >= N, "synthetic users should be cached");
+  assert.ok(members.cache.size >= N, "synthetic members should be cached");
+
+  // These take the predicate; the config holds a factory. Pass the factory itself and
+  // every entry matches, so the assertion passes even when the filter sweeps nothing.
+  const sweepers = discord.options.sweepers as unknown as {
+    users: { filter: () => (v: unknown) => boolean };
+    guildMembers: { filter: () => (v: unknown) => boolean };
+  };
+  discord.sweepers.sweepUsers(sweepers.users.filter());
+  discord.sweepers.sweepGuildMembers(sweepers.guildMembers.filter());
+
+  assert.equal(discord.users.cache.size, 0, "every swept user should be evicted");
+  assert.equal(members.cache.size, 0, "every swept member should be evicted");
+});
+
+test("a repeated entity is deduplicated rather than accumulated", () => {
+  const before = discord.users.cache.size;
+  for (let i = 0; i < 1000; i++) asAdder(discord.users)._add(rawUser(7));
+  assert.equal(
+    discord.users.cache.size,
+    before + 1,
+    "re-adding the same id must not grow the cache",
+  );
+  discord.sweepers.sweepUsers(() => true);
+});
+
+test("the message cache stays bounded per channel", () => {
+  const cache = discord.options.makeCache(
+    { name: "MessageManager" } as never,
+    undefined as never,
+    { name: "MessageManager" } as never,
+  ) as unknown as { maxSize?: number };
+  assert.ok(
+    typeof cache.maxSize === "number" && cache.maxSize > 0,
+    "MessageManager must keep a finite per-channel bound",
+  );
+});

--- a/test/cache-hygiene.test.ts
+++ b/test/cache-hygiene.test.ts
@@ -1,0 +1,155 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { GatewayIntentBits } from "discord.js";
+
+import "./env-setup.js";
+import { discord, ensureConnected } from "../src/client.js";
+
+const PROTECTED_MANAGERS = [
+  "GuildManager",
+  "ChannelManager",
+  "GuildChannelManager",
+  "RoleManager",
+  "PermissionOverwriteManager",
+];
+
+const intentBits = () => {
+  const intents = discord.options.intents as unknown as { bitfield?: bigint };
+  return BigInt(intents.bitfield ?? (discord.options.intents as unknown as bigint));
+};
+
+const hasIntent = (bit: number) => (intentBits() & BigInt(bit)) !== 0n;
+
+test("GuildMessages is not requested — nothing consumes MessageCreate and it caches every author", () => {
+  assert.equal(hasIntent(GatewayIntentBits.GuildMessages), false);
+});
+
+test("Guilds stays requested — the guild/channel/role caches every tool reads depend on it", () => {
+  assert.equal(hasIntent(GatewayIntentBits.Guilds), true);
+});
+
+test("protected managers keep an unlimited Collection", () => {
+  for (const name of PROTECTED_MANAGERS) {
+    const cache = discord.options.makeCache(
+      { name } as never,
+      undefined as never,
+      { name } as never,
+    );
+    assert.equal(
+      cache.constructor.name,
+      "Collection",
+      `${name} must stay a plain Collection: bounding it emits UnsupportedCacheOverwriteWarning and truncates tool output`,
+    );
+  }
+});
+
+test("ReactionManager stays unlimited — findReaction resolves emoji through its cache", () => {
+  const cache = discord.options.makeCache(
+    { name: "ReactionManager" } as never,
+    undefined as never,
+    { name: "ReactionManager" } as never,
+  );
+  assert.equal(cache.constructor.name, "Collection");
+});
+
+test("the unbounded caches this server fills are swept, often enough to matter", () => {
+  const sweepers = discord.options.sweepers as Record<
+    string,
+    { interval?: number; lifetime?: number } | undefined
+  >;
+  // Upper bounds, not just "> 0": discord.js ships a default threads sweeper, so a bare
+  // presence check stays green when this whole config is deleted.
+  const required = {
+    users: { maxInterval: 900 },
+    guildMembers: { maxInterval: 1800 },
+    messages: { maxInterval: 600, maxLifetime: 1800 },
+    threads: { maxInterval: 900, maxLifetime: 7200 },
+    invites: { maxInterval: 1800 },
+  } as const;
+
+  for (const [key, bound] of Object.entries(required)) {
+    const cfg = sweepers[key];
+    assert.ok(cfg, `no ${key} sweeper configured`);
+    assert.ok(
+      typeof cfg.interval === "number" && cfg.interval > 0 && cfg.interval <= bound.maxInterval,
+      `${key} sweeper interval must be in (0, ${bound.maxInterval}]s, got ${cfg.interval}`,
+    );
+    if ("maxLifetime" in bound) {
+      assert.ok(
+        typeof cfg.lifetime === "number" && cfg.lifetime > 0 && cfg.lifetime <= bound.maxLifetime,
+        `${key} sweeper lifetime must be in (0, ${bound.maxLifetime}]s, got ${cfg.lifetime}`,
+      );
+    }
+  }
+});
+
+test("the user and member sweep filters spare the bot's own entry", () => {
+  const sweepers = discord.options.sweepers as unknown as {
+    users: { filter: () => (u: { id: string; client: { user: { id: string } } }) => boolean };
+    guildMembers: {
+      filter: () => (m: { id: string; client: { user: { id: string } } }) => boolean;
+    };
+  };
+  const self = { id: "42", client: { user: { id: "42" } } };
+  const other = { id: "99", client: { user: { id: "42" } } };
+
+  assert.equal(sweepers.users.filter()(self), false);
+  assert.equal(sweepers.users.filter()(other), true);
+  assert.equal(sweepers.guildMembers.filter()(self), false);
+  assert.equal(sweepers.guildMembers.filter()(other), true);
+});
+
+test("every sweep filter actually evicts something", () => {
+  // null makes discord.js skip the sweep; false never evicts. Both look armed.
+  const sweepers = discord.options.sweepers as unknown as Record<
+    string,
+    { filter?: () => ((v: unknown) => boolean) | null } | undefined
+  >;
+  for (const key of ["users", "guildMembers", "invites"]) {
+    const predicate = sweepers[key]?.filter?.();
+    assert.equal(typeof predicate, "function", `${key} filter must return a predicate, not null`);
+  }
+  assert.equal(
+    sweepers.invites!.filter!()!({ id: "1" }),
+    true,
+    "the invites sweeper must evict cached invites",
+  );
+});
+
+test("a failed login leaves no ClientReady listener behind", async () => {
+  const original = discord.login.bind(discord);
+  discord.login = async () => {
+    throw new Error("An invalid token was provided.");
+  };
+  try {
+    for (let i = 0; i < 15; i++) await ensureConnected().catch(() => {});
+    assert.equal(
+      discord.listenerCount("clientReady"),
+      0,
+      "each failed login must remove the listener it registered",
+    );
+  } finally {
+    discord.login = original;
+  }
+});
+
+test("concurrent callers share one login attempt", async () => {
+  const original = discord.login.bind(discord);
+  let calls = 0;
+  discord.login = async () => {
+    calls++;
+    await new Promise((r) => setTimeout(r, 10));
+    throw new Error("An invalid token was provided.");
+  };
+  try {
+    await Promise.all([
+      ensureConnected().catch(() => {}),
+      ensureConnected().catch(() => {}),
+      ensureConnected().catch(() => {}),
+    ]);
+    assert.equal(calls, 1, "a second login respawns the shard and replays every guild");
+    assert.equal(discord.listenerCount("clientReady"), 0);
+  } finally {
+    discord.login = original;
+  }
+});

--- a/test/env-setup.ts
+++ b/test/env-setup.ts
@@ -1,0 +1,3 @@
+// src/client.ts captures DISCORD_TOKEN at import time. Login-path tests import this
+// first so they reach that code in CI, where no token exists; they all stub login.
+process.env.DISCORD_TOKEN ??= "test-token-login-is-stubbed";


### PR DESCRIPTION
## Problem

A deployment reported ~52 GB/day of RSS growth per container until the OOM killer fired. Reported by @Quentin-M in #89, which this supersedes.

## Root causes

Three, each verified against the discord.js 14.27.0 source and measured:

1. **A gateway firehose with no consumer.** The client requested `GuildMessages`, but nothing in the codebase subscribes to `MessageCreate`. discord.js caches arriving messages regardless of listeners (`actions/MessageCreate.js:25` runs before the emit on `:33`), and `Message._patch` caches the author `User` (`Message.js:103`) and `GuildMember` (`:342`) with a hard-coded `true` — so `cache: false` on a fetch cannot prevent those writes.

2. **No sweepers.** `Options.DefaultSweeperSettings` covers only `threads`. `client.users` and `guild.members` had neither a cache limit nor an eviction path. Measured at 663 bytes retained per distinct user, for the life of the process.

3. **A re-login storm.** `ensureConnected()`'s 30s READY timeout cleared `loginPromise` while `discord.login()` was still in flight, so every subsequent tool call started another login — each tearing down and respawning the shard, replaying every guild back into the caches.

Note that messages were never the unbounded part: `DefaultMakeCacheSettings` is `{ MessageManager: 200 }`, already a per-channel bound.

## Fix

Sweepers, not `makeCache` limits. `GuildManager`, `ChannelManager`, `GuildChannelManager`, `RoleManager` and `PermissionOverwriteManager` emit `UnsupportedCacheOverwriteWarning` and lose functionality when bounded, and several tools read them directly.

- `src/client.ts` — drop `GuildMessages`; add `users`, `guildMembers`, `messages` and `invites` sweepers and tighten `threads`; serialise login so the slot clears only once an attempt settles. `GuildMembers` stays deliberately: it carries `GUILD_MEMBER_REMOVE`, the only event that evicts from `guild.members`.
- `src/tools/roles.ts` — `list_roles` takes `memberCount` from `fetchMemberCounts()` (new in discord.js 14.27.0, closes #82) instead of counting a swept cache; `get_role_members` accumulates per page instead of reading the cache back after paging.
- `src/tools/permissions.ts` — `audit_permissions` resolves member names from the fetch results, closing a sweep race.
- `src/tools/forums.ts` — thread fetches are forced, since `messageCount` was maintained by gateway bookkeeping that no longer arrives.

## Verification

Live, in-process against a real guild, 25 rounds / 275 tool calls — every cache flat:

```
 rnd   users  members  channels  threads  dms  messages  invites  roles  overwrites
   1      55       56        68        0    0         0        2     24         239
  25      55       56        68        0    0         0        2     24         239
```

Live A/B soak over the MCP stdio server, 30 rounds each: pre-fix second-half slope 302 KB/round and never plateaus; fixed 59 KB/round and oscillates in a 1.8 MB band.

10 regression tests in `test/cache-hygiene.test.ts` and `test/cache-growth.test.ts`. Mutation-tested: re-adding the intent, neutering either sweep filter, removing or nulling the `invites` sweeper, deleting the `threads` sweeper, blowing the intervals out, and reintroducing a listener leak all turn CI red.

## Not addressed

- `get_server_stats`'s `botsInCache` / `humans` remain cache-scoped — unchanged from current behaviour, and correcting it means a tool-description edit.
- Active threads plateau at Discord's per-guild cap and are evicted on archive; sweeping live ones would silently change channel counts.
- No tool `description` strings change in this PR.
