### PR TITLE
chore: em dash cleanup in comments, changelog entry for the cache fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## [Unreleased]
+
+### Fixed
+
+- Long-running servers no longer grow without bound. The `GuildMessages` intent is no longer requested (nothing subscribes to `MessageCreate`, yet it cached every message together with its author `User` and `GuildMember`), sweepers are configured for the caches tool calls fill (`users`, `guildMembers`, `messages`, `invites`, plus a tightened `threads`), and a login timeout can no longer start a second login that respawns the shard and replays every guild into the caches. Reported by [@Quentin-M](https://github.com/Quentin-M) in [#89](https://github.com/PaSympa/discord-mcp/pull/89), whose production data (~52 GB/day per container) made the diagnosis possible
+- `discord_list_roles` reports real member counts from the API instead of counting whatever happened to be cached, which was frequently zero (closes [#82](https://github.com/PaSympa/discord-mcp/issues/82))
+- `discord_audit_permissions` resolves member names from its own fetch results, so a cache sweep can no longer blank them mid-report
+- `discord_get_role_members` accumulates each page as it is fetched instead of re-reading a cache that a sweep can empty between pages
+- `discord_get_forum_post` reports a current message count instead of a stale one
+
 ## [2.1.0] - 2026-07-13
 
 ### Changed

--- a/src/client.ts
+++ b/src/client.ts
@@ -37,7 +37,7 @@ const guildMembersEnabled = envEnabled("DISCORD_GUILD_MEMBERS");
 
 export const discord = new Client({
   // No GuildMessages: nothing consumes MessageCreate, yet it caches every message plus
-  // its author. GuildMembers must stay — GUILD_MEMBER_REMOVE is the only eviction event.
+  // its author. GuildMembers must stay: GUILD_MEMBER_REMOVE is the only eviction event.
   intents: [
     GatewayIntentBits.Guilds,
     GatewayIntentBits.GuildScheduledEvents,
@@ -149,7 +149,7 @@ export function allowListActive(): boolean {
   return allowedGuilds().length > 0;
 }
 
-/** True if the guild is in DISCORD_ALLOWED_GUILDS — or when no allow-list is configured (empty list allows all guilds). */
+/** True if the guild is in DISCORD_ALLOWED_GUILDS, or when no allow-list is configured (empty list allows all guilds). */
 export function isGuildAllowed(guildId: string): boolean {
   const list = allowedGuilds();
   return list.length === 0 || list.includes(guildId);
@@ -165,7 +165,7 @@ export function assertAllowedGuild(guildId: string | null | undefined): void {
 }
 
 /** Fetches a channel and enforces the guild allow-list before returning it. */
-export async function fetchChannelChecked(channelId: string, force = false) {
+export async function fetchChannelChecked(channelId: string, { force = false } = {}) {
   const channel = await discord.channels.fetch(channelId, { force });
   if (channel && "guildId" in channel) assertAllowedGuild(channel.guildId);
   return channel;

--- a/src/embeds.ts
+++ b/src/embeds.ts
@@ -3,7 +3,7 @@ import { z } from "zod";
 import { httpUrl } from "./tools/define.js";
 
 /**
- * Zod fields of a rich embed — spread into a tool's `z.object({...})` schema.
+ * Zod fields of a rich embed: spread into a tool's `z.object({...})` schema.
  * The single source of truth for embed input across the message, DM, and webhook tools.
  */
 export const embedFieldsShape = {
@@ -47,12 +47,12 @@ export const embedFieldsShape = {
 /** Schema for a single embed object (e.g. an item of `discord_send_multiple_embeds`). */
 export const embedObjectSchema = z.strictObject(embedFieldsShape);
 
-/** Up to 10 embeds — Discord's per-message cap, enforced at parse time and advertised as maxItems. */
+/** Up to 10 embeds: Discord's per-message cap, enforced at parse time and advertised as maxItems. */
 export const embedArraySchema = z
   .array(embedObjectSchema)
   .max(10, "Discord allows a maximum of 10 embeds per message.");
 
-/** Validated embed input — the typed shape `buildEmbed` consumes. */
+/** Validated embed input: the typed shape `buildEmbed` consumes. */
 export type EmbedInput = z.infer<typeof embedObjectSchema>;
 
 /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 /**
- * Discord MCP Server — stdio entry point. Server construction lives in
+ * Discord MCP Server: stdio entry point. Server construction lives in
  * `server.ts` (testable via in-memory transport); the Discord client in `client.ts`.
  */
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";

--- a/src/server.ts
+++ b/src/server.ts
@@ -12,7 +12,7 @@ import { getAllDefinitions, handleTool, hasTool } from "./tools/index.js";
 
 /**
  * Builds the MCP server with the tool list/call handlers wired in, leaving the
- * transport to the caller — stdio in production, in-memory in tests.
+ * transport to the caller: stdio in production, in-memory in tests.
  */
 export function createServer(version: string): Server {
   const server = new Server({ name: "discord-mcp", version }, { capabilities: { tools: {} } });

--- a/src/tools/define.ts
+++ b/src/tools/define.ts
@@ -89,12 +89,12 @@ function strictInput<S extends z.ZodType>(schema: S): S {
 /**
  * Declares one tool from a single source of truth: the zod `schema` derives the
  * client-facing `inputSchema` and validates incoming args, so `handle` receives
- * values already typed and checked — no `as` casts, no schema/handler drift.
+ * values already typed and checked: no `as` casts, no schema/handler drift.
  * Unknown argument keys are rejected (`additionalProperties: false`).
  * An optional `outputSchema` (a `z.object`) derives the advertised `outputSchema`
  * and checks the handler's `structuredContent` against it on the way out: a
  * conforming result is normalised (unknown keys dropped, text block regenerated to
- * match); a non-conforming one is rejected — the call returns an `isError` result
+ * match); a non-conforming one is rejected: the call returns an `isError` result
  * and the mismatch is logged, because conformance is a spec MUST and SDK clients
  * reject non-conforming results anyway.
  */

--- a/src/tools/forums.ts
+++ b/src/tools/forums.ts
@@ -30,8 +30,7 @@ async function getForumChannel(channelId: string): Promise<ForumChannel> {
  * Fetches a channel by ID and guarantees it is a thread channel.
  */
 async function getThreadChannel(id: string): Promise<ThreadChannel> {
-  // Forced: messageCount is gateway bookkeeping, and GuildMessages is no longer requested.
-  const channel = await fetchChannelChecked(id, true);
+  const channel = await fetchChannelChecked(id, { force: true });
   if (!channel || !channel.isThread())
     throw new Error(`Channel ${id} is not a thread or doesn't exist.`);
   return channel as ThreadChannel;

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -1,5 +1,5 @@
 /**
- * Tool registry — aggregates all tool modules and provides a unified interface
+ * Tool registry: aggregates all tool modules and provides a unified interface
  * for listing definitions and routing tool calls to the correct handler.
  *
  * To add a new tool module:
@@ -46,7 +46,7 @@ const allToolsets: Record<string, ToolModule> = {
 /**
  * Selects which toolsets to expose from `DISCORD_MCP_TOOLSETS` (comma-separated,
  * case-insensitive). Unset, empty, or `all` exposes everything; unknown names throw
- * at startup — a typo must not silently expose the full destructive surface.
+ * at startup: a typo must not silently expose the full destructive surface.
  */
 export function selectModules(): ToolModule[] {
   const raw = process.env.DISCORD_MCP_TOOLSETS?.trim();

--- a/src/tools/messages.ts
+++ b/src/tools/messages.ts
@@ -27,8 +27,8 @@ const messageSummary = z.object({
 /**
  * Looks up a reaction on a message by emoji argument.
  * The reaction cache is keyed by the emoji id (snowflake) for custom emoji and
- * by the raw unicode char for standard emoji — NOT by the "name:id" / "<:name:id>"
- * form the tool schema accepts — so a custom emoji is normalized to its id first.
+ * by the raw unicode char for standard emoji, NOT by the "name:id" / "<:name:id>"
+ * form the tool schema accepts, so a custom emoji is normalized to its id first.
  */
 function findReaction(msg: Message, emoji: string): MessageReaction | undefined {
   const customId = emoji.match(/^<a?:[^:]+:(\d{17,20})>$|^[^:]+:(\d{17,20})$/);

--- a/src/tools/roles.ts
+++ b/src/tools/roles.ts
@@ -248,7 +248,7 @@ const tools = [
       const guild = await discord.guilds.fetch(guild_id);
       const role = await fetchRole(guild, role_id);
       // No "members of a role" endpoint exists, so page the member list and filter
-      // (1000/page max), accumulating per page — a sweep can empty the cache mid-loop.
+      // (1000/page max), accumulating per page: a sweep can empty the cache mid-loop.
       const MAX_PAGES = 20;
       let after: string | undefined;
       let truncated = true;

--- a/src/tools/types.ts
+++ b/src/tools/types.ts
@@ -1,8 +1,8 @@
 /**
  * MCP tool behavioral hints (advisory, not guarantees). See the MCP spec
  * "tool annotations": readOnlyHint (only reads, never mutates), destructiveHint
- * (may perform irreversible updates — delete/ban/prune), idempotentHint (repeat
- * calls with same args add no effect), openWorldHint (talks to an external API —
+ * (may perform irreversible updates: delete/ban/prune), idempotentHint (repeat
+ * calls with same args add no effect), openWorldHint (talks to an external API,
  * always true here). title is a human-readable display name.
  */
 export interface ToolAnnotations {
@@ -27,7 +27,7 @@ export interface ToolDefinition {
 }
 
 /**
- * Standard response returned by every tool handler — a subset of the SDK's
+ * Standard response returned by every tool handler: a subset of the SDK's
  * `CallToolResult`. Handlers only ever emit text blocks; `structuredContent` is an
  * optional machine-readable mirror conforming to the tool's `outputSchema` when one
  * is declared. The index signature mirrors the SDK's passthrough `Result` (which

--- a/test/cache-hygiene.test.ts
+++ b/test/cache-hygiene.test.ts
@@ -20,11 +20,11 @@ const intentBits = () => {
 
 const hasIntent = (bit: number) => (intentBits() & BigInt(bit)) !== 0n;
 
-test("GuildMessages is not requested — nothing consumes MessageCreate and it caches every author", () => {
+test("GuildMessages is not requested: nothing consumes MessageCreate and it caches every author", () => {
   assert.equal(hasIntent(GatewayIntentBits.GuildMessages), false);
 });
 
-test("Guilds stays requested — the guild/channel/role caches every tool reads depend on it", () => {
+test("Guilds stays requested: the guild/channel/role caches every tool reads depend on it", () => {
   assert.equal(hasIntent(GatewayIntentBits.Guilds), true);
 });
 
@@ -43,7 +43,7 @@ test("protected managers keep an unlimited Collection", () => {
   }
 });
 
-test("ReactionManager stays unlimited — findReaction resolves emoji through its cache", () => {
+test("ReactionManager stays unlimited: findReaction resolves emoji through its cache", () => {
   const cache = discord.options.makeCache(
     { name: "ReactionManager" } as never,
     undefined as never,

--- a/test/mass-op-safety.test.ts
+++ b/test/mass-op-safety.test.ts
@@ -46,7 +46,7 @@ test("bulk_ban advertises and enforces the 200-ID Discord cap", async () => {
   );
 });
 
-test("set_nickname requires the nickname field — omission no longer silently clears", async () => {
+test("set_nickname requires the nickname field: omission no longer silently clears", async () => {
   const d = def(members, "discord_set_nickname");
   assert.ok(d.inputSchema.required?.includes("nickname"));
   await assert.rejects(


### PR DESCRIPTION
## What

- Removes em dashes from code comments, JSDoc, and test names (21 lines). Runtime strings are deliberately untouched: the `Invalid arguments` format is documented in the 2.0.0 changelog and asserted by `test/server.test.ts`, and tool descriptions must stay byte-identical between releases for the Canopii scanner.
- `fetchChannelChecked(id, { force: true })` replaces the bare-boolean second parameter, which lets the forums call site drop its explanatory comment.
- Adds the `[Unreleased]` changelog section for #90, crediting the original report.

No behavior change; 63 tests green.
