### PR TITLE
fix: fetch messages without caching so reaction reads stay fresh

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - `discord_audit_permissions` resolves member names from its own fetch results, so a cache sweep can no longer blank them mid-report
 - `discord_get_role_members` accumulates each page as it is fetched instead of re-reading a cache that a sweep can empty between pages
 - `discord_get_forum_post` reports a current message count instead of a stale one
+- Message fetches no longer populate the per-channel message cache, so `discord_get_reactions` and `discord_remove_reactions` read a fresh reaction snapshot instead of one frozen at first fetch. Contributed by [@Quentin-M](https://github.com/Quentin-M) in [#89](https://github.com/PaSympa/discord-mcp/pull/89)
 
 ## [2.1.0] - 2026-07-13
 

--- a/src/tools/dm.ts
+++ b/src/tools/dm.ts
@@ -85,7 +85,7 @@ const tools = [
     handle: async ({ user_id, message_id, content }) => {
       const user = await discord.users.fetch(user_id);
       const dm = await user.createDM();
-      const msg = await dm.messages.fetch(message_id);
+      const msg = await dm.messages.fetch({ message: message_id, cache: false });
       if (msg.author.id !== discord.user?.id)
         throw new Error("Can only edit messages sent by the bot.");
       await msg.edit(content);
@@ -116,7 +116,7 @@ const tools = [
     handle: async ({ user_id, message_id, content, ...embedArgs }) => {
       const user = await discord.users.fetch(user_id);
       const dm = await user.createDM();
-      const msg = await dm.messages.fetch(message_id);
+      const msg = await dm.messages.fetch({ message: message_id, cache: false });
       if (msg.author.id !== discord.user?.id)
         throw new Error("Can only edit embeds sent by the bot.");
       await msg.edit({
@@ -151,7 +151,7 @@ const tools = [
     handle: async ({ user_id, message_id }) => {
       const user = await discord.users.fetch(user_id);
       const dm = await user.createDM();
-      const msg = await dm.messages.fetch(message_id);
+      const msg = await dm.messages.fetch({ message: message_id, cache: false });
       if (msg.author.id !== discord.user?.id)
         throw new Error("Can only delete messages sent by the bot.");
       await msg.delete();
@@ -187,7 +187,7 @@ const tools = [
     handle: async ({ user_id, limit }) => {
       const user = await discord.users.fetch(user_id);
       const dm = await user.createDM();
-      const messages = await dm.messages.fetch({ limit });
+      const messages = await dm.messages.fetch({ limit, cache: false });
       const result = [...messages.values()]
         .sort((a, b) => a.createdTimestamp - b.createdTimestamp)
         .map((m) => ({
@@ -219,7 +219,7 @@ const tools = [
     handle: async ({ user_id, message_id, content }) => {
       const user = await discord.users.fetch(user_id);
       const dm = await user.createDM();
-      const target = await dm.messages.fetch(message_id);
+      const target = await dm.messages.fetch({ message: message_id, cache: false });
       const sent = await target.reply(content);
       return {
         content: [

--- a/src/tools/forums.ts
+++ b/src/tools/forums.ts
@@ -166,7 +166,7 @@ const tools = [
     }),
     handle: async ({ thread_id, limit }) => {
       const thread = await getThreadChannel(thread_id);
-      const messages = await thread.messages.fetch({ limit });
+      const messages = await thread.messages.fetch({ limit, cache: false });
       const result = {
         id: thread.id,
         name: thread.name,

--- a/src/tools/messages.ts
+++ b/src/tools/messages.ts
@@ -111,7 +111,7 @@ const tools = [
     }),
     handle: async ({ channel_id, message_id, content }) => {
       const channel = await getTextChannel(channel_id);
-      const target = await channel.messages.fetch(message_id);
+      const target = await channel.messages.fetch({ message: message_id, cache: false });
       const sent = await target.reply(content);
       return {
         content: [
@@ -149,7 +149,7 @@ const tools = [
     }),
     handle: async ({ channel_id, message_id, content }) => {
       const channel = await getTextChannel(channel_id);
-      const msg = await channel.messages.fetch(message_id);
+      const msg = await channel.messages.fetch({ message: message_id, cache: false });
       if (msg.author.id !== discord.user?.id)
         throw new Error("Can only edit messages sent by the bot.");
       const edited = await msg.edit(content);
@@ -180,7 +180,7 @@ const tools = [
     }),
     handle: async ({ channel_id, message_id, emoji }) => {
       const channel = await getTextChannel(channel_id);
-      const msg = await channel.messages.fetch(message_id);
+      const msg = await channel.messages.fetch({ message: message_id, cache: false });
       await msg.react(emoji);
       return {
         content: [
@@ -224,7 +224,7 @@ const tools = [
       const channel = await getTextChannel(channel_id);
       const duration = auto_archive_duration;
       if (message_id) {
-        const msg = await channel.messages.fetch(message_id);
+        const msg = await channel.messages.fetch({ message: message_id, cache: false });
         const thread = await msg.startThread({ name, autoArchiveDuration: duration });
         return {
           content: [
@@ -341,7 +341,7 @@ const tools = [
     }),
     handle: async ({ channel_id, message_id, ...embedArgs }) => {
       const channel = await getTextChannel(channel_id);
-      const msg = await channel.messages.fetch(message_id);
+      const msg = await channel.messages.fetch({ message: message_id, cache: false });
       if (msg.author.id !== discord.user?.id)
         throw new Error("Can only edit embeds sent by the bot.");
       await msg.edit({ embeds: [buildEmbed(embedArgs)] });
@@ -402,7 +402,7 @@ const tools = [
     }),
     handle: async ({ channel_id, message_id, reason }) => {
       const channel = await getTextChannel(channel_id);
-      await channel.messages.fetch(message_id);
+      await channel.messages.fetch({ message: message_id, cache: false });
       // msg.delete() cannot carry an audit-log reason; the raw REST call sets X-Audit-Log-Reason.
       await discord.rest.delete(Routes.channelMessage(channel.id, message_id), { reason });
       return { content: [{ type: "text", text: `✅ Message ${message_id} deleted.` }] };
@@ -428,7 +428,7 @@ const tools = [
     }),
     handle: async ({ channel_id, message_id, pin }) => {
       const channel = await getTextChannel(channel_id);
-      const msg = await channel.messages.fetch(message_id);
+      const msg = await channel.messages.fetch({ message: message_id, cache: false });
       if (pin) {
         await msg.pin();
       } else {
@@ -489,7 +489,7 @@ const tools = [
         throw new Error(
           "Channel is not an announcement channel — only announcement-channel messages can be published.",
         );
-      const msg = await channel.messages.fetch(message_id);
+      const msg = await channel.messages.fetch({ message: message_id, cache: false });
       try {
         await msg.crosspost();
       } catch (err) {
@@ -541,7 +541,7 @@ const tools = [
     }),
     handle: async ({ channel_id, message_id, emoji, user_id }) => {
       const channel = await getTextChannel(channel_id);
-      const msg = await channel.messages.fetch(message_id);
+      const msg = await channel.messages.fetch({ message: message_id, cache: false });
       if (!emoji) {
         await msg.reactions.removeAll();
         return {
@@ -596,7 +596,7 @@ const tools = [
     }),
     handle: async ({ channel_id, message_id, emoji, limit }) => {
       const channel = await getTextChannel(channel_id);
-      const msg = await channel.messages.fetch(message_id);
+      const msg = await channel.messages.fetch({ message: message_id, cache: false });
       const reaction = findReaction(msg, emoji);
       if (!reaction)
         throw new Error(`No reaction found for emoji "${emoji}" on message ${msg.id}.`);
@@ -653,7 +653,7 @@ const tools = [
     }),
     handle: async ({ channel_id, message_id, target_channel_id }) => {
       const channel = await getTextChannel(channel_id);
-      const msg = await channel.messages.fetch(message_id);
+      const msg = await channel.messages.fetch({ message: message_id, cache: false });
       const targetChannel = await getTextChannel(target_channel_id);
       // ThreadChannel<boolean> is the abstract base for PublicThreadChannel / PrivateThreadChannel;
       // any runtime instance is one of them, but the type narrowing can't be expressed without a cast.

--- a/test/cache-hygiene.test.ts
+++ b/test/cache-hygiene.test.ts
@@ -1,3 +1,5 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
 import { test } from "node:test";
 import assert from "node:assert/strict";
 import { GatewayIntentBits } from "discord.js";
@@ -151,5 +153,20 @@ test("concurrent callers share one login attempt", async () => {
     assert.equal(discord.listenerCount("clientReady"), 0);
   } finally {
     discord.login = original;
+  }
+});
+
+test("every message fetch declines the cache", () => {
+  // Single-message fetches are read-once: nothing in the repo reads messages.cache
+  // back, and a cached copy freezes the reaction snapshot until the sweeper runs.
+  for (const file of ["messages.ts", "dm.ts", "forums.ts"]) {
+    const src = readFileSync(join(__dirname, "..", "src", "tools", file), "utf8");
+    for (const hit of src.matchAll(/\.messages\.fetch\(/g)) {
+      const call = src.slice(hit.index, hit.index + 160);
+      assert.ok(
+        call.includes("cache: false"),
+        `${file}: ${call.split("\n")[0]} must pass cache: false`,
+      );
+    }
   }
 });


### PR DESCRIPTION
Lands the part of #89 that was correct and still unmerged, as @Quentin-M's change: `cache: false` on message fetches. His 11 call sites in `src/tools/messages.ts`, plus 6 more following the same pattern in `src/tools/dm.ts` and `src/tools/forums.ts` (17 total). The commit carries his co-author trailer.

Beyond memory hygiene this is a freshness fix: `Message#reactions` lives on the cached object, and since #90 removed the `GuildMessages` intent nothing updates a cached copy anymore. A second `discord_get_reactions` call on the same message was served the frozen snapshot for up to 15 minutes (the sweeper lifetime). With `cache: false` the copy is never stored, so `_fetchSingle` cannot short-circuit on it and every call hits the API.

Safe because nothing in the repo reads `channel.messages.cache` back (`grep -rn 'messages\.cache' src/` is empty aside from `msg.reactions.cache`, which lives on the fetched object itself, not in the channel cache). The audit-log-reason comment at the `delete_message` site is preserved. A source-scan test now enforces the invariant on every `.messages.fetch(` call.
