### PR TITLE
Add guild-wide message search

### DIFF
--- a/src/tools/messages.ts
+++ b/src/tools/messages.ts
@@ -12,7 +12,7 @@ import { z } from "zod";
 import { discord, getTextChannel, fetchChannelChecked } from "../client.js";
 import { MAX_FETCH_LIMIT, DEFAULTS, AUTO_ARCHIVE_DURATIONS } from "../constants.js";
 import { buildEmbed, embedFieldsShape, embedArraySchema } from "../embeds.js";
-import { defineModule, defineTool, snowflake, intIn, structured } from "./define.js";
+import { defineModule, defineTool, snowflake, guildId, intIn, structured } from "./define.js";
 
 const channelId = snowflake.describe("ID (snowflake) of the channel or thread.");
 const messageId = snowflake.describe("ID of the message.");
@@ -472,17 +472,11 @@ const tools = [
       "Search for messages across all channels in a guild using Discord's native search API. Returns messages matching the query with channel context. Requires READ_MESSAGE_HISTORY permission. Use discord_search_messages for channel-specific search.",
     annotations: { title: "Search guild messages", readOnlyHint: true, openWorldHint: true },
     schema: z.object({
-      guild_id: snowflake.describe("ID (snowflake) of the guild to search across all channels."),
+      guild_id: guildId,
       query: z.string().describe("Search query (case-insensitive)."),
-      channel_id: snowflake
-        .optional()
-        .describe("Optional. Restrict search to this channel ID."),
-      author_id: snowflake
-        .optional()
-        .describe("Optional. Only show messages from this user ID."),
-      limit: intIn(1, 100)
-        .default(25)
-        .describe("Max messages to return (1–100). Default 25."),
+      channel_id: snowflake.optional().describe("Optional. Restrict search to this channel ID."),
+      author_id: snowflake.optional().describe("Optional. Only show messages from this user ID."),
+      limit: intIn(1, 100).default(25).describe("Max messages to return (1–100). Default 25."),
     }),
     outputSchema: z.object({
       matches: z.array(
@@ -525,22 +519,9 @@ const tools = [
         channel_name: "",
       }));
 
-      // Resolve channel names
-      const channelIds = [...new Set(matches.map((m) => m.channel_id))];
-      const channelNames = new Map<string, string>();
-      for (const id of channelIds) {
-        try {
-          const channel = await discord.channels.fetch(id);
-          if (channel && "name" in channel) {
-            channelNames.set(id, channel.name ?? "unknown");
-          }
-        } catch {
-          channelNames.set(id, "unknown");
-        }
-      }
-
+      const guild = await discord.guilds.fetch(guild_id);
       for (const match of matches) {
-        match.channel_name = channelNames.get(match.channel_id) ?? "unknown";
+        match.channel_name = guild.channels.cache.get(match.channel_id)?.name ?? "unknown";
       }
 
       return structured({ matches });

--- a/src/tools/messages.ts
+++ b/src/tools/messages.ts
@@ -467,6 +467,86 @@ const tools = [
     },
   }),
   defineTool({
+    name: "discord_search_guild_messages",
+    description:
+      "Search for messages across all channels in a guild using Discord's native search API. Returns messages matching the query with channel context. Requires READ_MESSAGE_HISTORY permission. Use discord_search_messages for channel-specific search.",
+    annotations: { title: "Search guild messages", readOnlyHint: true, openWorldHint: true },
+    schema: z.object({
+      guild_id: snowflake.describe("ID (snowflake) of the guild to search across all channels."),
+      query: z.string().describe("Search query (case-insensitive)."),
+      channel_id: snowflake
+        .optional()
+        .describe("Optional. Restrict search to this channel ID."),
+      author_id: snowflake
+        .optional()
+        .describe("Optional. Only show messages from this user ID."),
+      limit: intIn(1, 100)
+        .default(25)
+        .describe("Max messages to return (1–100). Default 25."),
+    }),
+    outputSchema: z.object({
+      matches: z.array(
+        messageSummary.extend({
+          channel_id: z.string(),
+          channel_name: z.string(),
+        }),
+      ),
+    }),
+    handle: async ({ guild_id, query, channel_id, author_id, limit }) => {
+      const searchParams: Record<string, string> = { content: query, limit: String(limit) };
+      if (channel_id) searchParams.channel_id = channel_id;
+      if (author_id) searchParams.author_id = author_id;
+
+      const searchUrlParams = new URLSearchParams(searchParams);
+      const result = await discord.rest.get(Routes.guildMessagesSearch(guild_id), {
+        query: searchUrlParams,
+      });
+
+      const data = result as {
+        messages: Array<
+          Array<{
+            id: string;
+            content: string;
+            timestamp: string;
+            channel_id: string;
+            author: { username: string; discriminator: string };
+          }>
+        >;
+      };
+      const matches = data.messages.flat().map((m) => ({
+        id: m.id,
+        author:
+          m.author.discriminator === "0"
+            ? m.author.username
+            : `${m.author.username}#${m.author.discriminator}`,
+        content: m.content,
+        timestamp: m.timestamp,
+        channel_id: m.channel_id,
+        channel_name: "",
+      }));
+
+      // Resolve channel names
+      const channelIds = [...new Set(matches.map((m) => m.channel_id))];
+      const channelNames = new Map<string, string>();
+      for (const id of channelIds) {
+        try {
+          const channel = await discord.channels.fetch(id);
+          if (channel && "name" in channel) {
+            channelNames.set(id, channel.name ?? "unknown");
+          }
+        } catch {
+          channelNames.set(id, "unknown");
+        }
+      }
+
+      for (const match of matches) {
+        match.channel_name = channelNames.get(match.channel_id) ?? "unknown";
+      }
+
+      return structured({ matches });
+    },
+  }),
+  defineTool({
     name: "discord_crosspost_message",
     description:
       "Publish (crosspost) a message from an Announcement channel to every server that follows it. Only works in announcement channels on a message that has not already been published. Requires the Send Messages permission (and Manage Messages for messages authored by others). Returns a confirmation.",

--- a/test/server.test.ts
+++ b/test/server.test.ts
@@ -28,7 +28,7 @@ test("unknown tool is a JSON-RPC InvalidParams protocol error, not a tool result
 test("tools/list serves every definition and rejects unexpected cursors", async () => {
   const client = await connectedClient();
   const { tools } = await client.listTools();
-  assert.equal(tools.length, 97, "update this pin when adding/removing tools");
+  assert.equal(tools.length, 98, "update this pin when adding/removing tools");
   await assert.rejects(
     () => client.listTools({ cursor: "bogus" }),
     (err: unknown) => err instanceof McpError && err.code === ErrorCode.InvalidParams,


### PR DESCRIPTION
## Summary

Adds a new `discord_search_guild_messages` tool that uses Discord native guild search API (`GET /guilds/{guild.id}/messages/search`) to search across all channels in a guild.

## Changes

- New tool: `discord_search_guild_messages`
- Accepts `guild_id` and `query` (required), plus optional `channel_id`, `author_id`, and `limit`
- Returns matches with `id`, `author`, `content`, `timestamp`, `channel_id`, and `channel_name`
- Resolves channel names for each match

## Use Case

This enables searching across all channels in a server without manually looping through each channel. Useful for bots and AI agents that need to find context from conversations across multiple channels.

## Related

Closes #99