### PR TITLE
release: 2.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 
-## [Unreleased]
+## [2.1.1] - 2026-08-04
+
+### Security
+
+- npm audit is clean for the first time: the two @hono/node-server moderates accepted since June are resolved by MCP SDK 1.30.0 widening its dependency range, and six freshly published transitive advisories (undici, ip-address, fast-uri, hono, @hono/node-server, brace-expansion) are fixed within semver
 
 ### Fixed
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@pasympa/discord-mcp",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@pasympa/discord-mcp",
-      "version": "2.1.0",
+      "version": "2.1.1",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pasympa/discord-mcp",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "mcpName": "io.github.PaSympa/discord-mcp",
   "description": "A lightweight, multi-guild Discord MCP server with 95+ tools",
   "main": "dist/index.js",

--- a/server.json
+++ b/server.json
@@ -6,12 +6,12 @@
     "url": "https://github.com/PaSympa/discord-mcp",
     "source": "github"
   },
-  "version": "2.1.0",
+  "version": "2.1.1",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "@pasympa/discord-mcp",
-      "version": "2.1.0",
+      "version": "2.1.1",
       "transport": {
         "type": "stdio"
       },
@@ -27,7 +27,7 @@
     },
     {
       "registryType": "oci",
-      "identifier": "docker.io/pasympa/discord-mcp:2.1.0",
+      "identifier": "docker.io/pasympa/discord-mcp:2.1.1",
       "transport": {
         "type": "stdio"
       },


### PR DESCRIPTION
Patch release. Contents: the unbounded-cache fix (#90, reported by @Quentin-M in #89), message fetches without caching (#95, co-authored by Quentin Machu), tool-output correctness fixes (list_roles member counts closing #82, audit_permissions name resolution, get_forum_post freshness), dependency bumps (#91, #92, #93, #97, #98) and a fully clean npm audit (#96, #101). Zero tool-description changes. Merge with a MERGE COMMIT so the tagged commit reaches main.