### PR TITLE
fix: harden guild message search against the API contract

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,6 +185,8 @@ The server loads `.env` automatically via `dotenv`.
 | `DISCORD_MCP_TOOLSETS`    | `all`   | Comma-separated list of toolsets to expose, to keep the tool list small. Unset or `all` exposes every tool.                                                                                   |
 | `DISCORD_ALLOWED_GUILDS`  | all     | Comma-separated guild IDs the server may act on. When set, tool calls targeting any other guild are rejected — whether addressed by guild ID, channel ID, thread ID, webhook, or invite code. |
 
+Since 2.1.1 the server no longer requests the `GuildMessages` intent at all: nothing here subscribes to message events, and every message this server returns is fetched over REST, which connection intents do not gate. That intent used to make discord.js cache every message flowing through every channel, together with its author, which grew unbounded on a long-running server. Cache sweepers now bound what remains. `DISCORD_MESSAGE_CONTENT` therefore only affects whether the Message Content intent is requested at connect time; it does not change what any tool returns.
+
 These flags only control which gateway intents the server requests when identifying. Requesting a privileged intent that is **not** enabled in the Developer Portal makes the connection fail at the first tool call (close code `4014`) — set the flag to `false` to connect anyway.
 
 Data access is governed by the **portal toggles**, not by these flags: this server reads everything over the REST API, which Discord gates on the portal setting alone. So with the portal toggles on, setting these flags to `false` loses nothing. With a portal toggle **off**, the corresponding data is restricted regardless of the flags: message bodies come back empty (`content`, `embeds`, `attachments` — except the bot's own messages, DMs, and messages that mention the bot) and member listing fails — enable the toggle in the portal to restore it.
@@ -211,7 +213,7 @@ Data access is governed by the **portal toggles**, not by these flags: this serv
 
 ---
 
-## Available Tools (97)
+## Available Tools (98)
 
 ### Discovery & Navigation (4 tools)
 
@@ -222,28 +224,29 @@ Data access is governed by the **portal toggles**, not by these flags: this serv
 | `discord_list_channels`        | List all channels in a guild grouped by category                 |
 | `discord_find_channel_by_name` | Find a channel by name (partial match)                           |
 
-### Messages (18 tools)
+### Messages (19 tools)
 
-| Tool                            | Description                                         |
-| ------------------------------- | --------------------------------------------------- |
-| `discord_read_messages`         | Read the last N messages from a text channel        |
-| `discord_send_message`          | Send a plain text message                           |
-| `discord_reply_message`         | Reply to a specific message                         |
-| `discord_edit_message`          | Edit a message sent by the bot                      |
-| `discord_delete_message`        | Delete a specific message                           |
-| `discord_add_reaction`          | Add a reaction emoji to a message                   |
-| `discord_remove_reactions`      | Remove reactions (all, by emoji, or by user)        |
-| `discord_get_reactions`         | List users who reacted with a specific emoji        |
-| `discord_create_thread`         | Create a thread from a message or standalone        |
-| `discord_bulk_delete_messages`  | Delete multiple messages at once (2-100)            |
-| `discord_send_embed`            | Send a rich embed with all options                  |
-| `discord_edit_embed`            | Edit an embed previously sent by the bot            |
-| `discord_send_multiple_embeds`  | Send up to 10 embeds in a single message            |
-| `discord_pin_message`           | Pin or unpin a message                              |
-| `discord_fetch_pinned_messages` | List all pinned messages in a channel               |
-| `discord_search_messages`       | Search messages by keyword (last 100)               |
-| `discord_crosspost_message`     | Publish a message to announcement channel followers |
-| `discord_forward_message`       | Forward a message to another channel                |
+| Tool                            | Description                                              |
+| ------------------------------- | -------------------------------------------------------- |
+| `discord_read_messages`         | Read the last N messages from a text channel             |
+| `discord_send_message`          | Send a plain text message                                |
+| `discord_reply_message`         | Reply to a specific message                              |
+| `discord_edit_message`          | Edit a message sent by the bot                           |
+| `discord_delete_message`        | Delete a specific message                                |
+| `discord_add_reaction`          | Add a reaction emoji to a message                        |
+| `discord_remove_reactions`      | Remove reactions (all, by emoji, or by user)             |
+| `discord_get_reactions`         | List users who reacted with a specific emoji             |
+| `discord_create_thread`         | Create a thread from a message or standalone             |
+| `discord_bulk_delete_messages`  | Delete multiple messages at once (2-100)                 |
+| `discord_send_embed`            | Send a rich embed with all options                       |
+| `discord_edit_embed`            | Edit an embed previously sent by the bot                 |
+| `discord_send_multiple_embeds`  | Send up to 10 embeds in a single message                 |
+| `discord_pin_message`           | Pin or unpin a message                                   |
+| `discord_fetch_pinned_messages` | List all pinned messages in a channel                    |
+| `discord_search_messages`       | Search messages by keyword (last 100)                    |
+| `discord_search_guild_messages` | Search across every channel using Discord's search index |
+| `discord_crosspost_message`     | Publish a message to announcement channel followers      |
+| `discord_forward_message`       | Forward a message to another channel                     |
 
 ### Channels (8 tools)
 

--- a/src/tools/messages.ts
+++ b/src/tools/messages.ts
@@ -36,6 +36,16 @@ function findReaction(msg: Message, emoji: string): MessageReaction | undefined 
   return msg.reactions.cache.get(key);
 }
 
+/**
+ * Renders a raw API user the way discord.js `User#tag` does, so search results read
+ * identically to the sibling tools. Both "0" and "0000" mean a migrated handle.
+ */
+function userTag(user: { username: string; discriminator: string }): string {
+  return user.discriminator === "0" || user.discriminator === "0000"
+    ? user.username
+    : `${user.username}#${user.discriminator}`;
+}
+
 /** Tool definitions for channel and thread messages. */
 const tools = [
   defineTool({
@@ -476,7 +486,7 @@ const tools = [
       query: z.string().describe("Search query (case-insensitive)."),
       channel_id: snowflake.optional().describe("Optional. Restrict search to this channel ID."),
       author_id: snowflake.optional().describe("Optional. Only show messages from this user ID."),
-      limit: intIn(1, 100).default(25).describe("Max messages to return (1–100). Default 25."),
+      limit: intIn(1, 25).default(25).describe("Max messages to return (1–25). Default 25."),
     }),
     outputSchema: z.object({
       matches: z.array(
@@ -497,7 +507,7 @@ const tools = [
       });
 
       const data = result as {
-        messages: Array<
+        messages?: Array<
           Array<{
             id: string;
             content: string;
@@ -506,13 +516,17 @@ const tools = [
             author: { username: string; discriminator: string };
           }>
         >;
+        retry_after?: number;
       };
+      // Discord answers 202 with an index-not-ready body that carries no `messages`
+      // key while it builds the guild's search index.
+      if (!data.messages)
+        throw new Error(
+          `Discord is still building this server's message search index. Retry in ${Math.ceil(data.retry_after ?? 5)}s.`,
+        );
       const matches = data.messages.flat().map((m) => ({
         id: m.id,
-        author:
-          m.author.discriminator === "0"
-            ? m.author.username
-            : `${m.author.username}#${m.author.discriminator}`,
+        author: userTag(m.author),
         content: m.content,
         timestamp: m.timestamp,
         channel_id: m.channel_id,


### PR DESCRIPTION
Three defects in `discord_search_guild_messages` (merged in #100, not yet released), found by an adversarial audit and each verified live against the test guild.

**202 index-not-ready crashes the tool.** `RESTGetAPIGuildMessagesSearchResult` is a union: while Discord builds a guild's search index it answers HTTP 202 with `{ message, code: 110000, documents_indexed, retry_after }` and no `messages` key (discord-api-types payloads/v10/message.d.ts:2125). @discordjs/rest resolves that as success, so `data.messages.flat()` threw a raw TypeError at the user. It now returns a clear retry message.

**`limit` advertised 1-100 but the endpoint caps at 25** (rest/v10/guild.d.ts:470), so every value above 25 was a guaranteed 400. The 100 looked copied from the message-fetch limit, which governs a different route.

**Author formatting diverged from every sibling tool.** Webhooks carry discriminator `0000`, which the conditional did not treat as migrated, so a webhook rendered `name#0000` while `discord_read_messages` and `discord_search_messages` render `name`. The rendering is now a shared `userTag()` helper that mirrors discord.js `User#tag` (both `0` and `0000` mean a migrated handle), so search results read identically to the sibling tools.

## Verification

Same probe run against a `main` build and this branch, live on the test guild:

| Probe | main | this branch |
| --- | --- | --- |
| webhook author in search results | `Dragon Traveler #game-news#0000` | `Dragon Traveler #game-news` |
| bot author in search results | `SympaAssistant#1718` | `SympaAssistant#1718` |
| `limit: 26` | Discord 400 `NUMBER_TYPE_MAX` after a round trip | rejected by the schema |
| stubbed 202 body | `Cannot read properties of undefined (reading 'flat')` | `Discord is still building this server's message search index. Retry in 4s.` |

Cross-tool check on the same seeded message: `discord_search_guild_messages` and `discord_search_messages` both report `SympaAssistant#1718`.

Adjacent tools in the module (`discord_read_messages`, `discord_search_messages`, `discord_fetch_pinned_messages`) return byte-identical output on both builds, and both expose 98 tools. Build, lint, format:check and 64 tests green.

No existing tool description string changes, so the Canopii guard is unaffected.
