### PR TITLE
feat: page discord_read_messages into older history

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [Unreleased]
+
+### Added
+
+- `discord_read_messages` accepts `before`, `after` and `since` cursors, so a channel can be read past the 100-message per-call cap. Page backwards by re-calling with `before` set to the id of the oldest message received; `since` takes an ISO 8601 date or date-time and is converted to the equivalent `after` snowflake. At most one cursor per call, matching Discord's endpoint, and instants before the Discord epoch clamp to it rather than sending a negative id
+
 ## [2.1.1] - 2026-08-04
 
 ### Security

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Added
 
-- `discord_read_messages` accepts the `before`, `after` and `around` cursors Discord's messages endpoint supports, plus a `since` convenience, so a channel can be read past the 100-message per-call cap. Page backwards by re-calling with `before` set to the id of the oldest message received; `since` takes an ISO 8601 date or date-time and is converted to the equivalent `after` snowflake. At most one cursor per call, matching Discord's endpoint, and instants before the Discord epoch clamp to it rather than sending a negative id
+- `discord_read_messages` accepts the `before`, `after` and `around` cursors Discord's messages endpoint supports, plus a `since` convenience, so a channel can be read past the 100-message per-call cap. Page backwards by re-calling with `before` set to the id of the oldest message received; `since` takes an ISO 8601 date or a date-time with an explicit offset and is converted to the equivalent `after` snowflake. At most one cursor per call, matching Discord's endpoint, and instants before the Discord epoch clamp to it rather than sending a negative id
 
 ## [2.1.1] - 2026-08-04
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Added
 
-- `discord_read_messages` accepts `before`, `after` and `since` cursors, so a channel can be read past the 100-message per-call cap. Page backwards by re-calling with `before` set to the id of the oldest message received; `since` takes an ISO 8601 date or date-time and is converted to the equivalent `after` snowflake. At most one cursor per call, matching Discord's endpoint, and instants before the Discord epoch clamp to it rather than sending a negative id
+- `discord_read_messages` accepts the `before`, `after` and `around` cursors Discord's messages endpoint supports, plus a `since` convenience, so a channel can be read past the 100-message per-call cap. Page backwards by re-calling with `before` set to the id of the oldest message received; `since` takes an ISO 8601 date or date-time and is converted to the equivalent `after` snowflake. At most one cursor per call, matching Discord's endpoint, and instants before the Discord epoch clamp to it rather than sending a negative id
 
 ## [2.1.1] - 2026-08-04
 

--- a/README.md
+++ b/README.md
@@ -228,7 +228,7 @@ Data access is governed by the **portal toggles**, not by these flags: this serv
 
 | Tool                            | Description                                              |
 | ------------------------------- | -------------------------------------------------------- |
-| `discord_read_messages`         | Read the last N messages from a text channel             |
+| `discord_read_messages`         | Read messages, paging back through history               |
 | `discord_send_message`          | Send a plain text message                                |
 | `discord_reply_message`         | Reply to a specific message                              |
 | `discord_edit_message`          | Edit a message sent by the bot                           |

--- a/src/tools/messages.ts
+++ b/src/tools/messages.ts
@@ -6,6 +6,7 @@ import {
   Message,
   MessageReaction,
   Routes,
+  SnowflakeUtil,
   DiscordAPIError,
 } from "discord.js";
 import { z } from "zod";
@@ -16,6 +17,45 @@ import { defineModule, defineTool, snowflake, guildId, intIn, structured } from 
 
 const channelId = snowflake.describe("ID (snowflake) of the channel or thread.");
 const messageId = snowflake.describe("ID of the message.");
+
+/**
+ * History paging cursors. Discord's `GET /channels/{id}/messages` accepts at most
+ * one of `before` / `after` / `around` per request, so tools exposing them reject
+ * combinations at parse time instead of letting the API answer 400.
+ */
+const beforeCursor = snowflake.describe(
+  "Return only messages older than this message ID (snowflake). Page backwards through history by passing the id of the oldest message from the previous call.",
+);
+const afterCursor = snowflake.describe(
+  "Return only messages newer than this message ID (snowflake). Page forwards by passing the id of the newest message from the previous call.",
+);
+const sinceInstant = z
+  .string()
+  .refine((value) => !Number.isNaN(Date.parse(value)), {
+    message: "Must be an ISO 8601 date or date-time.",
+  })
+  .describe(
+    'Return only messages posted after this instant, as an ISO 8601 date or date-time (e.g. "2026-08-01" or "2026-08-01T09:00:00Z"). Convenience form of `after` for callers that know a date but not a message id.',
+  );
+
+const SINGLE_CURSOR_MESSAGE =
+  "Pass at most one of before, after, or since: Discord's messages endpoint accepts a single cursor.";
+
+/** True when at most one paging cursor was supplied. */
+function hasSingleCursor(args: { before?: string; after?: string; since?: string }): boolean {
+  return [args.before, args.after, args.since].filter((value) => value !== undefined).length <= 1;
+}
+
+/**
+ * Converts an ISO 8601 instant into the snowflake an `after` cursor expects.
+ * Snowflakes embed a millisecond timestamp, so a synthetic id marks that instant
+ * exactly. Instants before the Discord epoch are clamped to it: `generate` returns
+ * a negative id for them, which the API rejects.
+ */
+function cursorForInstant(iso: string): string {
+  const timestamp = Math.max(Date.parse(iso), Number(SnowflakeUtil.epoch));
+  return SnowflakeUtil.generate({ timestamp }).toString();
+}
 
 const messageSummary = z.object({
   id: z.string(),
@@ -48,20 +88,31 @@ const tools = [
   defineTool({
     name: "discord_read_messages",
     description:
-      "Read the most recent messages from a text channel or thread, oldest-to-newest. Returns { messages: [...] } with id, author, content, timestamp, attachment count, pinned flag. Use discord_search_messages to filter by keyword, or discord_fetch_pinned_messages for pinned messages only.",
+      "Read messages from a text channel or thread, oldest-to-newest. Without a cursor it returns the most recent messages; pass before, after, or since (at most one) to reach older history. Page backwards by re-calling with before set to the id of the oldest message you received, which lets you walk a channel past the 100-message per-call cap. Requires View Channel and Read Message History. Returns { messages: [...] } with id, author, content, timestamp, attachment count, pinned flag. Use discord_search_messages to filter by keyword, or discord_fetch_pinned_messages for pinned messages only.",
     annotations: { title: "Read messages", readOnlyHint: true, openWorldHint: true },
-    schema: z.object({
-      channel_id: snowflake.describe("ID (snowflake) of the channel or thread to read from."),
-      limit: intIn(1, MAX_FETCH_LIMIT)
-        .default(DEFAULTS.MESSAGES)
-        .describe("How many recent messages to fetch (1–100). Default 20."),
-    }),
+    schema: z
+      .object({
+        channel_id: snowflake.describe("ID (snowflake) of the channel or thread to read from."),
+        limit: intIn(1, MAX_FETCH_LIMIT)
+          .default(DEFAULTS.MESSAGES)
+          .describe("How many messages to fetch per call (1–100). Default 20."),
+        before: beforeCursor.optional(),
+        after: afterCursor.optional(),
+        since: sinceInstant.optional(),
+      })
+      .refine(hasSingleCursor, { message: SINGLE_CURSOR_MESSAGE }),
     outputSchema: z.object({
       messages: z.array(messageSummary.extend({ attachments: z.number(), pinned: z.boolean() })),
     }),
-    handle: async ({ channel_id, limit }) => {
+    handle: async ({ channel_id, limit, before, after, since }) => {
       const channel = await getTextChannel(channel_id);
-      const messages = await channel.messages.fetch({ limit, cache: false });
+      const resolvedAfter = after ?? (since === undefined ? undefined : cursorForInstant(since));
+      const messages = await channel.messages.fetch({
+        limit,
+        cache: false,
+        ...(before === undefined ? {} : { before }),
+        ...(resolvedAfter === undefined ? {} : { after: resolvedAfter }),
+      });
       const result = [...messages.values()]
         .sort((a, b) => a.createdTimestamp - b.createdTimestamp)
         .map((m) => ({

--- a/src/tools/messages.ts
+++ b/src/tools/messages.ts
@@ -33,12 +33,12 @@ const aroundCursor = snowflake.describe(
   "Return messages centred on this message ID (snowflake): Discord splits `limit` either side of it. Use it to pull the conversation surrounding one message, such as a discord_search_messages hit.",
 );
 const sinceInstant = z
-  .string()
-  .refine((value) => !Number.isNaN(Date.parse(value)), {
-    message: "Must be an ISO 8601 date or date-time.",
+  .union([z.iso.date(), z.iso.datetime({ offset: true })], {
+    error:
+      "Must be an ISO 8601 date (2026-08-01) or a date-time with an explicit offset (2026-08-01T09:00:00Z).",
   })
   .describe(
-    'Return only messages posted after this instant, as an ISO 8601 date or date-time (e.g. "2026-08-01" or "2026-08-01T09:00:00Z"). Convenience form of `after` for callers that know a date but not a message id.',
+    'Return only messages posted after this instant, as an ISO 8601 date or a date-time with an explicit offset (e.g. "2026-08-01" or "2026-08-01T09:00:00Z"). Convenience form of `after` for callers that know a date but not a message id.',
   );
 
 const SINGLE_CURSOR_MESSAGE =
@@ -61,7 +61,9 @@ function hasSingleCursor(args: {
  * Converts an ISO 8601 instant into the snowflake an `after` cursor expects.
  * Snowflakes embed a millisecond timestamp, so a synthetic id marks that instant
  * exactly. Instants before the Discord epoch are clamped to it: `generate` returns
- * a negative id for them, which the API rejects.
+ * a negative id for them, which the API rejects. The schema only admits a date or
+ * an offset-bearing date-time, both of which `Date.parse` reads as UTC or the given
+ * offset, so the result does not depend on the server's timezone.
  */
 function cursorForInstant(iso: string): string {
   const timestamp = Math.max(Date.parse(iso), Number(SnowflakeUtil.epoch));

--- a/src/tools/messages.ts
+++ b/src/tools/messages.ts
@@ -30,7 +30,7 @@ const afterCursor = snowflake.describe(
   "Return only messages newer than this message ID (snowflake). Page forwards by passing the id of the newest message from the previous call.",
 );
 const aroundCursor = snowflake.describe(
-  "Return messages centred on this message ID (snowflake): Discord splits `limit` either side of it. Use it to pull the conversation surrounding one message, such as a discord_search_messages hit.",
+  "Return messages centred on this message ID (snowflake): Discord splits `limit` either side of it, and an even `limit` puts the extra message on the newer side. Use it to read outward from a known message, such as a discord_search_guild_messages hit.",
 );
 const sinceInstant = z
   .union([z.iso.date(), z.iso.datetime({ offset: true })], {
@@ -101,7 +101,7 @@ const tools = [
   defineTool({
     name: "discord_read_messages",
     description:
-      "Read messages from a text channel or thread, oldest-to-newest. Without a cursor it returns the most recent messages; pass before, after, around, or since (at most one) to reach older history or the context surrounding a known message. Page backwards by re-calling with before set to the id of the oldest message you received, which walks a channel past the 100-message per-call cap. Requires View Channel and Read Message History. Returns { messages: [...] } with id, author, content, timestamp, attachment count, pinned flag. Use discord_search_messages to filter by keyword, or discord_fetch_pinned_messages for pinned messages only.",
+      "Read messages from a text channel or thread, oldest-to-newest. Page backwards by re-calling with before set to the id of the oldest message you received, which walks a channel past the 100-message per-call cap. Requires View Channel and Read Message History. Returns { messages: [...] } with id, author, content, timestamp, attachment count, pinned flag. Use discord_search_messages to filter by keyword, or discord_fetch_pinned_messages for pinned messages only.",
     annotations: { title: "Read messages", readOnlyHint: true, openWorldHint: true },
     schema: z
       .object({

--- a/src/tools/messages.ts
+++ b/src/tools/messages.ts
@@ -29,6 +29,9 @@ const beforeCursor = snowflake.describe(
 const afterCursor = snowflake.describe(
   "Return only messages newer than this message ID (snowflake). Page forwards by passing the id of the newest message from the previous call.",
 );
+const aroundCursor = snowflake.describe(
+  "Return messages centred on this message ID (snowflake): Discord splits `limit` either side of it. Use it to pull the conversation surrounding one message, such as a discord_search_messages hit.",
+);
 const sinceInstant = z
   .string()
   .refine((value) => !Number.isNaN(Date.parse(value)), {
@@ -39,11 +42,19 @@ const sinceInstant = z
   );
 
 const SINGLE_CURSOR_MESSAGE =
-  "Pass at most one of before, after, or since: Discord's messages endpoint accepts a single cursor.";
+  "Pass at most one of before, after, around, or since: Discord treats before/after/around as mutually exclusive, and since is a form of after.";
 
 /** True when at most one paging cursor was supplied. */
-function hasSingleCursor(args: { before?: string; after?: string; since?: string }): boolean {
-  return [args.before, args.after, args.since].filter((value) => value !== undefined).length <= 1;
+function hasSingleCursor(args: {
+  before?: string;
+  after?: string;
+  around?: string;
+  since?: string;
+}): boolean {
+  return (
+    [args.before, args.after, args.around, args.since].filter((value) => value !== undefined)
+      .length <= 1
+  );
 }
 
 /**
@@ -88,7 +99,7 @@ const tools = [
   defineTool({
     name: "discord_read_messages",
     description:
-      "Read messages from a text channel or thread, oldest-to-newest. Without a cursor it returns the most recent messages; pass before, after, or since (at most one) to reach older history. Page backwards by re-calling with before set to the id of the oldest message you received, which lets you walk a channel past the 100-message per-call cap. Requires View Channel and Read Message History. Returns { messages: [...] } with id, author, content, timestamp, attachment count, pinned flag. Use discord_search_messages to filter by keyword, or discord_fetch_pinned_messages for pinned messages only.",
+      "Read messages from a text channel or thread, oldest-to-newest. Without a cursor it returns the most recent messages; pass before, after, around, or since (at most one) to reach older history or the context surrounding a known message. Page backwards by re-calling with before set to the id of the oldest message you received, which walks a channel past the 100-message per-call cap. Requires View Channel and Read Message History. Returns { messages: [...] } with id, author, content, timestamp, attachment count, pinned flag. Use discord_search_messages to filter by keyword, or discord_fetch_pinned_messages for pinned messages only.",
     annotations: { title: "Read messages", readOnlyHint: true, openWorldHint: true },
     schema: z
       .object({
@@ -98,19 +109,21 @@ const tools = [
           .describe("How many messages to fetch per call (1–100). Default 20."),
         before: beforeCursor.optional(),
         after: afterCursor.optional(),
+        around: aroundCursor.optional(),
         since: sinceInstant.optional(),
       })
       .refine(hasSingleCursor, { message: SINGLE_CURSOR_MESSAGE }),
     outputSchema: z.object({
       messages: z.array(messageSummary.extend({ attachments: z.number(), pinned: z.boolean() })),
     }),
-    handle: async ({ channel_id, limit, before, after, since }) => {
+    handle: async ({ channel_id, limit, before, after, around, since }) => {
       const channel = await getTextChannel(channel_id);
       const resolvedAfter = after ?? (since === undefined ? undefined : cursorForInstant(since));
       const messages = await channel.messages.fetch({
         limit,
         cache: false,
         ...(before === undefined ? {} : { before }),
+        ...(around === undefined ? {} : { around }),
         ...(resolvedAfter === undefined ? {} : { after: resolvedAfter }),
       });
       const result = [...messages.values()]

--- a/test/paging.test.ts
+++ b/test/paging.test.ts
@@ -42,7 +42,7 @@ test("read_messages advertises the paging cursors as optional additions", () => 
   };
   assert.deepEqual(schema.required, ["channel_id"], "cursors must not become required");
   assert.equal(schema.additionalProperties, false);
-  for (const field of ["before", "after", "since"]) {
+  for (const field of ["before", "after", "around", "since"]) {
     assert.ok(schema.properties[field], `${field} must be advertised`);
     assert.ok(
       (schema.properties[field].description ?? "").length > 0,
@@ -57,6 +57,7 @@ test("read_messages sends no cursor when none was requested", async () => {
   assert.equal(calls.length, 1);
   assert.ok(!("before" in calls[0]), "an absent cursor must not be sent as an undefined key");
   assert.ok(!("after" in calls[0]), "an absent cursor must not be sent as an undefined key");
+  assert.ok(!("around" in calls[0]), "an absent cursor must not be sent as an undefined key");
 });
 
 test("read_messages passes before through untouched", async () => {
@@ -66,6 +67,14 @@ test("read_messages passes before through untouched", async () => {
   assert.ok(!("after" in calls[0]));
   assert.equal(calls[0].limit, 100);
   assert.equal(calls[0].cache, false, "history reads must not fill the message cache");
+});
+
+test("read_messages passes around through untouched", async () => {
+  const calls = captureFetches();
+  await read()({ channel_id: CHANNEL, around: OLDEST });
+  assert.equal(calls[0].around, OLDEST);
+  assert.ok(!("before" in calls[0]));
+  assert.ok(!("after" in calls[0]));
 });
 
 test("read_messages converts since into an after snowflake", async () => {
@@ -97,8 +106,12 @@ test("read_messages rejects more than one cursor", async () => {
   captureFetches();
   for (const args of [
     { channel_id: CHANNEL, before: OLDEST, after: OLDEST },
+    { channel_id: CHANNEL, before: OLDEST, around: OLDEST },
     { channel_id: CHANNEL, before: OLDEST, since: "2026-08-01" },
+    { channel_id: CHANNEL, after: OLDEST, around: OLDEST },
     { channel_id: CHANNEL, after: OLDEST, since: "2026-08-01" },
+    { channel_id: CHANNEL, around: OLDEST, since: "2026-08-01" },
+    { channel_id: CHANNEL, before: OLDEST, after: OLDEST, around: OLDEST },
   ]) {
     await assert.rejects(() => read()(args), ZodError, JSON.stringify(args));
   }

--- a/test/paging.test.ts
+++ b/test/paging.test.ts
@@ -65,8 +65,17 @@ test("read_messages passes before through untouched", async () => {
   await read()({ channel_id: CHANNEL, before: OLDEST, limit: 100 });
   assert.equal(calls[0].before, OLDEST);
   assert.ok(!("after" in calls[0]));
+  assert.ok(!("around" in calls[0]));
   assert.equal(calls[0].limit, 100);
   assert.equal(calls[0].cache, false, "history reads must not fill the message cache");
+});
+
+test("read_messages passes after through untouched", async () => {
+  const calls = captureFetches();
+  await read()({ channel_id: CHANNEL, after: OLDEST });
+  assert.equal(calls[0].after, OLDEST, "a caller-supplied after must not be dropped or rewritten");
+  assert.ok(!("before" in calls[0]));
+  assert.ok(!("around" in calls[0]));
 });
 
 test("read_messages passes around through untouched", async () => {

--- a/test/paging.test.ts
+++ b/test/paging.test.ts
@@ -1,0 +1,110 @@
+import { test, mock, afterEach } from "node:test";
+import assert from "node:assert/strict";
+import { ZodError } from "zod";
+import { SnowflakeUtil } from "discord.js";
+import { discord } from "../src/client.js";
+import messages from "../src/tools/messages.js";
+
+const GUILD = "111111111111111111";
+const CHANNEL = "333333333333333333";
+const OLDEST = "444444444444444444";
+
+afterEach(() => mock.restoreAll());
+
+/** Stubs the channel lookup and records the options every messages.fetch receives. */
+function captureFetches(): Record<string, unknown>[] {
+  const calls: Record<string, unknown>[] = [];
+  const channel = {
+    name: "chan",
+    guildId: GUILD,
+    isDMBased: () => false,
+    isTextBased: () => true,
+    messages: {
+      fetch: async (options: Record<string, unknown>) => {
+        calls.push(options);
+        return new Map();
+      },
+    },
+  };
+  mock.method(discord.channels, "fetch", async () => channel as never);
+  return calls;
+}
+
+const read = () => messages.handlers.get("discord_read_messages")!;
+
+test("read_messages advertises the paging cursors as optional additions", () => {
+  const definition = messages.definitions.find((d) => d.name === "discord_read_messages");
+  assert.ok(definition, "discord_read_messages should be defined");
+  const schema = definition.inputSchema as {
+    required: string[];
+    additionalProperties: boolean;
+    properties: Record<string, { description?: string }>;
+  };
+  assert.deepEqual(schema.required, ["channel_id"], "cursors must not become required");
+  assert.equal(schema.additionalProperties, false);
+  for (const field of ["before", "after", "since"]) {
+    assert.ok(schema.properties[field], `${field} must be advertised`);
+    assert.ok(
+      (schema.properties[field].description ?? "").length > 0,
+      `${field} must document its format`,
+    );
+  }
+});
+
+test("read_messages sends no cursor when none was requested", async () => {
+  const calls = captureFetches();
+  await read()({ channel_id: CHANNEL });
+  assert.equal(calls.length, 1);
+  assert.ok(!("before" in calls[0]), "an absent cursor must not be sent as an undefined key");
+  assert.ok(!("after" in calls[0]), "an absent cursor must not be sent as an undefined key");
+});
+
+test("read_messages passes before through untouched", async () => {
+  const calls = captureFetches();
+  await read()({ channel_id: CHANNEL, before: OLDEST, limit: 100 });
+  assert.equal(calls[0].before, OLDEST);
+  assert.ok(!("after" in calls[0]));
+  assert.equal(calls[0].limit, 100);
+  assert.equal(calls[0].cache, false, "history reads must not fill the message cache");
+});
+
+test("read_messages converts since into an after snowflake", async () => {
+  const calls = captureFetches();
+  await read()({ channel_id: CHANNEL, since: "2026-08-01T00:00:00Z" });
+  const after = calls[0].after;
+  assert.equal(typeof after, "string");
+  assert.equal(
+    new Date(Number(SnowflakeUtil.timestampFrom(after as string))).toISOString(),
+    "2026-08-01T00:00:00.000Z",
+    "the synthetic cursor must carry the requested instant",
+  );
+  assert.ok(!("before" in calls[0]));
+});
+
+test("read_messages clamps a pre-epoch since instead of sending a negative id", async () => {
+  const calls = captureFetches();
+  await read()({ channel_id: CHANNEL, since: "1999-01-01" });
+  const after = calls[0].after as string;
+  assert.ok(BigInt(after) > 0n, `Discord rejects negative snowflakes, got ${after}`);
+  assert.equal(
+    Number(SnowflakeUtil.timestampFrom(after)),
+    Number(SnowflakeUtil.epoch),
+    "instants before the Discord epoch clamp to it",
+  );
+});
+
+test("read_messages rejects more than one cursor", async () => {
+  captureFetches();
+  for (const args of [
+    { channel_id: CHANNEL, before: OLDEST, after: OLDEST },
+    { channel_id: CHANNEL, before: OLDEST, since: "2026-08-01" },
+    { channel_id: CHANNEL, after: OLDEST, since: "2026-08-01" },
+  ]) {
+    await assert.rejects(() => read()(args), ZodError, JSON.stringify(args));
+  }
+});
+
+test("read_messages rejects a since that is not a parsable date", async () => {
+  captureFetches();
+  await assert.rejects(() => read()({ channel_id: CHANNEL, since: "last tuesday" }), ZodError);
+});

--- a/test/paging.test.ts
+++ b/test/paging.test.ts
@@ -130,7 +130,52 @@ test("read_messages rejects more than one cursor", async () => {
   assert.equal(calls.length, 0, "an invalid cursor combination must not reach the Discord API");
 });
 
-test("read_messages rejects a since that is not a parsable date", async () => {
-  captureFetches();
-  await assert.rejects(() => read()({ channel_id: CHANNEL, since: "last tuesday" }), ZodError);
+test("read_messages accepts only timezone-stable since forms", async () => {
+  const calls = captureFetches();
+  // Each accepted form names one instant regardless of the server's TZ; the
+  // assertion pins that instant so a regression to local-time parsing fails here.
+  const accepted: [string, string][] = [
+    ["2026-08-01", "2026-08-01T00:00:00.000Z"],
+    ["2026-08-01T09:00:00Z", "2026-08-01T09:00:00.000Z"],
+    ["2026-08-01T09:00:00.250Z", "2026-08-01T09:00:00.250Z"],
+    ["2026-08-01T09:00:00+02:00", "2026-08-01T07:00:00.000Z"],
+    ["2026-08-01T09:00:00-07:00", "2026-08-01T16:00:00.000Z"],
+  ];
+  for (const [since, instant] of accepted) {
+    await read()({ channel_id: CHANNEL, since });
+    const after = calls.at(-1)!.after as string;
+    assert.equal(
+      new Date(Number(SnowflakeUtil.timestampFrom(after))).toISOString(),
+      instant,
+      since,
+    );
+  }
+  assert.equal(calls.length, accepted.length);
+
+  // An offset-less date-time would be read in the server's local timezone, so it
+  // is rejected along with everything that is not ISO 8601.
+  for (const since of [
+    "2026-08-01T09:00:00",
+    "2026-08-01 09:00:00Z",
+    "2026",
+    "2026-08",
+    "08/01/2026",
+    "1754038800000",
+    "last tuesday",
+  ]) {
+    await assert.rejects(
+      () => read()({ channel_id: CHANNEL, since }),
+      (error: unknown) => {
+        assert.ok(error instanceof ZodError);
+        assert.match(
+          error.issues.map((issue) => issue.message).join(" "),
+          /explicit offset/,
+          "the rejection must say what an acceptable since looks like",
+        );
+        return true;
+      },
+      since,
+    );
+  }
+  assert.equal(calls.length, accepted.length, "a rejected since must not reach the Discord API");
 });

--- a/test/paging.test.ts
+++ b/test/paging.test.ts
@@ -103,7 +103,7 @@ test("read_messages clamps a pre-epoch since instead of sending a negative id", 
 });
 
 test("read_messages rejects more than one cursor", async () => {
-  captureFetches();
+  const calls = captureFetches();
   for (const args of [
     { channel_id: CHANNEL, before: OLDEST, after: OLDEST },
     { channel_id: CHANNEL, before: OLDEST, around: OLDEST },
@@ -113,8 +113,21 @@ test("read_messages rejects more than one cursor", async () => {
     { channel_id: CHANNEL, around: OLDEST, since: "2026-08-01" },
     { channel_id: CHANNEL, before: OLDEST, after: OLDEST, around: OLDEST },
   ]) {
-    await assert.rejects(() => read()(args), ZodError, JSON.stringify(args));
+    await assert.rejects(
+      () => read()(args),
+      (error: unknown) => {
+        assert.ok(error instanceof ZodError);
+        assert.match(
+          error.issues.map((issue) => issue.message).join(" "),
+          /at most one/i,
+          "the rejection must name the constraint, not just fail",
+        );
+        return true;
+      },
+      JSON.stringify(args),
+    );
   }
+  assert.equal(calls.length, 0, "an invalid cursor combination must not reach the Discord API");
 });
 
 test("read_messages rejects a since that is not a parsable date", async () => {


### PR DESCRIPTION
## Problem

`discord_read_messages` exposes `limit` (1–100) and nothing else, so the most recent page *is* the entire reachable history. There is no cursor to walk backwards, which makes a question like "what did we decide about X last month" unanswerable through the tool once the channel has moved on. There is also no way to read the conversation surrounding a single known message.

## Change

Exposes every cursor `GET /channels/{channel.id}/messages` documents, plus one convenience:

| Param | Type | Meaning |
| --- | --- | --- |
| `before` | snowflake | messages older than this message id |
| `after` | snowflake | messages newer than this message id |
| `around` | snowflake | window centred on this message id, `limit` split either side |
| `since` | ISO 8601 date, or date-time with an explicit offset | messages after this instant, converted to the equivalent `after` snowflake |

`limit` was already there, so the tool's inputs now match the endpoint's.

Paging backwards becomes: call, take `messages[0].id` (the oldest, since results come back oldest-to-newest), pass it as `before`, repeat.

`since` is the one addition that is not an API parameter. It exists because a model usually knows a date but not a message id, and hand-building a snowflake is not something a caller should have to do.

`around` is what you want after a `discord_search_messages` hit: reading the messages surrounding it previously meant guessing a `before` cursor.

No new tool, so tool counts and the toolset list are unchanged, and the existing `cache: false` behaviour is preserved.

## Details worth a look

**One cursor per call.** The endpoint documents `before` / `after` / `around` as mutually exclusive, and `since` resolves to `after`, so the schema rejects all seven pairings at parse time via `.refine()` rather than letting the API answer 400. Zod 4 keeps refinements in-place, so `strictInput` still sees a `ZodObject` and `additionalProperties: false` is unaffected — `test/registry.test.ts` covers that.

**Pre-epoch instants are clamped.** `SnowflakeUtil.generate({ timestamp })` silently returns a *negative* id for instants before the Discord epoch (`{ timestamp: 0 }` yields `-5956206959001595903`), which the API rejects. `since` clamps to `SnowflakeUtil.epoch`.

**`since` only accepts timezone-stable forms.** It is a union of `z.iso.date()` and `z.iso.datetime({ offset: true })`, the repo's date idiom. An offset-less date-time such as `2026-08-18T08:00:00` is rejected, because `Date.parse` reads it in the server's local timezone and the same call would return different messages under different `TZ` values. The union also puts `format` and `pattern` into the advertised schema.

**Absent cursors are omitted** rather than passed as `undefined` keys.

## Testing

**Unit** — `test/paging.test.ts` adds 9 cases: the advertised schema (all four cursors optional and documented, `required` unchanged), no-cursor calls sending no cursor keys at all, `before`, `after` and `around` pass-through (each asserting the other two cursors are absent), `since` → snowflake conversion verified by round-tripping through `SnowflakeUtil.timestampFrom`, the pre-epoch clamp, mutual exclusion across every pairing (asserting the rejection names the constraint and that no fetch reaches the API), and a fixture table of accepted and rejected `since` forms that pins the resolved UTC instant of each accepted one. The suite passes under `TZ=UTC`, `Asia/Tokyo` and `America/Los_Angeles`.

Handlers are exercised through the existing `mock.method(discord.channels, "fetch", …)` pattern, so no network access.

`npm run lint`, `npm run format:check`, `npm run build` and `npm test` are all clean (73 passing, was 64).

**Live** — mocks can prove this branch assembles the right fetch options, but not that Discord honours them, so I also checked against a real guild. I ran `npm run build` on this branch and drove the resulting `dist/index.js` over stdio with a bot token, against a channel holding 1591 messages. 17 assertions, all passing:

| Case | Result |
| --- | --- |
| no cursor | newest 5, ordered oldest-to-newest |
| `before` | all older than the baseline, zero overlap |
| `since: 2026-08-20T00:00:00Z` | 100 messages, none older than the instant |
| `around` with `limit: 11` | pivot landed at index 5 of 11, messages on both sides |
| `before`+`after`, `before`+`around`, `after`+`since` | all rejected |
| three `before` pages at `limit: 100` | 300 distinct ids, reaching 5 days further back |
| `since: 1999-01-01` | no error, returned the channel's first message |

That last row is the pre-epoch clamp doing its job end to end: without it the negative snowflake reaches Discord and the call 400s.

As a control that the run really exercised this branch and not an installed copy, I replayed the same `around` and `since` calls against published `@pasympa/discord-mcp@2.1.1` with the same token and channel. Both come back `Unrecognized key`, which `additionalProperties: false` guarantees — so the passing `around` assertions above could only have come from this build.

The live driver needs a bot token and a specific channel id, so it is not committed.

## Possible follow-ups

Two related gaps I did not touch, to keep this PR to one endpoint:

- `discord_search_messages` has the same ceiling by construction: it filters whatever one fetch returned. `discord_search_guild_messages` (added on main since I opened this) covers the cross-channel case through Discord's own index, so the remaining gap is narrower than I first wrote: a channel-scoped keyword search still cannot look past one page. It could take the same cursors, or a bounded `max_scan` that walks several pages, but that changes its cost profile.
- `discord_fetch_pinned_messages` calls `fetchPins()` with no options while its description promises "all pinned messages". `FetchPinnedMessagesOptions` has `before` and `limit`, and the pins endpoint caps a page at 50, so a heavily pinned channel is silently truncated. Happy to open a separate issue or PR for that if useful.

🤖 Generated with [Claude Code](https://claude.com/claude-code)