### PR TITLE
chore: tighten the userTag doc comment to one line

### DIFF
--- a/src/tools/messages.ts
+++ b/src/tools/messages.ts
@@ -36,10 +36,7 @@ function findReaction(msg: Message, emoji: string): MessageReaction | undefined 
   return msg.reactions.cache.get(key);
 }
 
-/**
- * Renders a raw API user the way discord.js `User#tag` does, so search results read
- * identically to the sibling tools. Both "0" and "0000" mean a migrated handle.
- */
+/** Mirrors discord.js `User#tag`, which raw API users lack. Both "0" and "0000" mean migrated. */
 function userTag(user: { username: string; discriminator: string }): string {
   return user.discriminator === "0" || user.discriminator === "0000"
     ? user.username


### PR DESCRIPTION
Comment only, no behaviour change. The four-line block restated the function name; the one-liner keeps the two things the code cannot say: raw API users have no `tag` getter, which is why the helper exists, and both `0` and `0000` mean a migrated handle.

Build, lint, format:check and 64 tests green.