### PR TITLE
ci: label pull requests from their conventional-commit prefix

### DIFF
--- a/.github/workflows/label-pr.yml
+++ b/.github/workflows/label-pr.yml
@@ -1,0 +1,54 @@
+name: Label PR
+
+on:
+  pull_request_target:
+    types: [opened, edited, reopened]
+
+permissions:
+  pull-requests: write
+
+concurrency:
+  group: label-pr-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  label:
+    # Dependabot already labels its own pull requests.
+    if: github.event.pull_request.user.login != 'dependabot[bot]'
+    runs-on: ubuntu-latest
+    steps:
+      # pull_request_target runs with a writable token, so this job must never
+      # check out or execute the head branch: it only reads the PR title.
+      - uses: actions/github-script@v9
+        with:
+          script: |
+            const LABELS = {
+              feat: "enhancement",
+              fix: "bug",
+              docs: "documentation",
+              chore: "chore",
+              refactor: "chore",
+              style: "chore",
+              perf: "chore",
+              test: "chore",
+              build: "chore",
+              ci: "chore",
+            };
+            const pr = context.payload.pull_request;
+            const prefix = pr.title.match(/^([a-z]+)(\([^)]*\))?!?:/)?.[1];
+            const label = LABELS[prefix];
+            if (!label) {
+              core.info(`No label for title: ${pr.title}`);
+              return;
+            }
+            if (pr.labels.some((existing) => existing.name === label)) {
+              core.info(`Already labelled ${label}`);
+              return;
+            }
+            await github.rest.issues.addLabels({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: pr.number,
+              labels: [label],
+            });
+            core.info(`Added ${label}`);


### PR DESCRIPTION
Open PRs from humans were landing with no label at all (#103, #111, #102 all went in bare). Dependabot labels its own PRs and nothing else: its configuration only describes the PRs it raises, so there is no way to cover human PRs from `dependabot.yml`.

This adds a workflow that reads the PR title and maps its conventional-commit prefix:

| Prefix | Label |
| --- | --- |
| `feat` | `enhancement` |
| `fix` | `bug` |
| `docs` | `documentation` |
| `chore`, `refactor`, `style`, `perf`, `test`, `build`, `ci` | `chore` |

Anything else is left alone. A title already carrying its label is skipped, so editing a PR does not re-add it. Dependabot is excluded by actor.

## Security

`pull_request_target` is required to hold a writable token on a fork PR, and it is the trigger people get wrong. This job never runs `actions/checkout` and never executes anything from the head branch: it reads `context.payload.pull_request.title` and calls the API. Permissions are `pull-requests: write` only.

## Verification

The mapping table and regex were extracted from the workflow file itself and exercised against 14 real titles taken from this repo's history, including the scoped form `docs(readme):`, the breaking forms `feat!:` and `chore!:`, and negatives (`release: 2.1.1`, `2.1.1`, `Update README`, uppercase `FEAT:`). 14/14. The `chore` label was created for this.

Lint, format:check, build and 64 tests green.