### PR TITLE
feat: add discord_get_message_attachments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Added
 
 - `discord_read_messages` accepts the `before`, `after` and `around` cursors Discord's messages endpoint supports, plus a `since` convenience, so a channel can be read past the 100-message per-call cap. Page backwards by re-calling with `before` set to the id of the oldest message received; `since` takes an ISO 8601 date or a date-time with an explicit offset and is converted to the equivalent `after` snowflake. At most one cursor per call, matching Discord's endpoint, and instants before the Discord epoch clamp to it rather than sending a negative id
+- `discord_get_message_attachments` lists a message's file attachments: filename, original title (Discord strips non-ASCII characters from the filename), download url, content type, size, image dimensions, alt-text description, voice-message duration and waveform, spoiler flag. Discord signs attachment CDN urls with a 24-hour expiry and does not re-sign on every fetch; re-call the tool if a stored url has expired
 
 ## [2.1.1] - 2026-08-04
 

--- a/README.md
+++ b/README.md
@@ -213,7 +213,7 @@ Data access is governed by the **portal toggles**, not by these flags: this serv
 
 ---
 
-## Available Tools (98)
+## Available Tools (99)
 
 ### Discovery & Navigation (4 tools)
 
@@ -224,29 +224,30 @@ Data access is governed by the **portal toggles**, not by these flags: this serv
 | `discord_list_channels`        | List all channels in a guild grouped by category                 |
 | `discord_find_channel_by_name` | Find a channel by name (partial match)                           |
 
-### Messages (19 tools)
+### Messages (20 tools)
 
-| Tool                            | Description                                              |
-| ------------------------------- | -------------------------------------------------------- |
-| `discord_read_messages`         | Read messages, paging back through history               |
-| `discord_send_message`          | Send a plain text message                                |
-| `discord_reply_message`         | Reply to a specific message                              |
-| `discord_edit_message`          | Edit a message sent by the bot                           |
-| `discord_delete_message`        | Delete a specific message                                |
-| `discord_add_reaction`          | Add a reaction emoji to a message                        |
-| `discord_remove_reactions`      | Remove reactions (all, by emoji, or by user)             |
-| `discord_get_reactions`         | List users who reacted with a specific emoji             |
-| `discord_create_thread`         | Create a thread from a message or standalone             |
-| `discord_bulk_delete_messages`  | Delete multiple messages at once (2-100)                 |
-| `discord_send_embed`            | Send a rich embed with all options                       |
-| `discord_edit_embed`            | Edit an embed previously sent by the bot                 |
-| `discord_send_multiple_embeds`  | Send up to 10 embeds in a single message                 |
-| `discord_pin_message`           | Pin or unpin a message                                   |
-| `discord_fetch_pinned_messages` | List all pinned messages in a channel                    |
-| `discord_search_messages`       | Search messages by keyword (last 100)                    |
-| `discord_search_guild_messages` | Search across every channel using Discord's search index |
-| `discord_crosspost_message`     | Publish a message to announcement channel followers      |
-| `discord_forward_message`       | Forward a message to another channel                     |
+| Tool                              | Description                                              |
+| --------------------------------- | -------------------------------------------------------- |
+| `discord_read_messages`           | Read messages, paging back through history               |
+| `discord_send_message`            | Send a plain text message                                |
+| `discord_reply_message`           | Reply to a specific message                              |
+| `discord_edit_message`            | Edit a message sent by the bot                           |
+| `discord_delete_message`          | Delete a specific message                                |
+| `discord_add_reaction`            | Add a reaction emoji to a message                        |
+| `discord_remove_reactions`        | Remove reactions (all, by emoji, or by user)             |
+| `discord_get_reactions`           | List users who reacted with a specific emoji             |
+| `discord_create_thread`           | Create a thread from a message or standalone             |
+| `discord_bulk_delete_messages`    | Delete multiple messages at once (2-100)                 |
+| `discord_send_embed`              | Send a rich embed with all options                       |
+| `discord_edit_embed`              | Edit an embed previously sent by the bot                 |
+| `discord_send_multiple_embeds`    | Send up to 10 embeds in a single message                 |
+| `discord_pin_message`             | Pin or unpin a message                                   |
+| `discord_get_message_attachments` | List a message's attachments with download urls          |
+| `discord_fetch_pinned_messages`   | List all pinned messages in a channel                    |
+| `discord_search_messages`         | Search messages by keyword (last 100)                    |
+| `discord_search_guild_messages`   | Search across every channel using Discord's search index |
+| `discord_crosspost_message`       | Publish a message to announcement channel followers      |
+| `discord_forward_message`         | Forward a message to another channel                     |
 
 ### Channels (8 tools)
 

--- a/src/tools/messages.ts
+++ b/src/tools/messages.ts
@@ -74,6 +74,22 @@ const messageSummary = z.object({
   timestamp: z.string(),
 });
 
+const attachmentInfo = z.object({
+  id: z.string(),
+  filename: z.string(),
+  contentType: z.string().nullable(),
+  size: z.number(),
+  url: z.string(),
+  proxyUrl: z.string(),
+  width: z.number().nullable(),
+  height: z.number().nullable(),
+  description: z.string().nullable(),
+  title: z.string().nullable(),
+  duration: z.number().nullable(),
+  waveform: z.string().nullable(),
+  spoiler: z.boolean(),
+});
+
 /**
  * Looks up a reaction on a message by emoji argument.
  * The reaction cache is keyed by the emoji id (snowflake) for custom emoji and
@@ -745,6 +761,39 @@ const tools = [
         bot: u.bot,
       }));
       return structured({ reactions: result });
+    },
+  }),
+  defineTool({
+    name: "discord_get_message_attachments",
+    description:
+      "List the file attachments of a message: filename, title (original name when Discord strips non-ASCII from filename), url, content type, size in bytes, image dimensions, alt-text description, voice-message duration and waveform, spoiler flag. Discord signs CDN urls with a 24-hour expiry and does not re-sign on every fetch; re-call this tool if a stored url has expired. Requires View Channel and Read Message History. Read-only. Use discord_read_messages to find messages with attachments.",
+    annotations: { title: "Get message attachments", readOnlyHint: true, openWorldHint: true },
+    schema: z.object({
+      channel_id: channelId.describe(
+        "ID (snowflake) of the channel or thread containing the message.",
+      ),
+      message_id: messageId.describe("ID of the message whose attachments to list."),
+    }),
+    outputSchema: z.object({ attachments: z.array(attachmentInfo) }),
+    handle: async ({ channel_id, message_id }) => {
+      const channel = await getTextChannel(channel_id);
+      const msg = await channel.messages.fetch({ message: message_id, cache: false });
+      const attachments = [...msg.attachments.values()].map((a) => ({
+        id: a.id,
+        filename: a.name,
+        contentType: a.contentType,
+        size: a.size,
+        url: a.url,
+        proxyUrl: a.proxyURL,
+        width: a.width,
+        height: a.height,
+        description: a.description,
+        title: a.title,
+        duration: a.duration,
+        waveform: a.waveform,
+        spoiler: a.spoiler,
+      }));
+      return structured({ attachments });
     },
   }),
   defineTool({

--- a/src/tools/messages.ts
+++ b/src/tools/messages.ts
@@ -74,7 +74,7 @@ const messageSummary = z.object({
   timestamp: z.string(),
 });
 
-const attachmentInfo = z.object({
+const attachmentSummary = z.object({
   id: z.string(),
   filename: z.string(),
   contentType: z.string().nullable(),
@@ -766,7 +766,7 @@ const tools = [
   defineTool({
     name: "discord_get_message_attachments",
     description:
-      "List the file attachments of a message: filename, title (original name when Discord strips non-ASCII from filename), url, content type, size in bytes, image dimensions, alt-text description, voice-message duration and waveform, spoiler flag. Discord signs CDN urls with a 24-hour expiry and does not re-sign on every fetch; re-call this tool if a stored url has expired. Requires View Channel and Read Message History. Read-only. Use discord_read_messages to find messages with attachments.",
+      "List the file attachments of a message. Returns { attachments: [...] } with id, filename, title (the original name when Discord strips non-ASCII from filename), url, proxyUrl, contentType, size in bytes, width, height, alt-text description, voice-message duration and waveform, spoiler flag. Discord signs CDN urls with a 24-hour expiry and does not re-sign on every fetch; re-call this tool if a stored url has expired. Requires the View Channel and Read Message History permissions. Read-only. Use discord_read_messages to find messages with attachments.",
     annotations: { title: "Get message attachments", readOnlyHint: true, openWorldHint: true },
     schema: z.object({
       channel_id: channelId.describe(
@@ -774,7 +774,7 @@ const tools = [
       ),
       message_id: messageId.describe("ID of the message whose attachments to list."),
     }),
-    outputSchema: z.object({ attachments: z.array(attachmentInfo) }),
+    outputSchema: z.object({ attachments: z.array(attachmentSummary) }),
     handle: async ({ channel_id, message_id }) => {
       const channel = await getTextChannel(channel_id);
       const msg = await channel.messages.fetch({ message: message_id, cache: false });

--- a/test/attachments.test.ts
+++ b/test/attachments.test.ts
@@ -125,6 +125,7 @@ test("get_message_attachments maps every attachment field including nullable one
   });
   assert.equal(structured.attachments[1].spoiler, true);
   assert.equal(structured.attachments[1].width, 800);
+  assert.equal(structured.attachments[1].height, 600);
   assert.equal(structured.attachments[1].filename, "c953b519a8c28c42.png");
   assert.equal(structured.attachments[1].title, "전시부스 안내");
   assert.equal(structured.attachments[2].duration, 3.2);

--- a/test/attachments.test.ts
+++ b/test/attachments.test.ts
@@ -1,0 +1,139 @@
+import { test, mock, afterEach } from "node:test";
+import assert from "node:assert/strict";
+import { discord } from "../src/client.js";
+import messages from "../src/tools/messages.js";
+
+const GUILD = "111111111111111111";
+const CHANNEL = "333333333333333333";
+const MESSAGE = "555555555555555555";
+
+afterEach(() => mock.restoreAll());
+
+/** Stubs the channel lookup so the message fetch returns the given attachments. */
+function stubMessageWith(attachments: Map<string, unknown>): Record<string, unknown>[] {
+  const calls: Record<string, unknown>[] = [];
+  const channel = {
+    name: "chan",
+    guildId: GUILD,
+    isDMBased: () => false,
+    isTextBased: () => true,
+    messages: {
+      fetch: async (options: Record<string, unknown>) => {
+        calls.push(options);
+        return { id: MESSAGE, attachments };
+      },
+    },
+  };
+  mock.method(discord.channels, "fetch", async () => channel as never);
+  return calls;
+}
+
+const getAttachments = () => messages.handlers.get("discord_get_message_attachments")!;
+
+test("get_message_attachments advertises both ids as required and is read-only", () => {
+  const definition = messages.definitions.find((d) => d.name === "discord_get_message_attachments");
+  assert.ok(definition, "discord_get_message_attachments should be defined");
+  const schema = definition.inputSchema as {
+    required: string[];
+    additionalProperties: boolean;
+  };
+  assert.deepEqual(schema.required.toSorted(), ["channel_id", "message_id"]);
+  assert.equal(schema.additionalProperties, false);
+  assert.equal(definition.annotations?.readOnlyHint, true);
+  assert.ok(definition.outputSchema, "structured output must be advertised");
+});
+
+test("get_message_attachments maps every attachment field including nullable ones", async () => {
+  const attachments = new Map([
+    [
+      "777777777777777777",
+      {
+        id: "777777777777777777",
+        name: "report.pdf",
+        contentType: "application/pdf",
+        size: 12345,
+        url: "https://cdn.discordapp.com/attachments/1/2/report.pdf?ex=abc",
+        proxyURL: "https://media.discordapp.net/attachments/1/2/report.pdf",
+        width: null,
+        height: null,
+        description: null,
+        title: null,
+        duration: null,
+        waveform: null,
+        spoiler: false,
+      },
+    ],
+    [
+      "888888888888888888",
+      {
+        // Discord strips non-ASCII from the filename and keeps the original in title.
+        id: "888888888888888888",
+        name: "c953b519a8c28c42.png",
+        contentType: "image/png",
+        size: 54321,
+        url: "https://cdn.discordapp.com/attachments/1/3/c953b519a8c28c42.png?ex=def",
+        proxyURL: "https://media.discordapp.net/attachments/1/3/c953b519a8c28c42.png",
+        width: 800,
+        height: 600,
+        description: "a cat",
+        title: "전시부스 안내",
+        duration: null,
+        waveform: null,
+        // A plain name, so a name-prefix check could not pass this: spoiler is flag-based.
+        spoiler: true,
+      },
+    ],
+    [
+      "999999999999999999",
+      {
+        id: "999999999999999999",
+        name: "voice-message.ogg",
+        contentType: "audio/ogg",
+        size: 4321,
+        url: "https://cdn.discordapp.com/attachments/1/4/voice-message.ogg?ex=ghi",
+        proxyURL: "https://media.discordapp.net/attachments/1/4/voice-message.ogg",
+        width: null,
+        height: null,
+        description: null,
+        title: null,
+        duration: 3.2,
+        waveform: "AAECAwQ=",
+        spoiler: false,
+      },
+    ],
+  ]);
+  const calls = stubMessageWith(attachments);
+  const result = await getAttachments()({ channel_id: CHANNEL, message_id: MESSAGE });
+  assert.equal(calls[0].message, MESSAGE, "the requested message must be the one fetched");
+  assert.equal(calls[0].cache, false, "the fetched message must not be stored in the cache");
+  const structured = result.structuredContent as { attachments: Record<string, unknown>[] };
+  assert.equal(structured.attachments.length, 3);
+  assert.deepEqual(structured.attachments[0], {
+    id: "777777777777777777",
+    filename: "report.pdf",
+    contentType: "application/pdf",
+    size: 12345,
+    url: "https://cdn.discordapp.com/attachments/1/2/report.pdf?ex=abc",
+    proxyUrl: "https://media.discordapp.net/attachments/1/2/report.pdf",
+    width: null,
+    height: null,
+    description: null,
+    title: null,
+    duration: null,
+    waveform: null,
+    spoiler: false,
+  });
+  assert.equal(structured.attachments[1].spoiler, true);
+  assert.equal(structured.attachments[1].width, 800);
+  assert.equal(structured.attachments[1].filename, "c953b519a8c28c42.png");
+  assert.equal(structured.attachments[1].title, "전시부스 안내");
+  assert.equal(structured.attachments[2].duration, 3.2);
+  assert.equal(structured.attachments[2].waveform, "AAECAwQ=");
+});
+
+test("get_message_attachments returns an empty list for a message with no attachments", async () => {
+  stubMessageWith(new Map());
+  const result = await getAttachments()({ channel_id: CHANNEL, message_id: MESSAGE });
+  assert.deepEqual(result.structuredContent, { attachments: [] });
+  assert.ok(!result.isError);
+});

--- a/test/server.test.ts
+++ b/test/server.test.ts
@@ -28,7 +28,7 @@ test("unknown tool is a JSON-RPC InvalidParams protocol error, not a tool result
 test("tools/list serves every definition and rejects unexpected cursors", async () => {
   const client = await connectedClient();
   const { tools } = await client.listTools();
-  assert.equal(tools.length, 98, "update this pin when adding/removing tools");
+  assert.equal(tools.length, 99, "update this pin when adding/removing tools");
   await assert.rejects(
     () => client.listTools({ cursor: "bogus" }),
     (err: unknown) => err instanceof McpError && err.code === ErrorCode.InvalidParams,


### PR DESCRIPTION
## Summary

Adds `discord_get_message_attachments`: messages already report an attachment **count** via `discord_read_messages`, but there was no way to reach the files themselves. The Discord API carries everything needed on the message object, so this tool exposes it: filename, title, download url, content type, size in bytes, image dimensions, alt-text description, voice-message duration and waveform, and spoiler flag.

`title` matters more than it looks: Discord strips non-ASCII characters from `filename` and keeps the original in `title`. A Korean-named PDF in a real guild comes back with a hashed `filename` such as `c953b519a8c28c42.pdf` and the real name only in `title` (e.g. `"8월 추천 여행지"`), so a caller who only sees `filename` has lost the name entirely.

## Url lifetime

Discord signs attachment CDN urls with a 24-hour expiry (`ex`/`is`/`hm` query params) and does not re-sign on every fetch: two fetches of the same message minutes apart return the same `hm`, and `is` marks a bucketed issue time rather than the call. While valid, a url downloads without authentication. A client holding an expired url re-calls the tool. The handler passes `cache: false` so the fetched message is not stored in the message cache, matching every other read in the module.

## Changes

- `src/tools/messages.ts` — new `discord_get_message_attachments` tool (read-only, structured output via `outputSchema`)
- `test/attachments.test.ts` — 3 tests: schema advertisement (required ids, `additionalProperties: false`, `readOnlyHint`), full field mapping over three fixtures (a plain PDF, a stripped filename with a non-ASCII `title` and a flag-based spoiler, a voice message with `duration` and `waveform`) plus the fetched message id and `cache: false`, and the empty-attachments case
- `test/server.test.ts` — tool-count pin 98 → 99
- `README.md`, `CHANGELOG.md` — documentation

## Testing

- `npm run build`, `npm test` (67/67 pass), `npm run lint`, `prettier --check` all clean
- Verified end-to-end against a live guild: called the tool on a real message carrying a PNG attachment, then downloaded the returned url with plain `curl` — file size (171,918 bytes) and dimensions (2898×2124) matched the tool's report exactly
- Re-verified after review through this branch's build over stdio, on a message carrying a Korean-named PDF: `title` came back intact next to the stripped `filename`, the `title`/`duration`/`waveform` keys are present, and the url downloaded without auth at 1,420,484 bytes, matching `size`

🤖 Generated with [Claude Code](https://claude.com/claude-code)