### PR TITLE
fix: align the read_messages cursors with the module idioms

### DIFF
--- a/src/tools/messages.ts
+++ b/src/tools/messages.ts
@@ -30,7 +30,7 @@ const afterCursor = snowflake.describe(
   "Return only messages newer than this message ID (snowflake). Page forwards by passing the id of the newest message from the previous call.",
 );
 const aroundCursor = snowflake.describe(
-  "Return messages centred on this message ID (snowflake): Discord splits `limit` either side of it, and an even `limit` puts the extra message on the newer side. Use it to read outward from a known message, such as a discord_search_guild_messages hit.",
+  "Return messages centered on this message ID (snowflake): Discord splits `limit` either side of it, and an even `limit` puts the extra message on the newer side. Use it to read outward from a known message, such as a discord_search_guild_messages hit.",
 );
 const sinceInstant = z
   .union([z.iso.date(), z.iso.datetime({ offset: true })], {
@@ -38,13 +38,9 @@ const sinceInstant = z
       "Must be an ISO 8601 date (2026-08-01) or a date-time with an explicit offset (2026-08-01T09:00:00Z).",
   })
   .describe(
-    'Return only messages posted after this instant, as an ISO 8601 date or a date-time with an explicit offset (e.g. "2026-08-01" or "2026-08-01T09:00:00Z"). Convenience form of `after` for callers that know a date but not a message id.',
+    'Return only messages posted after this instant, as an ISO 8601 date or a date-time with an explicit offset (e.g. "2026-08-01" or "2026-08-01T09:00:00Z"). Convenience form of `after`: the call yields the oldest `limit` messages after that instant, so page forwards with `after` set to the newest id received.',
   );
 
-const SINGLE_CURSOR_MESSAGE =
-  "Pass at most one of before, after, around, or since: Discord treats before/after/around as mutually exclusive, and since is a form of after.";
-
-/** True when at most one paging cursor was supplied. */
 function hasSingleCursor(args: {
   before?: string;
   after?: string;
@@ -60,13 +56,14 @@ function hasSingleCursor(args: {
 /**
  * Converts an ISO 8601 instant into the snowflake an `after` cursor expects.
  * Snowflakes embed a millisecond timestamp, so a synthetic id marks that instant
- * exactly. Instants before the Discord epoch are clamped to it: `generate` returns
- * a negative id for them, which the API rejects. The schema only admits a date or
- * an offset-bearing date-time, both of which `Date.parse` reads as UTC or the given
- * offset, so the result does not depend on the server's timezone.
+ * exactly. The instant is clamped to the Discord epoch on one side (`generate`
+ * returns a negative id before it) and to now on the other (ids overflow 64 bits
+ * past 2154, and nothing can be posted in the future). The schema only admits a
+ * date or an offset-bearing date-time, both of which `Date.parse` reads as UTC or
+ * the given offset, so the result does not depend on the server's timezone.
  */
 function cursorForInstant(iso: string): string {
-  const timestamp = Math.max(Date.parse(iso), Number(SnowflakeUtil.epoch));
+  const timestamp = Math.min(Math.max(Date.parse(iso), Number(SnowflakeUtil.epoch)), Date.now());
   return SnowflakeUtil.generate({ timestamp }).toString();
 }
 
@@ -101,7 +98,7 @@ const tools = [
   defineTool({
     name: "discord_read_messages",
     description:
-      "Read messages from a text channel or thread, oldest-to-newest. Page backwards by re-calling with before set to the id of the oldest message you received, which walks a channel past the 100-message per-call cap. Requires View Channel and Read Message History. Returns { messages: [...] } with id, author, content, timestamp, attachment count, pinned flag. Use discord_search_messages to filter by keyword, or discord_fetch_pinned_messages for pinned messages only.",
+      "Read messages from a text channel or thread, oldest-to-newest. Page backwards by re-calling with before set to the id of the oldest message you received, which walks a channel past the 100-message per-call cap. Requires the View Channel and Read Message History permissions. Returns { messages: [...] } with id, author, content, timestamp, attachment count, pinned flag. Use discord_search_messages to filter by keyword, or discord_fetch_pinned_messages for pinned messages only.",
     annotations: { title: "Read messages", readOnlyHint: true, openWorldHint: true },
     schema: z
       .object({
@@ -114,7 +111,10 @@ const tools = [
         around: aroundCursor.optional(),
         since: sinceInstant.optional(),
       })
-      .refine(hasSingleCursor, { message: SINGLE_CURSOR_MESSAGE }),
+      .refine(
+        hasSingleCursor,
+        "Pass at most one of before, after, around, or since: Discord treats before/after/around as mutually exclusive, and since is a form of after.",
+      ),
     outputSchema: z.object({
       messages: z.array(messageSummary.extend({ attachments: z.number(), pinned: z.boolean() })),
     }),
@@ -124,9 +124,9 @@ const tools = [
       const messages = await channel.messages.fetch({
         limit,
         cache: false,
-        ...(before === undefined ? {} : { before }),
-        ...(around === undefined ? {} : { around }),
-        ...(resolvedAfter === undefined ? {} : { after: resolvedAfter }),
+        before,
+        after: resolvedAfter,
+        around,
       });
       const result = [...messages.values()]
         .sort((a, b) => a.createdTimestamp - b.createdTimestamp)

--- a/test/paging.test.ts
+++ b/test/paging.test.ts
@@ -55,17 +55,17 @@ test("read_messages sends no cursor when none was requested", async () => {
   const calls = captureFetches();
   await read()({ channel_id: CHANNEL });
   assert.equal(calls.length, 1);
-  assert.ok(!("before" in calls[0]), "an absent cursor must not be sent as an undefined key");
-  assert.ok(!("after" in calls[0]), "an absent cursor must not be sent as an undefined key");
-  assert.ok(!("around" in calls[0]), "an absent cursor must not be sent as an undefined key");
+  assert.equal(calls[0].before, undefined);
+  assert.equal(calls[0].after, undefined);
+  assert.equal(calls[0].around, undefined);
 });
 
 test("read_messages passes before through untouched", async () => {
   const calls = captureFetches();
   await read()({ channel_id: CHANNEL, before: OLDEST, limit: 100 });
   assert.equal(calls[0].before, OLDEST);
-  assert.ok(!("after" in calls[0]));
-  assert.ok(!("around" in calls[0]));
+  assert.equal(calls[0].after, undefined);
+  assert.equal(calls[0].around, undefined);
   assert.equal(calls[0].limit, 100);
   assert.equal(calls[0].cache, false, "history reads must not fill the message cache");
 });
@@ -74,16 +74,16 @@ test("read_messages passes after through untouched", async () => {
   const calls = captureFetches();
   await read()({ channel_id: CHANNEL, after: OLDEST });
   assert.equal(calls[0].after, OLDEST, "a caller-supplied after must not be dropped or rewritten");
-  assert.ok(!("before" in calls[0]));
-  assert.ok(!("around" in calls[0]));
+  assert.equal(calls[0].before, undefined);
+  assert.equal(calls[0].around, undefined);
 });
 
 test("read_messages passes around through untouched", async () => {
   const calls = captureFetches();
   await read()({ channel_id: CHANNEL, around: OLDEST });
   assert.equal(calls[0].around, OLDEST);
-  assert.ok(!("before" in calls[0]));
-  assert.ok(!("after" in calls[0]));
+  assert.equal(calls[0].before, undefined);
+  assert.equal(calls[0].after, undefined);
 });
 
 test("read_messages converts since into an after snowflake", async () => {
@@ -96,7 +96,7 @@ test("read_messages converts since into an after snowflake", async () => {
     "2026-08-01T00:00:00.000Z",
     "the synthetic cursor must carry the requested instant",
   );
-  assert.ok(!("before" in calls[0]));
+  assert.equal(calls[0].before, undefined);
 });
 
 test("read_messages clamps a pre-epoch since instead of sending a negative id", async () => {
@@ -109,6 +109,16 @@ test("read_messages clamps a pre-epoch since instead of sending a negative id", 
     Number(SnowflakeUtil.epoch),
     "instants before the Discord epoch clamp to it",
   );
+});
+
+test("read_messages clamps a future since to now instead of overflowing the id", async () => {
+  const calls = captureFetches();
+  const before = Date.now();
+  await read()({ channel_id: CHANNEL, since: "2200-01-01" });
+  const after = calls[0].after as string;
+  assert.ok(BigInt(after) < 1n << 64n, `snowflakes are 64-bit, got ${after}`);
+  const stamped = Number(SnowflakeUtil.timestampFrom(after));
+  assert.ok(stamped >= before && stamped <= Date.now(), "a future instant clamps to now");
 });
 
 test("read_messages rejects more than one cursor", async () => {


### PR DESCRIPTION
Follow-up to #110, which is merged and unreleased. A second pass compared the cursor code against the module's own idioms and the sibling read tools.

Changes, all in `src/tools/messages.ts` and its tests:

1. Optional cursors are passed straight to `messages.fetch`, as `members.ts` and `forums.ts` do. `makeURLSearchParams` drops `undefined` values, so the conditional spreads bought nothing. The tests now assert the keys are `undefined` instead of absent.
2. `since` is clamped to now on top of the epoch clamp. `SnowflakeUtil.generate` has no upper bound and ids overflow 64 bits past 2154, which Discord answers with a 400. Test added.
3. The `since` description says the call yields the oldest `limit` messages after the instant and that forward paging uses `after`. Without it, `since: "2026-01-01"` on a busy channel silently returns the first 20 messages of that day.
4. `.refine` uses the positional message form of `define.ts` and `roles.ts`, the module const is gone.
5. The permission sentence reads `Requires the ... permissions.` like the other 41 descriptions, and `centred` is spelled the US way like the rest of the code.

Verified: build, lint, format, 74 tests. Live against the test guild: offset-less `since` rejected under three timezones, `Z` and date-only forms identical across them, backward paging without duplicates, `around` split unchanged at limit 2, 10, 11. `since` values in 2200 and 9999 return an empty list instead of a 400; `1999-01-01` still returns the oldest messages. Merges clean with #117.