### PR TITLE
chore: sweep em dashes and sharpen two descriptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,14 @@
 
 ### Added
 
-- `discord_read_messages` accepts the `before`, `after` and `around` cursors Discord's messages endpoint supports, plus a `since` convenience, so a channel can be read past the 100-message per-call cap. Page backwards by re-calling with `before` set to the id of the oldest message received; `since` takes an ISO 8601 date or a date-time with an explicit offset and is converted to the equivalent `after` snowflake. At most one cursor per call, matching Discord's endpoint, and instants before the Discord epoch clamp to it rather than sending a negative id
+- `discord_read_messages` accepts the `before`, `after` and `around` cursors Discord's messages endpoint supports, plus a `since` convenience, so a channel can be read past the 100-message per-call cap. Page backwards by re-calling with `before` set to the id of the oldest message received; `since` takes an ISO 8601 date or a date-time with an explicit offset and is converted to the equivalent `after` snowflake. At most one cursor per call, matching Discord's endpoint, and instants before the Discord epoch or in the future clamp to those bounds rather than sending an invalid id
 - `discord_get_message_attachments` lists a message's file attachments: filename, original title (Discord strips non-ASCII characters from the filename), download url, content type, size, image dimensions, alt-text description, voice-message duration and waveform, spoiler flag. Discord signs attachment CDN urls with a 24-hour expiry and does not re-sign on every fetch; re-call the tool if a stored url has expired
+
+### Changed
+
+- `discord_set_role_permission` warns in its description that denying View Channel to @everyone also locks the bot out unless it holds an allow overwrite of its own
+- `discord_get_server_stats` describes `botsInCache` as a lower bound and `humans` as an upper bound, since both come from a member cache that is swept
+- Error messages no longer contain an em dash: validation failures read `Invalid arguments. field: reason` (the separator was an em dash) and Discord API hints follow the code and status after a period. The eleven tool descriptions that carried one are reworded the same way
 
 ## [2.1.1] - 2026-08-04
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 [![discord-mcp MCP server](https://glama.ai/mcp/servers/PaSympa/discord-mcp/badges/score.svg)](https://glama.ai/mcp/servers/PaSympa/discord-mcp)
 
 Manage your entire Discord server from **Claude Desktop**, **Claude Code**, **Cursor**, **VS Code Copilot**, or any MCP-compatible client.
-Messages, channels, roles, permissions, moderation, forums, webhooks — all through natural language.
+Messages, channels, roles, permissions, moderation, forums, webhooks, all through natural language.
 
 </div>
 
@@ -21,11 +21,11 @@ Messages, channels, roles, permissions, moderation, forums, webhooks — all thr
 
 ## Why this one?
 
-- **95+ tools** — messages, channels, roles, permissions, moderation, forums, webhooks, scheduled events, invites, DMs, embeds, and more
-- **Multi-guild** — works across multiple servers, no `GUILD_ID` lock-in
-- **Lightweight** — TypeScript + Node.js, ~70kB package, ~73MB Docker image (vs 400MB+ for Java alternatives)
-- **Modular** — clean architecture, easy to extend with new tools
-- **Two install methods** — npm or Docker, your choice
+- **95+ tools**: messages, channels, roles, permissions, moderation, forums, webhooks, scheduled events, invites, DMs, embeds, and more
+- **Multi-guild**: works across multiple servers, no `GUILD_ID` lock-in
+- **Lightweight**: TypeScript + Node.js, ~70kB package, ~73MB Docker image (vs 400MB+ for Java alternatives)
+- **Modular**: clean architecture, easy to extend with new tools
+- **Two install methods**: npm or Docker, your choice
 
 ---
 
@@ -47,7 +47,7 @@ Add this to your MCP client config and replace `YOUR_TOKEN_HERE` with your bot t
 }
 ```
 
-No install needed — `npx` handles everything.
+No install needed, `npx` handles everything.
 
 > Don't have a bot yet? See [Creating Your Discord Bot](#creating-your-discord-bot).
 
@@ -177,21 +177,21 @@ The server loads `.env` automatically via `dotenv`.
 
 ### Environment variables
 
-| Variable                  | Default | Description                                                                                                                                                                                   |
-| ------------------------- | ------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `DISCORD_TOKEN`           | —       | **Required.** Bot token.                                                                                                                                                                      |
-| `DISCORD_MESSAGE_CONTENT` | `true`  | Set to `false` to stop requesting the Message Content privileged gateway intent at connect time.                                                                                              |
-| `DISCORD_GUILD_MEMBERS`   | `true`  | Set to `false` to stop requesting the Server Members privileged gateway intent at connect time.                                                                                               |
-| `DISCORD_MCP_TOOLSETS`    | `all`   | Comma-separated list of toolsets to expose, to keep the tool list small. Unset or `all` exposes every tool.                                                                                   |
-| `DISCORD_ALLOWED_GUILDS`  | all     | Comma-separated guild IDs the server may act on. When set, tool calls targeting any other guild are rejected — whether addressed by guild ID, channel ID, thread ID, webhook, or invite code. |
+| Variable                  | Default | Description                                                                                                                                                                                  |
+| ------------------------- | ------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `DISCORD_TOKEN`           | none    | **Required.** Bot token.                                                                                                                                                                     |
+| `DISCORD_MESSAGE_CONTENT` | `true`  | Set to `false` to stop requesting the Message Content privileged gateway intent at connect time.                                                                                             |
+| `DISCORD_GUILD_MEMBERS`   | `true`  | Set to `false` to stop requesting the Server Members privileged gateway intent at connect time.                                                                                              |
+| `DISCORD_MCP_TOOLSETS`    | `all`   | Comma-separated list of toolsets to expose, to keep the tool list small. Unset or `all` exposes every tool.                                                                                  |
+| `DISCORD_ALLOWED_GUILDS`  | all     | Comma-separated guild IDs the server may act on. When set, tool calls targeting any other guild are rejected, whether addressed by guild ID, channel ID, thread ID, webhook, or invite code. |
 
 Since 2.1.1 the server no longer requests the `GuildMessages` intent at all: nothing here subscribes to message events, and every message this server returns is fetched over REST, which connection intents do not gate. That intent used to make discord.js cache every message flowing through every channel, together with its author, which grew unbounded on a long-running server. Cache sweepers now bound what remains. `DISCORD_MESSAGE_CONTENT` therefore only affects whether the Message Content intent is requested at connect time; it does not change what any tool returns.
 
-These flags only control which gateway intents the server requests when identifying. Requesting a privileged intent that is **not** enabled in the Developer Portal makes the connection fail at the first tool call (close code `4014`) — set the flag to `false` to connect anyway.
+These flags only control which gateway intents the server requests when identifying. Requesting a privileged intent that is **not** enabled in the Developer Portal makes the connection fail at the first tool call (close code `4014`); set the flag to `false` to connect anyway.
 
-Data access is governed by the **portal toggles**, not by these flags: this server reads everything over the REST API, which Discord gates on the portal setting alone. So with the portal toggles on, setting these flags to `false` loses nothing. With a portal toggle **off**, the corresponding data is restricted regardless of the flags: message bodies come back empty (`content`, `embeds`, `attachments` — except the bot's own messages, DMs, and messages that mention the bot) and member listing fails — enable the toggle in the portal to restore it.
+Data access is governed by the **portal toggles**, not by these flags: this server reads everything over the REST API, which Discord gates on the portal setting alone. So with the portal toggles on, setting these flags to `false` loses nothing. With a portal toggle **off**, the corresponding data is restricted regardless of the flags: message bodies come back empty (`content`, `embeds`, `attachments`; except the bot's own messages, DMs, and messages that mention the bot) and member listing fails; enable the toggle in the portal to restore it.
 
-**Toolsets** (`DISCORD_MCP_TOOLSETS`): `discovery`, `messages`, `channels`, `permissions`, `members`, `roles`, `moderation`, `screening`, `stats`, `forums`, `webhooks`, `scheduled_events`, `invites`, `dm`. Example — `DISCORD_MCP_TOOLSETS=discovery,messages,members` exposes only the discovery, message, and member tools. Note: a toolset ships its whole module, including its destructive tools (`messages` includes bulk delete; `members` includes kick/ban) — use `DISCORD_ALLOWED_GUILDS` and the dry-run defaults to bound them. Only the listed toolsets' tools are advertised and callable. Unknown names make the server fail at startup instead of silently exposing everything (an empty value counts as unset and exposes all).
+**Toolsets** (`DISCORD_MCP_TOOLSETS`): `discovery`, `messages`, `channels`, `permissions`, `members`, `roles`, `moderation`, `screening`, `stats`, `forums`, `webhooks`, `scheduled_events`, `invites`, `dm`. Example; `DISCORD_MCP_TOOLSETS=discovery,messages,members` exposes only the discovery, message, and member tools. Note: a toolset ships its whole module, including its destructive tools (`messages` includes bulk delete; `members` includes kick/ban); use `DISCORD_ALLOWED_GUILDS` and the dry-run defaults to bound them. Only the listed toolsets' tools are advertised and callable. Unknown names make the server fail at startup instead of silently exposing everything (an empty value counts as unset and exposes all).
 
 ---
 
@@ -468,7 +468,7 @@ discord-mcp/
 - Use environment variables or a `.env` file (not versioned)
 - Give the bot only the permissions it needs
 - Restrict the server to specific servers with `DISCORD_ALLOWED_GUILDS`
-- Irreversible mass actions (`bulk_ban`, `prune_members`, `bulk_delete_messages`, `delete_channel`) default to a `dry_run` preview — pass `dry_run:false` to apply
+- Irreversible mass actions (`bulk_ban`, `prune_members`, `bulk_delete_messages`, `delete_channel`) default to a `dry_run` preview; pass `dry_run:false` to apply
 
 ---
 
@@ -478,11 +478,11 @@ Contributions are welcome!
 
 1. Fork the repository
 2. Create a feature branch (`git checkout -b feature/my-feature`)
-3. Follow the modular structure — see [Adding a new tool](#adding-a-new-tool)
+3. Follow the modular structure, see [Adding a new tool](#adding-a-new-tool)
 4. Commit your changes and open a pull request
 
 ---
 
 ## License
 
-MIT — see [LICENSE](LICENSE) for details.
+MIT, see [LICENSE](LICENSE) for details.

--- a/src/client.ts
+++ b/src/client.ts
@@ -70,7 +70,7 @@ discord.on(Events.Error, (err) => console.error("Discord client error:", err.mes
 discord.on(Events.ShardError, (err) => console.error("Discord shard error:", err.message));
 discord.on(Events.Invalidated, () => {
   console.error(
-    "Discord session invalidated — connection is dead; the next tool call will re-login.",
+    "Discord session invalidated: the connection is dead and the next tool call will re-login.",
   );
   discordReady = false;
   loginPromise = null;

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -3,15 +3,15 @@ import { ZodError } from "zod";
 
 /** Plain-language hints for the Discord API error codes most likely to surface through these tools. */
 const DISCORD_ERROR_HINTS: Record<number, string> = {
-  10003: "Unknown channel — check channel_id.",
-  10004: "Unknown guild — the bot is not in that server or guild_id is wrong.",
-  10008: "Unknown message — wrong message_id, or it was already deleted.",
-  10011: "Unknown role — check role_id.",
-  10013: "Unknown user — check user_id.",
-  10026: "Unknown ban — the user is not banned.",
-  50001: "Missing access — the bot is not in the guild or cannot see this channel.",
-  50013: "Missing permissions — the bot lacks the permission this action requires.",
-  50035: "Invalid form body — one or more arguments are invalid.",
+  10003: "Unknown channel; check channel_id.",
+  10004: "Unknown guild; the bot is not in that server or guild_id is wrong.",
+  10008: "Unknown message; wrong message_id, or it was already deleted.",
+  10011: "Unknown role; check role_id.",
+  10013: "Unknown user; check user_id.",
+  10026: "Unknown ban; the user is not banned.",
+  50001: "Missing access; the bot is not in the guild or cannot see this channel.",
+  50013: "Missing permissions; the bot lacks the permission this action requires.",
+  50035: "Invalid form body; one or more arguments are invalid.",
 };
 
 /** Formats an error for the MCP client, surfacing DiscordAPIError code/status and an actionable hint. */
@@ -23,13 +23,13 @@ export function formatToolError(err: unknown): string {
         return path ? `${path}: ${i.message}` : i.message;
       })
       .join("; ");
-    return `Invalid arguments — ${detail}`;
+    return `Invalid arguments. ${detail}`;
   }
   if (err instanceof DiscordAPIError) {
     const code = Number(err.code);
     const hint = DISCORD_ERROR_HINTS[code];
     const base = `Discord API error ${err.code} (HTTP ${err.status}): ${err.message}`;
-    return hint ? `${base} — ${hint}` : base;
+    return hint ? `${base}. ${hint}` : base;
   }
   return err instanceof Error ? err.message : String(err);
 }

--- a/src/tools/invites.ts
+++ b/src/tools/invites.ts
@@ -66,7 +66,7 @@ const tools = [
   defineTool({
     name: "discord_get_invite",
     description:
-      "Look up a single invite by its code: target server and channel, inviter, and expiry. Works for any public invite, but this endpoint never returns usage counters (uses/max_uses/max_age read 0) — use discord_list_invites or discord_list_channel_invites for real counters. Read-only. Returns a JSON object.",
+      "Look up a single invite by its code: target server and channel, inviter, and expiry. Works for any public invite, but this endpoint never returns usage counters (uses/max_uses/max_age read 0); use discord_list_invites or discord_list_channel_invites for real counters. Read-only. Returns a JSON object.",
     annotations: { title: "Get invite", readOnlyHint: true, openWorldHint: true },
     schema: z.object({
       invite_code: z

--- a/src/tools/members.ts
+++ b/src/tools/members.ts
@@ -328,7 +328,7 @@ const tools = [
         .array(snowflake)
         .min(1)
         .max(200)
-        .describe("Array of user IDs (snowflakes) to ban (max 200 per call — Discord API limit)."),
+        .describe("Array of user IDs (snowflakes) to ban (max 200 per call, a Discord API limit)."),
       delete_message_seconds: intIn(0, 604800)
         .default(0)
         .describe(

--- a/src/tools/messages.ts
+++ b/src/tools/messages.ts
@@ -529,7 +529,7 @@ const tools = [
   defineTool({
     name: "discord_search_messages",
     description:
-      "Keyword search over a channel's recent messages using case-insensitive substring matching. Scans only up to the last 100 messages — it does not search full history. Returns { matches: [...] } with id, author, content, timestamp. Use discord_read_messages to fetch recent messages without filtering.",
+      "Keyword search over a channel's recent messages using case-insensitive substring matching. Scans only up to the last 100 messages; it does not search full history. Returns { matches: [...] } with id, author, content, timestamp. Use discord_read_messages to fetch recent messages without filtering.",
     annotations: { title: "Search messages", readOnlyHint: true, openWorldHint: true },
     schema: z.object({
       channel_id: snowflake.describe("ID (snowflake) of the channel or thread to search."),
@@ -641,7 +641,7 @@ const tools = [
       const channel = await fetchChannelChecked(channel_id);
       if (!channel || channel.type !== ChannelType.GuildAnnouncement)
         throw new Error(
-          "Channel is not an announcement channel — only announcement-channel messages can be published.",
+          "Channel is not an announcement channel; only announcement-channel messages can be published.",
         );
       const msg = await channel.messages.fetch({ message: message_id, cache: false });
       try {

--- a/src/tools/moderation.ts
+++ b/src/tools/moderation.ts
@@ -17,7 +17,7 @@ const tools = [
   defineTool({
     name: "discord_get_audit_log",
     description:
-      "Fetch the server's audit log — a record of administrative actions (bans, kicks, role/channel changes, etc.) with who performed them and when. Requires the View Audit Log permission. Returns { entries: [...] } with id, action, executor, target, reason, createdAt. Read-only.",
+      "Fetch the server's audit log, the record of administrative actions (bans, kicks, role/channel changes, etc.) with who performed them and when. Requires the View Audit Log permission. Returns { entries: [...] } with id, action, executor, target, reason, createdAt. Read-only.",
     annotations: { title: "Get audit log", readOnlyHint: true, openWorldHint: true },
     schema: z.object({
       guild_id: guildId,

--- a/src/tools/permissions.ts
+++ b/src/tools/permissions.ts
@@ -47,7 +47,7 @@ const tools = [
   defineTool({
     name: "discord_set_role_permission",
     description:
-      "Add or update a per-channel permission overwrite for a role, allowing and/or denying specific permissions. Merges with the role's existing overwrite (does not reset it). Requires the Manage Roles permission. Use discord_set_member_permission to target a single member instead.",
+      "Add or update a per-channel permission overwrite for a role, allowing and/or denying specific permissions. Merges with the role's existing overwrite (does not reset it). Denying View Channel to @everyone also locks the bot out unless it holds an allow overwrite of its own; grant that with discord_set_member_permission before the deny. Requires the Manage Roles permission. Use discord_set_member_permission to target a single member instead.",
     annotations: {
       title: "Set role channel permission",
       readOnlyHint: false,
@@ -128,7 +128,7 @@ const tools = [
   defineTool({
     name: "discord_reset_channel_permissions",
     description:
-      "Remove ALL permission overwrites on a channel, so only role/server-level permissions apply. Does NOT re-sync with the category — use discord_lock_channel_permissions for that. IRREVERSIBLE — the cleared overwrites cannot be recovered. Requires the Manage Roles permission.",
+      "Remove ALL permission overwrites on a channel, so only role/server-level permissions apply. Does NOT re-sync with the category; use discord_lock_channel_permissions for that. IRREVERSIBLE: the cleared overwrites cannot be recovered. Requires the Manage Roles permission.",
     annotations: {
       title: "Reset channel permissions",
       readOnlyHint: false,

--- a/src/tools/roles.ts
+++ b/src/tools/roles.ts
@@ -233,7 +233,7 @@ const tools = [
   defineTool({
     name: "discord_get_role_members",
     description:
-      "List members who currently hold a specific role, scanning up to 20,000 members. Returns { members: [...], truncated } — check `truncated` on very large servers. Read-only. Use discord_list_roles to discover role IDs first.",
+      "List members who currently hold a specific role, scanning up to 20,000 members. Returns { members: [...], truncated }; check `truncated` on very large servers. Read-only. Use discord_list_roles to discover role IDs first.",
     annotations: { title: "Get role members", readOnlyHint: true, openWorldHint: true },
     schema: z.object({
       guild_id: guildId,
@@ -301,7 +301,7 @@ const tools = [
       const maxPosition = guild.roles.cache.size - 1;
       if (position > maxPosition)
         throw new Error(
-          `position ${position} is out of range — this server's highest role position is ${maxPosition}.`,
+          `position ${position} is out of range; this server's highest role position is ${maxPosition}.`,
         );
       await role.setPosition(position);
       return {
@@ -312,7 +312,7 @@ const tools = [
   defineTool({
     name: "discord_set_role_icon",
     description:
-      "Set or clear a role's icon — either a custom image or a unicode emoji. Requires the server to be Boost Level 2+ (the ROLE_ICONS feature) and the Manage Roles permission. Pass null to either field to remove that icon. Returns a confirmation.",
+      "Set or clear a role's icon, either a custom image or a unicode emoji. Requires the server to be Boost Level 2+ (the ROLE_ICONS feature) and the Manage Roles permission. Pass null to either field to remove that icon. Returns a confirmation.",
     annotations: {
       title: "Set role icon",
       readOnlyHint: false,

--- a/src/tools/scheduledEvents.ts
+++ b/src/tools/scheduledEvents.ts
@@ -216,7 +216,7 @@ const tools = [
   defineTool({
     name: "discord_edit_scheduled_event",
     description:
-      "Update a scheduled event; only provided fields change. Use the status field to start ('ACTIVE'), end ('COMPLETED'), or cancel ('CANCELED') an event — note Discord only allows certain status transitions. Requires the Manage Events permission.",
+      "Update a scheduled event; only provided fields change. Use the status field to start ('ACTIVE'), end ('COMPLETED'), or cancel ('CANCELED') an event; Discord only allows certain status transitions. Requires the Manage Events permission.",
     annotations: {
       title: "Edit scheduled event",
       readOnlyHint: false,
@@ -388,7 +388,7 @@ const tools = [
         );
       if (event.entityType !== GuildScheduledEventEntityType.External && channel_id)
         throw new Error(
-          "channel_id is only honored for EXTERNAL events — VOICE/STAGE invites always point at the event's own channel; omit channel_id.",
+          "channel_id is only honored for EXTERNAL events; VOICE/STAGE invites always point at the event's own channel; omit channel_id.",
         );
       const url = await event.createInviteURL({
         channel: channel_id,

--- a/src/tools/screening.ts
+++ b/src/tools/screening.ts
@@ -7,7 +7,7 @@ const tools = [
   defineTool({
     name: "discord_get_membership_screening",
     description:
-      "Fetch the server's membership screening form — the rules/questions new members must accept before gaining access. Requires the server to have the Community feature enabled. Read-only. Returns the form as JSON, including its version.",
+      "Fetch the server's membership screening form, the rules/questions new members must accept before gaining access. Requires the server to have the Community feature enabled. Read-only. Returns the form as JSON, including its version.",
     annotations: { title: "Get membership screening", readOnlyHint: true, openWorldHint: true },
     schema: z.object({
       guild_id: guildId,

--- a/src/tools/stats.ts
+++ b/src/tools/stats.ts
@@ -8,7 +8,7 @@ const tools = [
   defineTool({
     name: "discord_get_server_stats",
     description:
-      "Get a snapshot of server metrics: total members (humans vs cached bots), channel breakdown (text/voice/category), role count, boost tier and count, and creation date. Read-only. Returns a JSON object. Note: the bot count reflects only members currently in cache.",
+      "Get a snapshot of server metrics: total members (humans vs cached bots), channel breakdown (text/voice/category), role count, boost tier and count, and creation date. Read-only. Returns a JSON object. Note: bots are counted from the member cache only, so botsInCache is a lower bound and humans (total minus cached bots) an upper bound.",
     annotations: { title: "Get server stats", readOnlyHint: true, openWorldHint: true },
     schema: z.object({
       guild_id: guildId,

--- a/src/tools/webhooks.ts
+++ b/src/tools/webhooks.ts
@@ -21,7 +21,7 @@ const tools = [
   defineTool({
     name: "discord_create_webhook",
     description:
-      "Create a webhook on a channel and return its ID and token. SECURITY: the returned token grants anyone the ability to post as this webhook without authentication — treat it as a secret. Requires the Manage Webhooks permission. Use the returned id+token with discord_send_webhook_message.",
+      "Create a webhook on a channel and return its ID and token. SECURITY: the returned token grants anyone the ability to post as this webhook without authentication; treat it as a secret. Requires the Manage Webhooks permission. Use the returned id+token with discord_send_webhook_message.",
     annotations: {
       title: "Create webhook",
       readOnlyHint: false,
@@ -53,7 +53,7 @@ const tools = [
   defineTool({
     name: "discord_send_webhook_message",
     description:
-      "Send a message through a webhook using its ID and token (no bot permissions needed — the token authorizes the send). Supports per-message username/avatar overrides and up to 10 embeds. At least one of content or embeds is required. Returns the new message ID.",
+      "Send a message through a webhook using its ID and token (no bot permissions needed; the token authorizes the send). Supports per-message username/avatar overrides and up to 10 embeds. At least one of content or embeds is required. Returns the new message ID.",
     annotations: {
       title: "Send webhook message",
       readOnlyHint: false,
@@ -89,7 +89,7 @@ const tools = [
         const guildOfWebhook = (await discord.fetchWebhook(webhook_id, webhook_token)).guildId;
         if (!guildOfWebhook)
           throw new Error(
-            "Webhook has no resolvable guild — refused while DISCORD_ALLOWED_GUILDS is active.",
+            "Webhook has no resolvable guild; refused while DISCORD_ALLOWED_GUILDS is active.",
           );
         assertAllowedGuild(guildOfWebhook);
       }
@@ -149,7 +149,7 @@ const tools = [
   defineTool({
     name: "discord_delete_webhook",
     description:
-      "Permanently delete a webhook by its ID, invalidating its token. IRREVERSIBLE — any integrations using the old token will stop working. Requires the Manage Webhooks permission.",
+      "Permanently delete a webhook by its ID, invalidating its token. IRREVERSIBLE: any integrations using the old token will stop working. Requires the Manage Webhooks permission.",
     annotations: {
       title: "Delete webhook",
       readOnlyHint: false,
@@ -251,7 +251,7 @@ const tools = [
         const guildOfWebhook = (await discord.fetchWebhook(webhook_id, webhook_token)).guildId;
         if (!guildOfWebhook)
           throw new Error(
-            "Webhook has no resolvable guild — refused while DISCORD_ALLOWED_GUILDS is active.",
+            "Webhook has no resolvable guild; refused while DISCORD_ALLOWED_GUILDS is active.",
           );
         assertAllowedGuild(guildOfWebhook);
       }
@@ -290,7 +290,7 @@ const tools = [
         const guildOfWebhook = (await discord.fetchWebhook(webhook_id, webhook_token)).guildId;
         if (!guildOfWebhook)
           throw new Error(
-            "Webhook has no resolvable guild — refused while DISCORD_ALLOWED_GUILDS is active.",
+            "Webhook has no resolvable guild; refused while DISCORD_ALLOWED_GUILDS is active.",
           );
         assertAllowedGuild(guildOfWebhook);
       }
@@ -326,7 +326,7 @@ const tools = [
         const guildOfWebhook = (await discord.fetchWebhook(webhook_id, webhook_token)).guildId;
         if (!guildOfWebhook)
           throw new Error(
-            "Webhook has no resolvable guild — refused while DISCORD_ALLOWED_GUILDS is active.",
+            "Webhook has no resolvable guild; refused while DISCORD_ALLOWED_GUILDS is active.",
           );
         assertAllowedGuild(guildOfWebhook);
       }

--- a/test/allowlist.test.ts
+++ b/test/allowlist.test.ts
@@ -70,11 +70,11 @@ test("no tool module bypasses the checked channel fetch", () => {
     const src = readFileSync(join(dir, file), "utf-8");
     assert.ok(
       !/discord\.channels\.fetch/.test(src),
-      `${file} calls discord.channels.fetch directly — use fetchChannelChecked/getTextChannel/getGuildChannel`,
+      `${file} calls discord.channels.fetch directly; use fetchChannelChecked/getTextChannel/getGuildChannel`,
     );
     assert.ok(
       !/guild_id:\s*snowflake\b/.test(src),
-      `${file} declares a raw guild_id: snowflake input — use the allow-list-enforcing guildId fragment`,
+      `${file} declares a raw guild_id: snowflake input; use the allow-list-enforcing guildId fragment`,
     );
   }
 });

--- a/test/server.test.ts
+++ b/test/server.test.ts
@@ -58,7 +58,7 @@ test("formatToolError flattens ZodError paths and surfaces Discord hints", () =>
   const zerr = z.object({ channel_id: z.string() }).safeParse({ channel_id: 1 });
   assert.ok(!zerr.success);
   const msg = formatToolError(zerr.error as ZodError);
-  assert.match(msg, /^Invalid arguments — channel_id: /);
+  assert.match(msg, /^Invalid arguments\. channel_id: /);
 
   const derr = new DiscordAPIError(
     { code: 50013, message: "Missing Permissions" },
@@ -70,7 +70,7 @@ test("formatToolError flattens ZodError paths and surfaces Discord hints", () =>
   );
   const dmsg = formatToolError(derr);
   assert.match(dmsg, /50013/);
-  assert.match(dmsg, /Missing permissions — the bot lacks/);
+  assert.match(dmsg, /Missing permissions; the bot lacks/);
 
   assert.equal(formatToolError(new Error("boom")), "boom");
 });


### PR DESCRIPTION
The batched description lot, shipped in one release so Canopii's description guard fires once, alongside the `discord_read_messages` rewrite already on main.

1. `discord_set_role_permission` warns that denying View Channel to @everyone also locks the bot out unless it holds an allow overwrite of its own, and says to grant that first. Only Administrator bypasses overwrites; the bot self-locked once during the 2026-06-11 campaign.
2. `discord_get_server_stats` describes `botsInCache` as a lower bound and `humans` as an upper bound. Both derive from a member cache the sweepers empty.
3. Every em dash in `src/`, `test/` and README is gone. Eleven tool descriptions and one field description are reworded with a comma, semicolon or colon. Error strings change shape: validation failures read `Invalid arguments. field: reason`, Discord API hints follow the code and status after a period. The two tests pinning those formats are updated, and CHANGELOG records the change since 2.0.0 documented the old format.

Verified: build, lint, format, 77 tests. Live against the test guild: a 404 on a message reads `Discord API error 10008 (HTTP 404): Unknown Message. Unknown message; wrong message_id, or it was already deleted.`, a malformed id reads `Invalid arguments. message_id: Must be a Discord snowflake ID (17-20 digits).`, and the read tools return the same output as before.

| Description | Characters |
| --- | --- |
| `discord_set_role_permission` before | 276 |
| `discord_set_role_permission` after | 443 |
| longest in the set, `discord_get_message_attachments` | 556 |