### PR TITLE
release: 2.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [Unreleased]
+## [2.2.0] - 2026-09-03
 
 ### Added
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@pasympa/discord-mcp",
-  "version": "2.1.1",
+  "version": "2.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@pasympa/discord-mcp",
-      "version": "2.1.1",
+      "version": "2.2.0",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pasympa/discord-mcp",
-  "version": "2.1.1",
+  "version": "2.2.0",
   "mcpName": "io.github.PaSympa/discord-mcp",
   "description": "A lightweight, multi-guild Discord MCP server with 95+ tools",
   "main": "dist/index.js",

--- a/server.json
+++ b/server.json
@@ -6,12 +6,12 @@
     "url": "https://github.com/PaSympa/discord-mcp",
     "source": "github"
   },
-  "version": "2.1.1",
+  "version": "2.2.0",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "@pasympa/discord-mcp",
-      "version": "2.1.1",
+      "version": "2.2.0",
       "transport": {
         "type": "stdio"
       },
@@ -27,7 +27,7 @@
     },
     {
       "registryType": "oci",
-      "identifier": "docker.io/pasympa/discord-mcp:2.1.1",
+      "identifier": "docker.io/pasympa/discord-mcp:2.2.0",
       "transport": {
         "type": "stdio"
       },


### PR DESCRIPTION
Minor release. Contents: the before/after/around/since cursors on discord_read_messages (#110, co-authored by Lee, YoungHoon, with the #118 follow-up), the new discord_get_message_attachments tool (#117, same author), and the batched description lot (#119: set_role_permission lockout warning, get_server_stats cache hedge, em-dash sweep with the new error-message shape). Tool count 98 to 99. Twelve tool descriptions change, so Canopii's guard fires once for this release. Merge with a MERGE COMMIT so the tagged commit reaches main.