### PR TITLE
fix: page discord_fetch_pinned_messages past the first 50

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,8 @@
 
 ### Fixed
 
-- `discord_fetch_pinned_messages` pages through every pin instead of silently stopping at the first 50. It called `fetchPins()` with no options while promising "all pinned messages", so a channel with more pins than one page returned a truncated list with nothing to say so. It now takes `limit` (1-50) and a `before` cursor and returns `hasMore` and `nextBefore`, matching `discord_list_forum_threads`. The `before` cursor is compared against when a message was pinned, not when it was sent. The call also declines the message cache, which the repo requires of every other message fetch
-- `discord_pin_message` reports the current per-channel pin cap of 250, not the old 50. Discord raised it when pins were reworked, and the API states it: the 251st pin answers `400` with `Maximum number of pins reached (250)`
+- `discord_fetch_pinned_messages` pages through every pin instead of silently stopping at the first 50. It called `fetchPins()` with no options while promising "all pinned messages", so a channel with more pins than one page returned a truncated list with nothing to say so. It now takes `limit` (1-50) and a `before` cursor and returns `hasMore` and `nextBefore`, matching `discord_list_forum_threads`. The `before` cursor is compared against when a message was pinned, not when it was sent. The call also declines the message cache, which the repo requires of every other message fetch. Contributed by [@nobel6018](https://github.com/nobel6018) in [#122](https://github.com/PaSympa/discord-mcp/pull/122)
+- `discord_pin_message` reports the current per-channel pin cap of 250, not the old 50. Discord raised it when pins were reworked, and the API states it: the 251st pin answers `400` with `Maximum number of pins reached (250)`. Contributed by [@nobel6018](https://github.com/nobel6018) in [#122](https://github.com/PaSympa/discord-mcp/pull/122)
 
 ## [2.2.0] - 2026-09-03
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [Unreleased]
+
+### Fixed
+
+- `discord_fetch_pinned_messages` pages through every pin instead of silently stopping at the first 50. It called `fetchPins()` with no options while promising "all pinned messages", so a channel with more pins than one page returned a truncated list with nothing to say so. It now takes `limit` (1-50) and a `before` cursor and returns `hasMore` and `nextBefore`, matching `discord_list_forum_threads`. The `before` cursor is compared against when a message was pinned, not when it was sent. The call also declines the message cache, which the repo requires of every other message fetch
+- `discord_pin_message` reports the current per-channel pin cap of 250, not the old 50. Discord raised it when pins were reworked, and the API states it: the 251st pin answers `400` with `Maximum number of pins reached (250)`
+
 ## [2.2.0] - 2026-09-03
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -243,7 +243,7 @@ Data access is governed by the **portal toggles**, not by these flags: this serv
 | `discord_send_multiple_embeds`    | Send up to 10 embeds in a single message                 |
 | `discord_pin_message`             | Pin or unpin a message                                   |
 | `discord_get_message_attachments` | List a message's attachments with download urls          |
-| `discord_fetch_pinned_messages`   | List all pinned messages in a channel                    |
+| `discord_fetch_pinned_messages`   | List a channel's pinned messages, paged                  |
 | `discord_search_messages`         | Search messages by keyword (last 100)                    |
 | `discord_search_guild_messages`   | Search across every channel using Discord's search index |
 | `discord_crosspost_message`       | Publish a message to announcement channel followers      |

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -3,6 +3,9 @@
 /** Per-fetch cap for most Discord list endpoints (messages, reactions, events); members/bans use DEFAULTS.MEMBERS_MAX. */
 export const MAX_FETCH_LIMIT = 100;
 
+/** Per-fetch cap for the channel pins endpoint, which is half the usual list cap. */
+export const MAX_PINS_LIMIT = 50;
+
 /** Default and maximum fetch limits by context. */
 export const DEFAULTS = {
   MESSAGES: 20,

--- a/src/tools/messages.ts
+++ b/src/tools/messages.ts
@@ -833,11 +833,12 @@ const tools = [
         pinnedAt: pinnedAt.toISOString(),
       }));
       // Pins come back newest-pinned first, so the last item carries the oldest
-      // pinnedAt: that is the cursor for the next page.
-      const nextBefore = pinned.hasMore
-        ? (pinned.items.at(-1)?.pinnedAt.toISOString() ?? null)
-        : null;
-      return structured({ messages, hasMore: pinned.hasMore, nextBefore });
+      // pinnedAt: that is the cursor for the next page. Reporting hasMore from the
+      // cursor keeps the pair from disagreeing, so a caller looping while hasMore is
+      // true always has something to send.
+      const oldest = pinned.items.at(-1);
+      const nextBefore = pinned.hasMore && oldest ? oldest.pinnedAt.toISOString() : null;
+      return structured({ messages, hasMore: nextBefore !== null, nextBefore });
     },
   }),
   defineTool({

--- a/src/tools/messages.ts
+++ b/src/tools/messages.ts
@@ -11,7 +11,7 @@ import {
 } from "discord.js";
 import { z } from "zod";
 import { discord, getTextChannel, fetchChannelChecked } from "../client.js";
-import { MAX_FETCH_LIMIT, DEFAULTS, AUTO_ARCHIVE_DURATIONS } from "../constants.js";
+import { MAX_FETCH_LIMIT, MAX_PINS_LIMIT, DEFAULTS, AUTO_ARCHIVE_DURATIONS } from "../constants.js";
 import { buildEmbed, embedFieldsShape, embedArraySchema } from "../embeds.js";
 import { defineModule, defineTool, snowflake, guildId, intIn, structured } from "./define.js";
 
@@ -500,7 +500,7 @@ const tools = [
   defineTool({
     name: "discord_pin_message",
     description:
-      "Pin or unpin a message in a channel, controlled by the pin flag. Requires the Pin Messages permission (a dedicated permission since early 2026, separate from Manage Messages). A channel holds at most 50 pins. Idempotent: pinning an already-pinned message (or unpinning an unpinned one) has no additional effect.",
+      "Pin or unpin a message in a channel, controlled by the pin flag. Requires the Pin Messages permission (a dedicated permission since early 2026, separate from Manage Messages). A channel holds at most 250 pins. Idempotent: pinning an already-pinned message (or unpinning an unpinned one) has no additional effect.",
     annotations: {
       title: "Pin or unpin message",
       readOnlyHint: false,
@@ -799,25 +799,45 @@ const tools = [
   defineTool({
     name: "discord_fetch_pinned_messages",
     description:
-      "List all pinned messages in a channel. Returns { messages: [...] } with id, author, content, timestamp, pinnedAt. Read-only. Use discord_pin_message to change which messages are pinned.",
+      "List a channel's pinned messages, most recently pinned first. Returns { messages: [...], hasMore, nextBefore } with id, author, content, timestamp, pinnedAt. Discord serves at most 50 pins per call, so when hasMore is true pass nextBefore back as `before` to fetch the next page. Requires View Channel and Read Message History. Read-only. Use discord_pin_message to change which messages are pinned.",
     annotations: { title: "Fetch pinned messages", readOnlyHint: true, openWorldHint: true },
     schema: z.object({
       channel_id: snowflake.describe("ID (snowflake) of the channel or thread to list pins from."),
+      limit: intIn(1, MAX_PINS_LIMIT)
+        .default(MAX_PINS_LIMIT)
+        .describe("Max pins per page (1–50). Default 50."),
+      before: z.iso
+        .datetime({ offset: true })
+        .optional()
+        .describe(
+          "Pagination cursor: an ISO timestamp compared against when a message was pinned, not when it was sent. Pass the previous response's nextBefore to fetch older pins.",
+        ),
     }),
     outputSchema: z.object({
       messages: z.array(messageSummary.extend({ pinnedAt: z.string() })),
+      hasMore: z.boolean(),
+      nextBefore: z.string().nullable(),
     }),
-    handle: async ({ channel_id }) => {
+    handle: async ({ channel_id, limit, before }) => {
       const channel = await getTextChannel(channel_id);
-      const pinned = await channel.messages.fetchPins();
-      const result = pinned.items.map(({ message: m, pinnedAt }) => ({
+      const pinned = await channel.messages.fetchPins({
+        limit,
+        cache: false,
+        ...(before === undefined ? {} : { before: new Date(before) }),
+      });
+      const messages = pinned.items.map(({ message: m, pinnedAt }) => ({
         id: m.id,
         author: m.author.tag,
         content: m.content,
         timestamp: m.createdAt.toISOString(),
         pinnedAt: pinnedAt.toISOString(),
       }));
-      return structured({ messages: result });
+      // Pins come back newest-pinned first, so the last item carries the oldest
+      // pinnedAt: that is the cursor for the next page.
+      const nextBefore = pinned.hasMore
+        ? (pinned.items.at(-1)?.pinnedAt.toISOString() ?? null)
+        : null;
+      return structured({ messages, hasMore: pinned.hasMore, nextBefore });
     },
   }),
   defineTool({

--- a/test/cache-hygiene.test.ts
+++ b/test/cache-hygiene.test.ts
@@ -159,9 +159,11 @@ test("concurrent callers share one login attempt", async () => {
 test("every message fetch declines the cache", () => {
   // Single-message fetches are read-once: nothing in the repo reads messages.cache
   // back, and a cached copy freezes the reaction snapshot until the sweeper runs.
+  // fetchPins is covered too: `fetch(` alone let it through while it filled the
+  // same cache.
   for (const file of ["messages.ts", "dm.ts", "forums.ts"]) {
     const src = readFileSync(join(__dirname, "..", "src", "tools", file), "utf8");
-    for (const hit of src.matchAll(/\.messages\.fetch\(/g)) {
+    for (const hit of src.matchAll(/\.messages\.fetch(?:Pins)?\(/g)) {
       const call = src.slice(hit.index, hit.index + 160);
       assert.ok(
         call.includes("cache: false"),

--- a/test/pins.test.ts
+++ b/test/pins.test.ts
@@ -134,6 +134,23 @@ test("fetch_pinned_messages cursors on pinnedAt, not on when the message was sen
   );
 });
 
+test("fetch_pinned_messages handles a channel with no pins", async () => {
+  capturePinFetches(false, []);
+  const empty = payload(await fetchPinned()({ channel_id: CHANNEL }));
+  assert.deepEqual(empty.messages, []);
+  assert.equal(empty.hasMore, false);
+  assert.equal(empty.nextBefore, null);
+});
+
+test("fetch_pinned_messages never reports hasMore without a cursor to follow", async () => {
+  // Discord should not answer has_more over an empty page, but a caller looping on
+  // hasMore would spin forever if it ever did.
+  capturePinFetches(true, []);
+  const result = payload(await fetchPinned()({ channel_id: CHANNEL }));
+  assert.equal(result.nextBefore, null);
+  assert.equal(result.hasMore, false, "hasMore must imply a usable nextBefore");
+});
+
 test("fetch_pinned_messages rejects an offset-less before and an over-large limit", async () => {
   const calls = capturePinFetches(false, PAGE);
   for (const args of [

--- a/test/pins.test.ts
+++ b/test/pins.test.ts
@@ -1,0 +1,149 @@
+import { test, mock, afterEach } from "node:test";
+import assert from "node:assert/strict";
+import { ZodError } from "zod";
+import { discord } from "../src/client.js";
+import messages from "../src/tools/messages.js";
+
+// Every fixture message was sent long before any of them was pinned, so a cursor
+// taken from the wrong field is visible in the assertions below.
+const SENT_AT = "2025-06-15T00:00:00.000Z";
+const GUILD = "111111111111111111";
+const CHANNEL = "333333333333333333";
+
+afterEach(() => mock.restoreAll());
+
+interface PinFixture {
+  id: string;
+  pinnedAt: string;
+}
+
+/** Stubs the channel lookup and records the options every fetchPins receives. */
+function capturePinFetches(hasMore: boolean, items: PinFixture[]): Record<string, unknown>[] {
+  const calls: Record<string, unknown>[] = [];
+  const channel = {
+    name: "chan",
+    guildId: GUILD,
+    isDMBased: () => false,
+    isTextBased: () => true,
+    messages: {
+      fetchPins: async (options: Record<string, unknown>) => {
+        calls.push(options);
+        return {
+          hasMore,
+          items: items.map(({ id, pinnedAt }) => ({
+            message: {
+              id,
+              author: { tag: "someone" },
+              content: `pinned ${id}`,
+              createdAt: new Date(SENT_AT),
+            },
+            pinnedAt: new Date(pinnedAt),
+          })),
+        };
+      },
+    },
+  };
+  mock.method(discord.channels, "fetch", async () => channel as never);
+  return calls;
+}
+
+const fetchPinned = () => messages.handlers.get("discord_fetch_pinned_messages")!;
+
+function payload(result: { structuredContent?: unknown }): {
+  messages: { id: string; timestamp: string; pinnedAt: string }[];
+  hasMore: boolean;
+  nextBefore: string | null;
+} {
+  return result.structuredContent as never;
+}
+
+// Newest-pinned first, which is the order Discord returns.
+const PAGE: PinFixture[] = [
+  { id: "1", pinnedAt: "2026-03-03T00:00:00.000Z" },
+  { id: "2", pinnedAt: "2026-02-02T00:00:00.000Z" },
+  { id: "3", pinnedAt: "2026-01-01T00:00:00.000Z" },
+];
+
+test("fetch_pinned_messages advertises limit and before as optional additions", () => {
+  const definition = messages.definitions.find((d) => d.name === "discord_fetch_pinned_messages");
+  assert.ok(definition, "discord_fetch_pinned_messages should be defined");
+  const schema = definition.inputSchema as {
+    required: string[];
+    additionalProperties: boolean;
+    properties: Record<string, { description?: string; maximum?: number; default?: number }>;
+  };
+  assert.deepEqual(schema.required, ["channel_id"], "paging inputs must not become required");
+  assert.equal(schema.additionalProperties, false);
+  for (const field of ["limit", "before"]) {
+    assert.ok(schema.properties[field], `${field} must be advertised`);
+    assert.ok(
+      (schema.properties[field].description ?? "").length > 0,
+      `${field} must document its format`,
+    );
+  }
+  assert.equal(schema.properties.limit.maximum, 50, "the pins endpoint caps a page at 50, not 100");
+  assert.equal(schema.properties.limit.default, 50);
+});
+
+test("fetch_pinned_messages sends no cursor and declines the cache by default", async () => {
+  const calls = capturePinFetches(false, PAGE);
+  await fetchPinned()({ channel_id: CHANNEL });
+  assert.equal(calls.length, 1);
+  assert.equal(calls[0].limit, 50);
+  assert.equal(calls[0].cache, false, "pins must not fill the message cache");
+  assert.ok(!("before" in calls[0]), "an absent cursor must not be sent as an undefined key");
+});
+
+test("fetch_pinned_messages passes before through as a Date", async () => {
+  const calls = capturePinFetches(false, PAGE);
+  await fetchPinned()({ channel_id: CHANNEL, before: "2026-02-02T00:00:00.000Z", limit: 10 });
+  assert.ok(calls[0].before instanceof Date, "discord.js expects a DateResolvable");
+  assert.equal((calls[0].before as Date).toISOString(), "2026-02-02T00:00:00.000Z");
+  assert.equal(calls[0].limit, 10);
+});
+
+test("fetch_pinned_messages reports the next cursor only when a page was truncated", async () => {
+  capturePinFetches(true, PAGE);
+  const truncated = payload(await fetchPinned()({ channel_id: CHANNEL }));
+  assert.equal(truncated.hasMore, true);
+  assert.equal(
+    truncated.nextBefore,
+    "2026-01-01T00:00:00.000Z",
+    "the cursor is the oldest pinnedAt on the page, not the newest",
+  );
+  assert.equal(truncated.messages.length, 3);
+
+  mock.restoreAll();
+  capturePinFetches(false, PAGE);
+  const complete = payload(await fetchPinned()({ channel_id: CHANNEL }));
+  assert.equal(complete.hasMore, false);
+  assert.equal(complete.nextBefore, null, "a complete page must not invite another call");
+});
+
+test("fetch_pinned_messages cursors on pinnedAt, not on when the message was sent", async () => {
+  capturePinFetches(true, PAGE);
+  const result = payload(await fetchPinned()({ channel_id: CHANNEL }));
+  const oldest = result.messages.at(-1)!;
+  assert.equal(oldest.timestamp, SENT_AT, "timestamp still reports when the message was sent");
+  assert.equal(oldest.pinnedAt, "2026-01-01T00:00:00.000Z");
+  assert.equal(result.nextBefore, oldest.pinnedAt, "the cursor must follow pinnedAt");
+  assert.notEqual(
+    result.nextBefore,
+    oldest.timestamp,
+    "cursoring on the sent time would re-fetch or skip pins",
+  );
+});
+
+test("fetch_pinned_messages rejects an offset-less before and an over-large limit", async () => {
+  const calls = capturePinFetches(false, PAGE);
+  for (const args of [
+    { channel_id: CHANNEL, before: "2026-02-02T00:00:00" },
+    { channel_id: CHANNEL, before: "2026-02-02" },
+    { channel_id: CHANNEL, before: "last tuesday" },
+    { channel_id: CHANNEL, limit: 51 },
+    { channel_id: CHANNEL, limit: 0 },
+  ]) {
+    await assert.rejects(() => fetchPinned()(args), ZodError, JSON.stringify(args));
+  }
+  assert.equal(calls.length, 0, "invalid arguments must not reach the Discord API");
+});


### PR DESCRIPTION
## Problem

`discord_fetch_pinned_messages` advertises "List all pinned messages in a channel" and calls `fetchPins()` with no options. That endpoint serves at most 50 pins per call, so the tool returns one page and gives the caller nothing to indicate that more exist: no cursor, no flag, no count.

The gap is not marginal. Discord raised the per-channel pin cap to 250 when pins were reworked, so a fully pinned channel returns 50 and hides the other 200. A model reading that result concludes the channel has 50 pins, and there is no way for it to learn otherwise.

## Change

| Input | Type | Meaning |
| --- | --- | --- |
| `limit` | 1-50, default 50 | pins per page |
| `before` | ISO date-time with offset | return pins fixed before this instant |

The result gains `hasMore` and `nextBefore`, so paging is: call, and while `hasMore` is true, re-call with `before` set to `nextBefore`. That is the shape `discord_list_forum_threads` already uses, so the two paginated read tools now behave the same way.

Three details worth a look.

**The cursor is a timestamp, not a snowflake.** `discord-api-types` documents the query parameter as "Get messages pinned before this timestamp", and it compares against when a message was pinned rather than when it was sent. Those differ for any pin of an older message, so `nextBefore` comes from `pinnedAt` and never from `timestamp`. A test pins fixtures whose sent time and pin time fall on different dates so that taking the wrong field fails loudly.

**The page cap is 50, not the usual 100.** Reusing `MAX_FETCH_LIMIT` would let 51 through validation only for Discord to reject it, so this adds `MAX_PINS_LIMIT`.

**The call now declines the message cache.** `test/cache-hygiene.test.ts` requires `cache: false` on every message fetch, which the 2.1.1 cache-growth work introduced, but its regex is `\.messages\.fetch\(` and so never matched `fetchPins(`. This widens it to `\.messages\.fetch(?:Pins)?\(`. Removing the new `cache: false` makes that test fail with `messages.ts: .messages.fetchPins({ must pass cache: false`, so the guard now really covers the call. This matters more with paging in place, since a full walk fetches up to five times as many messages as before.

## One stale number corrected

`discord_pin_message` says "A channel holds at most 50 pins". It is 250. I did not take that from the release announcement: I pinned messages in a test channel until Discord refused, and the 251st answers `400` with `Maximum number of pins reached (250)`. Happy to drop this hunk if you would rather keep the PR to one tool.

## Testing

**Unit.** `test/pins.test.ts` adds 6 cases covering the advertised schema (both inputs optional, `required` unchanged, `limit` capped at 50), a default call sending no cursor key and `cache: false`, `before` arriving as a `Date`, `nextBefore` appearing only when a page was truncated, the cursor following `pinnedAt` rather than `timestamp`, and rejection of an over-large `limit` and of an offset-less or unparsable `before`. 83 passing, was 77. Lint, format check and build are clean.

**Live.** Mocks cannot show that Discord honours the cursor, so I built this branch and drove `dist/index.js` over stdio against a channel I filled to the 250-pin cap. Expectations are derived from a raw API count rather than hardcoded:

| Case | Result |
| --- | --- |
| default call | 50 items, `hasMore` true, `nextBefore` set |
| walk at default page size | 5 pages, 250 distinct ids, `pinnedAt` strictly descending, last page `hasMore` false |
| walk at `limit: 10` | 25 pages, identical ids in identical order to the 50-per-page walk |
| `limit: 51`, offset-less `before`, date-only `before` | all rejected before any API call |

The third row is the one that would expose an off-by-one cursor: changing the page size changes every boundary, and a wrong cursor shows up as a duplicate or a gap.

As a control that the run exercised this branch, the same calls against published `@pasympa/discord-mcp@2.2.0` on the same channel return `messages=50` with no `hasMore` and no `nextBefore`, and reject `limit` as `Unrecognized key`.

The live driver needs a bot token and a specific channel, so it is not committed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
