### PR TITLE
feat: list the threads in a text or announcement channel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## [Unreleased]
+
+### Added
+
+- `discord_list_channel_threads` lists the threads in a text or announcement channel: every active thread plus paginated archived ones, public or private, each flagged with whether it is private. `discord_create_thread` could already start a thread there, but only `discord_list_forum_threads` could enumerate any, and it covers forums alone, so a thread created outside a forum could not be found again without already knowing its id. The result uses the same `hasMore` and `nextBefore` shape as `discord_list_forum_threads`
+
+### Fixed
+
+- The archived-threads `limit` floor is 2, not 1. Discord answers `limit: 1` with `400 limit[NUMBER_TYPE_MIN]: int value should be greater than or equal to 2`, and the floor is absent from the endpoint's documented query parameters, so `discord_list_forum_threads` advertised a value the API rejects
+
 ## [2.2.0] - 2026-09-03
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,11 +4,11 @@
 
 ### Added
 
-- `discord_list_channel_threads` lists the threads in a text or announcement channel: every active thread plus paginated archived ones, public or private, each flagged with whether it is private. `discord_create_thread` could already start a thread there, but only `discord_list_forum_threads` could enumerate any, and it covers forums alone, so a thread created outside a forum could not be found again without already knowing its id. The result uses the same `hasMore` and `nextBefore` shape as `discord_list_forum_threads`
+- `discord_list_channel_threads` lists the threads in a text or announcement channel: every active thread plus paginated archived ones, public or private, each flagged with whether it is private. `discord_create_thread` could already start a thread there, but only `discord_list_forum_threads` could enumerate any, and it covers forums alone, so a thread created outside a forum could not be found again without already knowing its id. The result uses the same `hasMore` and `nextBefore` shape as `discord_list_forum_threads`. Contributed by [@nobel6018](https://github.com/nobel6018) in [#123](https://github.com/PaSympa/discord-mcp/pull/123)
 
 ### Fixed
 
-- The archived-threads `limit` floor is 2, not 1. Discord answers `limit: 1` with `400 limit[NUMBER_TYPE_MIN]: int value should be greater than or equal to 2`, and the floor is absent from the endpoint's documented query parameters, so `discord_list_forum_threads` advertised a value the API rejects
+- The archived-threads `limit` floor is 2, not 1. Discord answers `limit: 1` with `400 limit[NUMBER_TYPE_MIN]: int value should be greater than or equal to 2`, and the floor is absent from the endpoint's documented query parameters, so `discord_list_forum_threads` advertised a value the API rejects. Contributed by [@nobel6018](https://github.com/nobel6018) in [#123](https://github.com/PaSympa/discord-mcp/pull/123)
 
 ## [2.2.0] - 2026-09-03
 

--- a/README.md
+++ b/README.md
@@ -213,7 +213,7 @@ Data access is governed by the **portal toggles**, not by these flags: this serv
 
 ---
 
-## Available Tools (99)
+## Available Tools (100)
 
 ### Discovery & Navigation (4 tools)
 
@@ -224,7 +224,7 @@ Data access is governed by the **portal toggles**, not by these flags: this serv
 | `discord_list_channels`        | List all channels in a guild grouped by category                 |
 | `discord_find_channel_by_name` | Find a channel by name (partial match)                           |
 
-### Messages (20 tools)
+### Messages (21 tools)
 
 | Tool                              | Description                                              |
 | --------------------------------- | -------------------------------------------------------- |
@@ -237,6 +237,7 @@ Data access is governed by the **portal toggles**, not by these flags: this serv
 | `discord_remove_reactions`        | Remove reactions (all, by emoji, or by user)             |
 | `discord_get_reactions`           | List users who reacted with a specific emoji             |
 | `discord_create_thread`           | Create a thread from a message or standalone             |
+| `discord_list_channel_threads`    | List a text channel's threads, paged                     |
 | `discord_bulk_delete_messages`    | Delete multiple messages at once (2-100)                 |
 | `discord_send_embed`              | Send a rich embed with all options                       |
 | `discord_edit_embed`              | Edit an embed previously sent by the bot                 |

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,7 +1,14 @@
 /** Shared constants used across tool modules. */
 
-/** Per-fetch cap for most Discord list endpoints (messages, reactions, events); members/bans use DEFAULTS.MEMBERS_MAX. */
+/** Per-fetch cap for most Discord list endpoints (messages, reactions, events, archived threads); members/bans use DEFAULTS.MEMBERS_MAX. */
 export const MAX_FETCH_LIMIT = 100;
+
+/**
+ * The archived-threads endpoint refuses `limit: 1` with
+ * `limit[NUMBER_TYPE_MIN]: int value should be greater than or equal to 2`.
+ * The floor is undocumented, so it is pinned here rather than rediscovered.
+ */
+export const MIN_ARCHIVED_THREAD_LIMIT = 2;
 
 /** Default and maximum fetch limits by context. */
 export const DEFAULTS = {

--- a/src/tools/forums.ts
+++ b/src/tools/forums.ts
@@ -1,6 +1,7 @@
 import { ChannelType, ForumChannel, ThreadChannel } from "discord.js";
 import { z } from "zod";
 import { discord, fetchChannelChecked } from "../client.js";
+import { MAX_FETCH_LIMIT, MIN_ARCHIVED_THREAD_LIMIT } from "../constants.js";
 import { defineTool, defineModule, snowflake, guildId, intIn, structured } from "./define.js";
 
 const threadId = snowflake.describe("ID (snowflake) of the forum post (thread).");
@@ -196,9 +197,9 @@ const tools = [
       forum_channel_id: snowflake.describe(
         "ID (snowflake) of the forum channel to list posts from.",
       ),
-      limit: intIn(1, 100)
-        .default(100)
-        .describe("Max archived posts per page (1–100). Default 100."),
+      limit: intIn(MIN_ARCHIVED_THREAD_LIMIT, MAX_FETCH_LIMIT)
+        .default(MAX_FETCH_LIMIT)
+        .describe("Max archived posts per page (2–100). Discord rejects 1. Default 100."),
       before: z.iso
         .datetime({ offset: true })
         .optional()

--- a/src/tools/messages.ts
+++ b/src/tools/messages.ts
@@ -1,6 +1,8 @@
 import {
+  AnyThreadChannel,
   ChannelType,
   TextChannel,
+  NewsChannel,
   PublicThreadChannel,
   PrivateThreadChannel,
   Message,
@@ -10,8 +12,13 @@ import {
   DiscordAPIError,
 } from "discord.js";
 import { z } from "zod";
-import { discord, getTextChannel, fetchChannelChecked } from "../client.js";
-import { MAX_FETCH_LIMIT, DEFAULTS, AUTO_ARCHIVE_DURATIONS } from "../constants.js";
+import { discord, getTextChannel, fetchChannelChecked, validateId } from "../client.js";
+import {
+  MAX_FETCH_LIMIT,
+  MIN_ARCHIVED_THREAD_LIMIT,
+  DEFAULTS,
+  AUTO_ARCHIVE_DURATIONS,
+} from "../constants.js";
 import { buildEmbed, embedFieldsShape, embedArraySchema } from "../embeds.js";
 import { defineModule, defineTool, snowflake, guildId, intIn, structured } from "./define.js";
 
@@ -107,6 +114,40 @@ function userTag(user: { username: string; discriminator: string }): string {
   return user.discriminator === "0" || user.discriminator === "0000"
     ? user.username
     : `${user.username}#${user.discriminator}`;
+}
+
+/** Shape of a thread summary returned by the channel thread lister. */
+const channelThreadSummary = z.object({
+  id: z.string(),
+  name: z.string(),
+  private: z.boolean(),
+  archived: z.boolean().nullable(),
+  locked: z.boolean().nullable(),
+  messageCount: z.number().nullable(),
+  createdAt: z.string().nullable(),
+});
+
+/**
+ * Fetches a channel by ID and guarantees it can hold threads of its own. Forums are
+ * already excluded by getTextChannel, which rejects them as not message-capable;
+ * this rules out threads themselves and voice or stage channels, none of which carry
+ * a thread manager.
+ */
+async function getThreadParent(channelId: string): Promise<TextChannel | NewsChannel> {
+  // Not getTextChannel: a forum is not text-based, so it would be rejected there as
+  // "not message-capable" and the caller would never be pointed at the forum tool.
+  const channel = await fetchChannelChecked(validateId(channelId, "channel_id"));
+  // Discriminate on `type` rather than instanceof, matching getForumChannel: a
+  // second copy of discord.js in the tree would break instanceof silently.
+  if (channel?.type === ChannelType.GuildForum || channel?.type === ChannelType.GuildMedia)
+    throw new Error(
+      `Channel ${channelId} is a forum. Use discord_list_forum_threads to list its posts.`,
+    );
+  if (channel?.type !== ChannelType.GuildText && channel?.type !== ChannelType.GuildAnnouncement)
+    throw new Error(
+      `Channel ${channelId} holds no threads of its own or doesn't exist. Pass a text or announcement channel.`,
+    );
+  return channel;
 }
 
 /** Tool definitions for channel and thread messages. */
@@ -279,6 +320,68 @@ const tools = [
           },
         ],
       };
+    },
+  }),
+  defineTool({
+    name: "discord_list_channel_threads",
+    description:
+      "List the threads in a text or announcement channel. Returns { threads: [...], hasMore, nextBefore }. The first call includes active threads plus the first page of archived ones; while hasMore is true pass nextBefore back as `before`. hasMore means that page came back full, so the last call can return nothing. Requires View Channel and Read Message History. Read-only. Use discord_list_forum_threads for a forum's posts.",
+    annotations: { title: "List channel threads", readOnlyHint: true, openWorldHint: true },
+    schema: z.object({
+      channel_id: snowflake.describe(
+        "ID (snowflake) of the text or announcement channel to list threads from.",
+      ),
+      limit: intIn(MIN_ARCHIVED_THREAD_LIMIT, MAX_FETCH_LIMIT)
+        .default(MAX_FETCH_LIMIT)
+        .describe("Max archived threads per page (2–100). Discord rejects 1. Default 100."),
+      type: z
+        .enum(["public", "private"])
+        .default("public")
+        .describe(
+          "Which archived threads to page through. Private requires the Manage Threads permission. Active threads are returned either way. Default public.",
+        ),
+      before: z.iso
+        .datetime({ offset: true })
+        .optional()
+        .describe(
+          "Pagination cursor: an ISO timestamp compared against when a thread was archived. Pass the previous response's nextBefore to fetch older archived threads. When set, active threads are omitted.",
+        ),
+    }),
+    outputSchema: z.object({
+      threads: z.array(channelThreadSummary),
+      hasMore: z.boolean(),
+      nextBefore: z.string().nullable(),
+    }),
+    handle: async ({ channel_id, limit, type, before }) => {
+      const channel = await getThreadParent(channel_id);
+      const collected: AnyThreadChannel[] = [];
+      // A cursor means the caller is already walking archived pages, so re-sending
+      // the active ones would duplicate what it read on the first call.
+      if (before === undefined) {
+        const active = await channel.threads.fetchActive();
+        collected.push(...active.threads.values());
+      }
+      const archived = await channel.threads.fetchArchived({
+        type,
+        limit,
+        ...(before === undefined ? {} : { before: new Date(before) }),
+      });
+      collected.push(...archived.threads.values());
+      const threads = collected.map((t) => ({
+        id: t.id,
+        name: t.name,
+        private: t.type === ChannelType.PrivateThread,
+        archived: t.archived,
+        locked: t.locked,
+        messageCount: t.messageCount,
+        createdAt: t.createdAt?.toISOString() ?? null,
+      }));
+      // Reporting hasMore from the cursor keeps the pair from disagreeing, so a
+      // caller looping while hasMore is true always has something to send.
+      const oldest = archived.threads.last();
+      const nextBefore =
+        archived.hasMore && oldest?.archivedAt ? oldest.archivedAt.toISOString() : null;
+      return structured({ threads, hasMore: nextBefore !== null, nextBefore });
     },
   }),
   defineTool({

--- a/test/channel-threads.test.ts
+++ b/test/channel-threads.test.ts
@@ -1,0 +1,226 @@
+import { test, mock, afterEach } from "node:test";
+import assert from "node:assert/strict";
+import { ZodError } from "zod";
+import { ChannelType } from "discord.js";
+import { discord } from "../src/client.js";
+import messages from "../src/tools/messages.js";
+
+const GUILD = "111111111111111111";
+const CHANNEL = "333333333333333333";
+
+afterEach(() => mock.restoreAll());
+
+interface ThreadFixture {
+  id: string;
+  name: string;
+  type?: ChannelType;
+  archivedAt?: string | null;
+}
+
+/** Minimal stand-in for discord.js Collection: the handler needs values() and last(). */
+function collection(items: ThreadFixture[]) {
+  const built = items.map((t) => ({
+    id: t.id,
+    name: t.name,
+    type: t.type ?? ChannelType.PublicThread,
+    archived: t.archivedAt !== undefined && t.archivedAt !== null,
+    locked: false,
+    messageCount: 3,
+    createdAt: new Date("2026-01-01T00:00:00.000Z"),
+    archivedAt: t.archivedAt == null ? null : new Date(t.archivedAt),
+  }));
+  const map = new Map(built.map((t) => [t.id, t])) as Map<string, (typeof built)[number]> & {
+    last(): (typeof built)[number] | undefined;
+  };
+  map.last = () => built.at(-1);
+  return map;
+}
+
+interface Stub {
+  activeCalls: number;
+  archivedCalls: Record<string, unknown>[];
+}
+
+function stubChannel(opts: {
+  type?: ChannelType;
+  active?: ThreadFixture[];
+  archived?: ThreadFixture[];
+  hasMore?: boolean;
+}): Stub {
+  const stub: Stub = { activeCalls: 0, archivedCalls: [] };
+  const channel = {
+    name: "chan",
+    guildId: GUILD,
+    type: opts.type ?? ChannelType.GuildText,
+    isDMBased: () => false,
+    isTextBased: () => true,
+    threads: {
+      fetchActive: async () => {
+        stub.activeCalls++;
+        return { threads: collection(opts.active ?? []) };
+      },
+      fetchArchived: async (options: Record<string, unknown>) => {
+        stub.archivedCalls.push(options);
+        return { threads: collection(opts.archived ?? []), hasMore: opts.hasMore ?? false };
+      },
+    },
+  };
+  mock.method(discord.channels, "fetch", async () => channel as never);
+  return stub;
+}
+
+const listThreads = () => messages.handlers.get("discord_list_channel_threads")!;
+
+function payload(result: { structuredContent?: unknown }): {
+  threads: { id: string; name: string; private: boolean; archived: boolean | null }[];
+  hasMore: boolean;
+  nextBefore: string | null;
+} {
+  return result.structuredContent as never;
+}
+
+const ACTIVE: ThreadFixture[] = [{ id: "a1", name: "live" }];
+const ARCHIVED: ThreadFixture[] = [
+  { id: "z1", name: "older", archivedAt: "2026-03-03T00:00:00.000Z" },
+  { id: "z2", name: "oldest", archivedAt: "2026-02-02T00:00:00.000Z" },
+];
+
+test("list_channel_threads advertises its inputs with only channel_id required", () => {
+  const definition = messages.definitions.find((d) => d.name === "discord_list_channel_threads");
+  assert.ok(definition, "discord_list_channel_threads should be defined");
+  const schema = definition.inputSchema as {
+    required: string[];
+    additionalProperties: boolean;
+    properties: Record<
+      string,
+      { description?: string; maximum?: number; minimum?: number; enum?: string[] }
+    >;
+  };
+  assert.deepEqual(schema.required, ["channel_id"]);
+  assert.equal(schema.additionalProperties, false);
+  for (const field of ["limit", "type", "before"]) {
+    assert.ok(schema.properties[field], `${field} must be advertised`);
+    assert.ok((schema.properties[field].description ?? "").length > 0);
+  }
+  assert.equal(schema.properties.limit.maximum, 100);
+  assert.equal(schema.properties.limit.minimum, 2, "the archived-threads endpoint refuses limit 1");
+  assert.deepEqual(schema.properties.type.enum, ["public", "private"]);
+});
+
+test("list_channel_threads returns active threads alongside the first archived page", async () => {
+  const stub = stubChannel({ active: ACTIVE, archived: ARCHIVED });
+  const result = payload(await listThreads()({ channel_id: CHANNEL }));
+  assert.equal(stub.activeCalls, 1, "the first call must include active threads");
+  assert.deepEqual(
+    result.threads.map((t) => t.id),
+    ["a1", "z1", "z2"],
+  );
+  assert.equal(result.threads[0].archived, false, "an active thread is not archived");
+  assert.equal(stub.archivedCalls[0].type, "public", "public archived threads by default");
+  assert.equal(stub.archivedCalls[0].limit, 100);
+  assert.ok(!("before" in stub.archivedCalls[0]));
+});
+
+test("list_channel_threads omits active threads once the caller is paging", async () => {
+  const stub = stubChannel({ active: ACTIVE, archived: ARCHIVED });
+  const result = payload(
+    await listThreads()({ channel_id: CHANNEL, before: "2026-03-03T00:00:00.000Z" }),
+  );
+  assert.equal(stub.activeCalls, 0, "re-sending active threads would duplicate page one");
+  assert.deepEqual(
+    result.threads.map((t) => t.id),
+    ["z1", "z2"],
+  );
+  assert.ok(stub.archivedCalls[0].before instanceof Date);
+});
+
+test("list_channel_threads cursors on archivedAt and only when a page was truncated", async () => {
+  stubChannel({ active: ACTIVE, archived: ARCHIVED, hasMore: true });
+  const truncated = payload(await listThreads()({ channel_id: CHANNEL }));
+  assert.equal(truncated.hasMore, true);
+  assert.equal(
+    truncated.nextBefore,
+    "2026-02-02T00:00:00.000Z",
+    "the cursor is the oldest archivedAt on the page",
+  );
+
+  mock.restoreAll();
+  stubChannel({ active: ACTIVE, archived: ARCHIVED, hasMore: false });
+  const complete = payload(await listThreads()({ channel_id: CHANNEL }));
+  assert.equal(complete.hasMore, false);
+  assert.equal(complete.nextBefore, null);
+});
+
+test("list_channel_threads never reports hasMore without a cursor to follow", async () => {
+  // An archived page with nothing in it leaves no archivedAt to cursor on.
+  stubChannel({ active: ACTIVE, archived: [], hasMore: true });
+  const result = payload(await listThreads()({ channel_id: CHANNEL }));
+  assert.equal(result.nextBefore, null);
+  assert.equal(result.hasMore, false, "hasMore must imply a usable nextBefore");
+});
+
+test("list_channel_threads reports which threads are private", async () => {
+  stubChannel({
+    active: [{ id: "p1", name: "hidden", type: ChannelType.PrivateThread }, ...ACTIVE],
+    archived: [],
+  });
+  const result = payload(await listThreads()({ channel_id: CHANNEL }));
+  assert.equal(result.threads.find((t) => t.id === "p1")!.private, true);
+  assert.equal(result.threads.find((t) => t.id === "a1")!.private, false);
+});
+
+test("list_channel_threads handles a channel with no threads", async () => {
+  stubChannel({ active: [], archived: [] });
+  const empty = payload(await listThreads()({ channel_id: CHANNEL }));
+  assert.deepEqual(empty.threads, []);
+  assert.equal(empty.hasMore, false);
+  assert.equal(empty.nextBefore, null);
+});
+
+test("list_channel_threads points a forum at the tool that lists its posts", async () => {
+  // A forum is not text-based, so a generic message-capable check would reject it
+  // first and the caller would never learn which tool to use.
+  for (const type of [ChannelType.GuildForum, ChannelType.GuildMedia]) {
+    mock.restoreAll();
+    stubChannel({ type });
+    await assert.rejects(
+      () => listThreads()({ channel_id: CHANNEL }),
+      /use discord_list_forum_threads/i,
+      `type ${type} should redirect`,
+    );
+  }
+});
+
+test("list_channel_threads refuses channels that hold no threads of their own", async () => {
+  for (const type of [ChannelType.GuildVoice, ChannelType.PublicThread]) {
+    mock.restoreAll();
+    stubChannel({ type });
+    await assert.rejects(
+      () => listThreads()({ channel_id: CHANNEL }),
+      /holds no threads of its own/,
+      `type ${type} should be refused`,
+    );
+  }
+});
+
+test("list_channel_threads forwards the requested archived type", async () => {
+  const stub = stubChannel({ active: ACTIVE, archived: ARCHIVED });
+  await listThreads()({ channel_id: CHANNEL, type: "private" });
+  assert.equal(stub.archivedCalls[0].type, "private");
+  assert.equal(stub.activeCalls, 1, "active threads come back whichever type was asked for");
+});
+
+test("list_channel_threads rejects a bad cursor, limit or type", async () => {
+  const stub = stubChannel({ active: ACTIVE, archived: ARCHIVED });
+  for (const args of [
+    { channel_id: CHANNEL, before: "2026-03-03T00:00:00" },
+    { channel_id: CHANNEL, before: "2026-03-03" },
+    { channel_id: CHANNEL, limit: 101 },
+    { channel_id: CHANNEL, limit: 1 },
+    { channel_id: CHANNEL, limit: 0 },
+    { channel_id: CHANNEL, type: "secret" },
+  ]) {
+    await assert.rejects(() => listThreads()(args), ZodError, JSON.stringify(args));
+  }
+  assert.equal(stub.archivedCalls.length, 0, "invalid arguments must not reach the Discord API");
+});

--- a/test/server.test.ts
+++ b/test/server.test.ts
@@ -28,7 +28,7 @@ test("unknown tool is a JSON-RPC InvalidParams protocol error, not a tool result
 test("tools/list serves every definition and rejects unexpected cursors", async () => {
   const client = await connectedClient();
   const { tools } = await client.listTools();
-  assert.equal(tools.length, 99, "update this pin when adding/removing tools");
+  assert.equal(tools.length, 100, "update this pin when adding/removing tools");
   await assert.rejects(
     () => client.listTools({ cursor: "bogus" }),
     (err: unknown) => err instanceof McpError && err.code === ErrorCode.InvalidParams,


### PR DESCRIPTION
## Problem

`discord_create_thread` starts a thread in a text or announcement channel, but nothing lists them. `discord_list_forum_threads` is the only thread lister and it takes a forum id, so a thread created outside a forum cannot be found again unless the caller already kept its id. The two tools also sit in different toolsets, so `DISCORD_MCP_TOOLSETS=messages` gives you thread creation with no way to enumerate the result.

## Change

`discord_list_channel_threads` lists the threads in a text or announcement channel: every active thread plus paginated archived ones, `public` or `private`, each flagged with whether it is private. It lives in `messages.ts` beside `discord_create_thread` so that toolset now carries both halves.

| Input | Type | Meaning |
| --- | --- | --- |
| `channel_id` | snowflake | text or announcement channel |
| `limit` | 2-100, default 100 | archived threads per page |
| `type` | `public` or `private`, default `public` | which archived threads to page |
| `before` | ISO date-time with offset | archived-at cursor |

The result is `{ threads, hasMore, nextBefore }`, the same shape `discord_list_forum_threads` returns, and the first call (no `before`) folds in the active threads. A forum id is redirected to `discord_list_forum_threads` rather than rejected generically.

## Two undocumented behaviours of the archived-threads endpoint

Both turned up by calling the endpoint rather than by reading it. `RESTGetAPIChannelThreadsArchivedQuery` declares `limit?: number` with no bounds.

**`limit` has a floor of 2.** `limit: 1` answers `400` with `limit[NUMBER_TYPE_MIN]: int value should be greater than or equal to 2`. `discord_list_forum_threads` advertises `1` today, so it lets through a value Discord rejects. This pins the floor as `MIN_ARCHIVED_THREAD_LIMIT` and applies it to both tools. The ceiling is a real 100 (`NUMBER_TYPE_MAX` above that), so `MAX_FETCH_LIMIT` fits and its comment now names archived threads.

**`has_more` means the page came back full, not that more threads exist.** A channel with exactly 2 archived threads answers `limit: 2` with `has_more: true` and `limit: 3` with `has_more: false`. Following the cursor off a full page can return an empty list, so the description says so.

The forums change is the only edit outside the new tool. Happy to drop it if you would rather keep this to one tool.

## Details worth a look

`hasMore` is derived from the cursor rather than passed through, so the two can never disagree: a caller looping while `hasMore` is true always has a `nextBefore` to send.

The channel check discriminates on `channel.type`, matching `getForumChannel`, rather than on `instanceof`. It also bypasses `getTextChannel` deliberately: a forum is not text-based, so routing through it would reject a forum as "not message-capable" and the caller would never be pointed at the forum tool.

## Testing

**Unit.** `test/channel-threads.test.ts` adds 11 cases: the advertised schema including the `limit` floor and the `type` enum, active threads folded into the first page, active threads omitted once a cursor is passed, the cursor tracking `archivedAt` and only appearing on a truncated page, `hasMore` never true without a cursor, the private flag, an empty channel, the forum redirect, refusal of voice channels and of threads themselves, `type` forwarding, and rejection of a bad cursor, limit or type. 88 passing, was 77. Lint, format check and build are clean. `test/server.test.ts` pins the tool count, so that moves from 99 to 100 along with the three counts in the README.

**Live.** Built this branch and drove `dist/index.js` over stdio against a channel holding one active and two archived threads, with expectations derived from the raw API rather than hardcoded. 19 assertions, all passing: the folded first page, `hasMore` matching whether the page came back full, the cursor walk terminating with `nextBefore` null after returning every archived thread exactly once, the final page arriving empty as documented, the forum and voice refusals, and rejection of `limit: 101`, an offset-less `before` and an unknown `type`.

The live driver needs a bot token and a specific channel, so it is not committed.

## Note on the changelog

This adds a `## [Unreleased]` block. #122 adds one too, so whichever lands second will want a rebase on that section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
